### PR TITLE
Add Spurti Levels, Trophy Leagues, and onboarding-group leaderboards

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -259,13 +259,74 @@ function StudentView({ profile, onBack }) {
         </div>
         <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
+      <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['chats','Chats'], ['polls','Polls'], ['leaderboard','Top 50']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['chats','Chats'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'chats' && <Chats chats={profile.chats} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
-      {tab === 'leaderboard' && <Leaderboard rows={profile.leaderboard} />}
+      {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
     </main>
+  );
+}
+
+function LevelStatus({ student }) {
+  const tier = String(student.trophyLeague || 'Bronze').split(' ')[0].toLowerCase();
+  return (
+    <section className="level-status">
+      <div className="level-tiles">
+        <div className="level-tile">
+          <span>Level</span>
+          <strong>{student.level}</strong>
+          <em>lifetime achievement</em>
+        </div>
+        <div className={`level-tile league tier-${tier}`}>
+          <span>Trophy League</span>
+          <strong>{student.trophyLeague}</strong>
+          <em>current performance</em>
+        </div>
+        <div className="level-tile">
+          <span>Legend Badge</span>
+          <strong>{student.legendBadgeUnlocked ? '🏅 Unlocked' : '🔒 Locked'}</strong>
+          <em>reach 1500 SP once</em>
+        </div>
+        <div className="level-tile">
+          <span>Onboarding Group</span>
+          <strong className="group">{student.leaderboardGroupLabel || '—'}</strong>
+          <em>biweekly cohort</em>
+        </div>
+      </div>
+      <p className="level-note">
+        Level shows your highest achievement and never decreases. Trophy League shows your current performance and can move up or down with your current Spurti Points.
+        {student.legendBadgeUnlocked ? ' You have unlocked the Legend Badge by reaching 1500 Spurti Points at least once.' : ''}
+      </p>
+    </section>
+  );
+}
+
+function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
+  const [type, setType] = useState('overall');
+  const rows = type === 'overall' ? overall : group;
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <h2>Leaderboard</h2>
+        <select value={type} onChange={e => setType(e.target.value)}>
+          <option value="overall">Overall Leaderboard</option>
+          <option value="my_onboarding_group">My Onboarding Group</option>
+        </select>
+      </div>
+      {type === 'my_onboarding_group' && groupLabel &&
+        <p className="muted">Showing students onboarded in your group: {groupLabel}</p>}
+      <table className="table">
+        <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>Level</th><th>SP</th></tr></thead>
+        <tbody>{rows.map(row => (
+          <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}>
+            <td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.level}</td><td>{row.totalSp}</td>
+          </tr>
+        ))}</tbody>
+      </table>
+    </section>
   );
 }
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -187,6 +187,40 @@ input {
   padding: 20px;
   margin-bottom: 18px;
 }
+/* Spurti Levels & Trophy Leagues */
+.level-status {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: 16px;
+  margin-bottom: 18px;
+}
+.level-tiles {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+.level-tile {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: #fafdff;
+}
+.level-tile > span { display: block; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+.level-tile > strong { display: block; font-size: 24px; margin: 4px 0 2px; color: var(--primary); }
+.level-tile > strong.group { font-size: 15px; }
+.level-tile > em { display: block; color: var(--muted); font-style: normal; font-size: 12px; }
+.level-tile.league { color: #fff; border: none; }
+.level-tile.league > span, .level-tile.league > strong, .level-tile.league > em { color: #fff; }
+.level-tile.league.tier-bronze   { background: linear-gradient(135deg, #a97142, #cd7f32); }
+.level-tile.league.tier-silver   { background: linear-gradient(135deg, #9aa3ab, #c0c0c0); }
+.level-tile.league.tier-gold     { background: linear-gradient(135deg, #d4a017, #ffd700); }
+.level-tile.league.tier-platinum { background: linear-gradient(135deg, #4aa3a3, #7fdbda); }
+.level-tile.league.tier-diamond  { background: linear-gradient(135deg, #3b82c4, #5fc8f0); }
+.level-tile.league.tier-legend   { background: linear-gradient(135deg, #6d28d9, #c026d3); }
+.level-note { color: var(--muted); font-size: 13px; margin-top: 12px; line-height: 1.5; }
+@media (max-width: 720px) { .level-tiles { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 .pulse-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -9,7 +9,13 @@ const studentSchema = new mongoose.Schema({
   status: { type: String, enum: ['active', 'excused'], default: 'active', index: true },
   excusedAt: { type: Date, default: null },
   excusedReason: { type: String, default: '' },
-  totalSp: { type: Number, default: 100, index: true }
+  totalSp: { type: Number, default: 100, index: true },
+  // Spurti Levels & Trophy Leagues — derived views over SP (see services/levels.js).
+  highestSpEver: { type: Number, default: 100, index: true },
+  level: { type: Number, default: 1 },
+  trophyLeague: { type: String, default: 'Bronze II' },
+  legendBadgeUnlocked: { type: Boolean, default: false },
+  leaderboardGroup: { type: String, default: '', index: true }
 }, { timestamps: true });
 
 studentSchema.index({ name: 'text', email: 'text', alternateEmail: 'text' });

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import ChatSPReview from './models/ChatSPReview.js';
 import { recalculateStudentSp } from './scripts/lib/ingestion.js';
+import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -142,6 +143,18 @@ async function studentPayload(student) {
   const top50Cutoff = allStudents[49]?.totalSp || null;
   const currentIndex = allStudents.findIndex(s => s.email === email);
   const nextStudent = currentIndex > 0 ? allStudents[currentIndex - 1] : null;
+  // Spurti Levels & Trophy Leagues — derived from existing SP (lifetime highest + current).
+  const highestSpEver = Math.max(Number(student.highestSpEver) || 0, Number(student.totalSp) || 0);
+  const myGroup = leaderboardGroup(student.internshipStartDate);
+  const groupStudents = allStudents.filter(s => leaderboardGroup(s.internshipStartDate) === myGroup);
+  const mapRow = (row, index) => ({
+    rank: index + 1,
+    name: row.name,
+    maskedEmail: maskEmail(row.email),
+    totalSp: row.totalSp,
+    level: levelFor(Math.max(Number(row.highestSpEver) || 0, Number(row.totalSp) || 0)),
+    isCurrentStudent: row.email === email
+  });
   return {
     student: {
       _id: String(student._id),
@@ -155,7 +168,13 @@ async function studentPayload(student) {
       excusedReason: student.excusedReason,
       totalSp: student.totalSp,
       rank: rankInfo?.rank || null,
-      cohortSize: rankInfo?.cohortSize || null
+      cohortSize: rankInfo?.cohortSize || null,
+      highestSpEver,
+      level: levelFor(highestSpEver),
+      trophyLeague: leagueBand(student.totalSp),
+      legendBadgeUnlocked: legendBadge(highestSpEver),
+      leaderboardGroup: myGroup,
+      leaderboardGroupLabel: groupLabel(myGroup)
     },
     transactions,
     chats,
@@ -168,13 +187,8 @@ async function studentPayload(student) {
       pointsToTop50: top50Cutoff === null ? null : Math.max(0, top50Cutoff - student.totalSp + 1),
       pointsToNextRank: nextStudent ? Math.max(1, nextStudent.totalSp - student.totalSp + 1) : 0
     },
-    leaderboard: leaderboard.map((row, index) => ({
-      rank: index + 1,
-      name: row.name,
-      maskedEmail: maskEmail(row.email),
-      totalSp: row.totalSp,
-      isCurrentStudent: row.email === email
-    }))
+    leaderboard: leaderboard.map(mapRow),
+    groupLeaderboard: groupStudents.slice(0, 50).map(mapRow)
   };
 }
 
@@ -254,9 +268,19 @@ api.post('/confirm', async (req, res) => {
   res.json(await studentPayload(student));
 });
 
-api.get('/leaderboard', async (_req, res) => {
-  const students = await Student.find({ status: { $ne: 'excused' } }).sort({ totalSp: -1, name: 1 }).limit(50).lean();
-  res.json(students.map((s, i) => ({ rank: i + 1, name: s.name, maskedEmail: maskEmail(s.email), totalSp: s.totalSp })));
+api.get('/leaderboard', async (req, res) => {
+  const type = String(req.query.leaderboardType || 'overall');
+  const filter = { status: { $ne: 'excused' } };
+  if (type === 'my_onboarding_group' && req.query.group) filter.leaderboardGroup = String(req.query.group);
+  const students = await Student.find(filter).sort({ totalSp: -1, name: 1 }).limit(50).lean();
+  res.json(students.map((s, i) => ({
+    rank: i + 1,
+    name: s.name,
+    maskedEmail: maskEmail(s.email),
+    totalSp: s.totalSp,
+    level: levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0)),
+    trophyLeague: leagueBand(s.totalSp)
+  })));
 });
 
 api.post('/ping', async (req, res) => {

--- a/server/services/levels.js
+++ b/server/services/levels.js
@@ -1,0 +1,85 @@
+/**
+ * Spurti Levels, Trophy Leagues, Legend status, and biweekly onboarding groups.
+ *
+ * These are DERIVED VIEWS over the existing SP system — pure functions, no DB,
+ * no side effects. SP transactions and balances are never changed here.
+ * Spec: research/05_experiments/spurti_levels_leagues/samagama_spurti_levels_leagues_spec.md
+ */
+
+// Current SP -> Trophy League. Exact bands from the spec (§4).
+const LEAGUE_BANDS = [
+  [1500, Infinity, 'Legend'],
+  [1400, 1499, 'Diamond I'],
+  [1300, 1399, 'Diamond II'],
+  [1200, 1299, 'Diamond III'],
+  [1100, 1199, 'Platinum I'],
+  [1000, 1099, 'Platinum II'],
+  [900, 999, 'Platinum III'],
+  [800, 899, 'Gold I'],
+  [700, 799, 'Gold II'],
+  [600, 699, 'Gold III'],
+  [500, 599, 'Silver I'],
+  [400, 499, 'Silver II'],
+  [300, 399, 'Silver III'],
+  [200, 299, 'Bronze I'],
+  [100, 199, 'Bronze II'],
+  [0, 99, 'Bronze III'],
+];
+
+export function leagueBand(currentSp) {
+  const sp = Math.max(0, Number(currentSp) || 0);
+  for (const [lo, hi, name] of LEAGUE_BANDS) if (sp >= lo && sp <= hi) return name;
+  return 'Bronze III';
+}
+
+// Level = lifetime achievement, never decreases. floor(highestSpEver / 100).
+export function levelFor(highestSpEver) {
+  return Math.floor(Math.max(0, Number(highestSpEver) || 0) / 100);
+}
+
+// Legend Badge = highestSpEver >= 1500, permanent once unlocked.
+export function legendBadge(highestSpEver) {
+  return (Number(highestSpEver) || 0) >= 1500;
+}
+
+// Tier family (Bronze/Silver/Gold/Platinum/Diamond/Legend) — used for UI colour.
+export function leagueTier(league) {
+  return String(league || '').split(' ')[0] || 'Bronze';
+}
+
+// Biweekly onboarding group from a date: day 1-15 -> first half, 16-end -> second half.
+// Returns e.g. "2026-06-01_to_2026-06-15". Uses UTC date parts (onboarding dates
+// in this system are stored at 09:00 IST = 03:30Z, so the UTC day matches intent).
+export function leaderboardGroup(onboardingDate) {
+  if (!onboardingDate) return '';
+  const d = new Date(onboardingDate);
+  if (isNaN(d.getTime())) return '';
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth();
+  const day = d.getUTCDate();
+  const mm = String(m + 1).padStart(2, '0');
+  if (day <= 15) return `${y}-${mm}-01_to_${y}-${mm}-15`;
+  const lastDay = new Date(Date.UTC(y, m + 1, 0)).getUTCDate();
+  return `${y}-${mm}-16_to_${y}-${mm}-${String(lastDay).padStart(2, '0')}`;
+}
+
+// "2026-06-01_to_2026-06-15" -> "2026-06-01 to 2026-06-15" (for display).
+export function groupLabel(group) {
+  return String(group || '').replace('_to_', ' to ');
+}
+
+/**
+ * Derive all level/league fields for a student.
+ * highestSpEver never drops below the running max; current SP drives the league.
+ */
+export function deriveLevels({ totalSp = 0, highestSpEver, internshipStartDate } = {}) {
+  const high = Math.max(Number(totalSp) || 0, Number(highestSpEver) || 0);
+  return {
+    currentSp: Number(totalSp) || 0,
+    highestSpEver: high,
+    level: levelFor(high),
+    trophyLeague: leagueBand(totalSp),
+    legendBadgeUnlocked: legendBadge(high),
+    leaderboardGroup: leaderboardGroup(internshipStartDate),
+  };
+}

--- a/sync-levels.cjs
+++ b/sync-levels.cjs
@@ -1,0 +1,107 @@
+/**
+ * sync-levels.cjs — Spurti Levels & Trophy Leagues backfill + sync.
+ *
+ * IDEMPOTENT. First run = one-time migration. Every later run = a sync that
+ * picks up whatever SP changed since. Never lowers highestSpEver. It only adds
+ * the derived fields to the existing students collection — it does NOT touch SP
+ * transactions, balances, or any scoring logic.
+ *
+ * Derived per spec (services/levels.js is the canonical source; mirrored here so
+ * this can run standalone as plain CommonJS without the ESM server build):
+ *   highestSpEver = max(stored highestSpEver, max ledger balanceAfter, totalSp)
+ *   level         = floor(highestSpEver / 100)            (never decreases)
+ *   trophyLeague  = band(currentSp)                        (current performance)
+ *   legendBadge   = highestSpEver >= 1500                  (permanent once true)
+ *   leaderboardGroup = biweekly window from internshipStartDate
+ *
+ * USAGE
+ *   node sync-levels.cjs                  # uses MONGO_URI from .env (production)
+ *   MONGO_URI=mongodb://127.0.0.1:27017/analysis_summership_banded node sync-levels.cjs
+ *   DEMO=1 ... node sync-levels.cjs       # also upsert a demo high-tier student (local only)
+ *
+ * PRODUCTION: run this once after `git pull` (migration), then add it as the LAST
+ * step of the nightly SP pipeline/cron so derived fields stay fresh. No edits to
+ * existing scoring scripts are needed.
+ */
+require('dotenv').config();
+const { MongoClient, ObjectId } = require('mongodb');
+
+const URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/analysis_summership';
+const DEMO = process.env.DEMO === '1';
+
+const LEAGUE_BANDS = [
+  [1500, Infinity, 'Legend'], [1400, 1499, 'Diamond I'], [1300, 1399, 'Diamond II'],
+  [1200, 1299, 'Diamond III'], [1100, 1199, 'Platinum I'], [1000, 1099, 'Platinum II'],
+  [900, 999, 'Platinum III'], [800, 899, 'Gold I'], [700, 799, 'Gold II'],
+  [600, 699, 'Gold III'], [500, 599, 'Silver I'], [400, 499, 'Silver II'],
+  [300, 399, 'Silver III'], [200, 299, 'Bronze I'], [100, 199, 'Bronze II'], [0, 99, 'Bronze III'],
+];
+const leagueBand = (sp) => { sp = Math.max(0, Number(sp) || 0); for (const [lo, hi, n] of LEAGUE_BANDS) if (sp >= lo && sp <= hi) return n; return 'Bronze III'; };
+const levelFor = (h) => Math.floor(Math.max(0, Number(h) || 0) / 100);
+const legendBadge = (h) => (Number(h) || 0) >= 1500;
+function leaderboardGroup(date) {
+  if (!date) return '';
+  const d = new Date(date); if (isNaN(d.getTime())) return '';
+  const y = d.getUTCFullYear(), m = d.getUTCMonth(), day = d.getUTCDate(), mm = String(m + 1).padStart(2, '0');
+  if (day <= 15) return `${y}-${mm}-01_to_${y}-${mm}-15`;
+  const last = new Date(Date.UTC(y, m + 1, 0)).getUTCDate();
+  return `${y}-${mm}-16_to_${y}-${mm}-${String(last).padStart(2, '0')}`;
+}
+
+(async () => {
+  const c = new MongoClient(URI);
+  await c.connect();
+  const db = c.db();
+  console.log(`sync-levels -> ${db.databaseName}`);
+  const students = db.collection('students');
+  const tx = db.collection('sptransactions');
+
+  // max historical running balance per student, in one pass
+  const maxByEmail = new Map();
+  for (const r of await tx.aggregate([{ $group: { _id: '$email', maxBal: { $max: '$balanceAfter' } } }]).toArray()) {
+    maxByEmail.set(r._id, Number(r.maxBal) || 0);
+  }
+
+  const all = await students.find({}).toArray();
+  const ops = [];
+  for (const s of all) {
+    const high = Math.max(Number(s.highestSpEver) || 0, maxByEmail.get(s.email) || 0, Number(s.totalSp) || 0);
+    ops.push({ updateOne: { filter: { _id: s._id }, update: { $set: {
+      highestSpEver: high,
+      level: levelFor(high),
+      trophyLeague: leagueBand(s.totalSp),
+      legendBadgeUnlocked: legendBadge(high),
+      leaderboardGroup: leaderboardGroup(s.internshipStartDate),
+    } } } });
+  }
+  const result = ops.length ? await students.bulkWrite(ops) : { modifiedCount: 0 };
+  console.log(`students processed: ${ops.length}, modified: ${result.modifiedCount}`);
+
+  if (DEMO) {
+    const email = 'demo.legend@samagama.in';
+    const start = new Date('2026-06-04T03:30:00.000Z'); // -> group 2026-06-01_to_2026-06-15
+    const high = 1620;
+    await students.deleteOne({ email });
+    await tx.deleteMany({ email });
+    const sid = new ObjectId();
+    await students.insertOne({
+      _id: sid, name: 'Demo Legend (test)', email, alternateEmail: '',
+      internshipStartDate: start, internshipEndDate: null, status: 'active',
+      totalSp: high, highestSpEver: high, level: levelFor(high),
+      trophyLeague: leagueBand(high), legendBadgeUnlocked: legendBadge(high),
+      leaderboardGroup: leaderboardGroup(start), createdAt: new Date(), updatedAt: new Date(), __v: 0,
+    });
+    const mk = (cat, delta, bal, reason, dt) => ({
+      _id: new ObjectId(), email, studentId: sid, category: cat, sessionLabel: '',
+      deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: bal,
+      reason, dateTime: dt, createdAt: new Date(), updatedAt: new Date(), __v: 0,
+    });
+    await tx.insertMany([
+      mk('initial', 100, 100, 'Initial Spurti Points credited by system on onboarding.', start),
+      mk('manual', 1520, 1620, 'Demo award to showcase Legend tier rendering.', new Date('2026-06-20T09:00:00.000Z')),
+    ]);
+    console.log(`DEMO student upserted: ${email} (SP ${high}, Level ${levelFor(high)}, Legend)`);
+  }
+
+  await c.close();
+})().catch(e => { console.error('FAILED:', e); process.exit(1); });


### PR DESCRIPTION
Derived motivation layer on top of existing SP. SP scoring is untouched.

- server/services/levels.js: pure league/level/legend/group helpers
- Student model: store highestSpEver + derived level/trophyLeague/ legendBadgeUnlocked/leaderboardGroup (additive, defaults)
- studentPayload: expose Level, Trophy League, Legend badge, onboarding group; embed an onboarding-group leaderboard alongside the overall one
- /leaderboard: optional leaderboardType=overall|my_onboarding_group
- client: LevelStatus card + LeaderboardTabs (Overall / My Onboarding Group)
- sync-levels.cjs: idempotent backfill + sync (migration on first run); computes highestSpEver from max ledger balance; never lowers it. Demo high-tier student gated behind DEMO=1 (never created in prod).

No edits to any SP scoring/ingestion script.