### PR TITLE
feat: Peer Stars & Comparison — search, bookmark, and compare peers

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -270,10 +270,11 @@ function StudentView({ profile, onBack }) {
       </header>
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard'], ['peers','⭐ Peers']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
+      {tab === 'peers' && <PeersTab profile={profile} />}
     </main>
   );
 }
@@ -837,5 +838,297 @@ function SurveyModal({ survey, student, onDone }) {
   );
 }
 
+
+// ── Peer Stars, Search & Comparison ─────────────────────────────────────────
+
+function starKey(email) { return `spurti_starred_${String(email || 'guest')}`; }
+
+function loadStarred(email) {
+  try { return JSON.parse(localStorage.getItem(starKey(email)) || '[]'); }
+  catch { return []; }
+}
+
+function saveStar(email, peer) {
+  const list = loadStarred(email);
+  if (!list.find(p => p._id === peer._id)) {
+    list.unshift(peer);
+    localStorage.setItem(starKey(email), JSON.stringify(list.slice(0, 50)));
+  }
+}
+
+function removeStar(email, peerId) {
+  const list = loadStarred(email).filter(p => p._id !== peerId);
+  localStorage.setItem(starKey(email), JSON.stringify(list));
+}
+
+function PeersTab({ profile }) {
+  const { student, leaderboard, cohort } = profile;
+  const myEmail = student.email;
+  const [starred, setStarred] = useState(() => loadStarred(myEmail));
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const [searchMsg, setSearchMsg] = useState('');
+  const [comparePeer, setComparePeer] = useState(null);
+
+  const isStarred = (id) => starred.some(p => p._id === id);
+
+  function toggleStar(peer) {
+    if (isStarred(peer._id)) {
+      removeStar(myEmail, peer._id);
+      setStarred(prev => prev.filter(p => p._id !== peer._id));
+    } else {
+      saveStar(myEmail, peer);
+      setStarred(prev => [peer, ...prev.filter(p => p._id !== peer._id)]);
+    }
+  }
+
+  async function doSearch() {
+    const q = query.trim();
+    if (q.length < 2) { setSearchMsg('Type at least 2 characters.'); setSearchResults([]); return; }
+    setSearching(true);
+    setSearchMsg('');
+    try {
+      const res = await fetch(`${API}/search?q=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      if (data.exact && data.profile) {
+        const p = data.profile.student;
+        setSearchResults([{ _id: p._id, name: p.name, maskedEmail: maskEmailClient(p.email || ''), totalSp: p.totalSp, level: p.level, trophyLeague: p.trophyLeague }]);
+        setSearchMsg('1 result found.');
+      } else {
+        const hits = (data.matches || []).filter(m => m._id !== student._id);
+        setSearchResults(hits);
+        setSearchMsg(hits.length ? `${hits.length} result${hits.length > 1 ? 's' : ''} found.` : 'No matching student found.');
+      }
+    } catch {
+      setSearchMsg('Search failed — please try again.');
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  // Leaderboard rows (exclude self), enriched with _id from profile leaderboard
+  const lbPeers = leaderboard
+    .filter(row => !row.isCurrentStudent)
+    .map(row => ({
+      _id: row.maskedEmail, // use maskedEmail as stable ID for leaderboard peers
+      name: row.name,
+      maskedEmail: row.maskedEmail,
+      totalSp: row.totalSp,
+      level: row.level,
+      trophyLeague: row.trophyLeague || '',
+      rank: row.rank
+    }));
+
+  return (
+    <section className="panel peers-panel">
+      <div className="peers-search-bar">
+        <h2 className="peers-heading">⭐ Peers</h2>
+        <div className="peers-search-row">
+          <input
+            id="peer-search-input"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && doSearch()}
+            placeholder="Search peers by name or email…"
+          />
+          <button id="peer-search-btn" className="primary" onClick={doSearch} disabled={searching}>
+            {searching ? 'Searching…' : 'Search'}
+          </button>
+        </div>
+        {searchMsg && <p className={searchMsg.includes('No') || searchMsg.includes('failed') ? 'error' : 'muted peers-msg'}>{searchMsg}</p>}
+        {searchResults.length > 0 && (
+          <div className="peer-results">
+            {searchResults.map(peer => (
+              <PeerCard
+                key={peer._id}
+                peer={peer}
+                starred={isStarred(peer._id)}
+                onStar={() => toggleStar(peer)}
+                onCompare={() => setComparePeer(peer)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {starred.length > 0 && (
+        <div className="peers-section">
+          <h3 className="peers-section-title">★ Starred Peers <span className="peers-count">{starred.length}</span></h3>
+          <div className="peer-cards">
+            {starred.map(peer => (
+              <PeerCard
+                key={peer._id}
+                peer={peer}
+                starred
+                onStar={() => toggleStar(peer)}
+                onCompare={() => setComparePeer(peer)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="peers-section">
+        <h3 className="peers-section-title">☆ Star from Leaderboard <span className="peers-count">{lbPeers.length}</span></h3>
+        <div className="peers-lb-list">
+          {lbPeers.map(peer => (
+            <div key={peer._id} className="peers-lb-row">
+              <span className="peers-lb-rank">#{peer.rank}</span>
+              <span className="peers-lb-name">{peer.name}</span>
+              <span className="peers-lb-sp">{peer.totalSp} SP</span>
+              <span className="peers-lb-league">{peer.trophyLeague}</span>
+              <div className="peers-lb-actions">
+                <button
+                  id={`star-lb-${peer.rank}`}
+                  className={`star-btn${isStarred(peer._id) ? ' starred' : ''}`}
+                  onClick={() => toggleStar(peer)}
+                  title={isStarred(peer._id) ? 'Unstar' : 'Star this peer'}
+                >{isStarred(peer._id) ? '★' : '☆'}</button>
+                <button
+                  id={`compare-lb-${peer.rank}`}
+                  className="secondary compare-btn"
+                  onClick={() => setComparePeer(peer)}
+                >vs</button>
+              </div>
+            </div>
+          ))}
+          {lbPeers.length === 0 && <p className="muted">No leaderboard peers to show.</p>}
+        </div>
+      </div>
+
+      {comparePeer && (
+        <PeerCompareModal
+          me={student}
+          cohort={cohort}
+          peer={comparePeer}
+          onClose={() => setComparePeer(null)}
+        />
+      )}
+    </section>
+  );
+}
+
+function maskEmailClient(email) {
+  const [name, domain] = String(email || '').split('@');
+  if (!name || !domain) return email || '—';
+  const start = name.slice(0, Math.min(2, name.length));
+  const end = name.length > 4 ? name.slice(-2) : '';
+  return `${start}${'*'.repeat(Math.max(3, name.length - start.length - end.length))}${end}@${domain}`;
+}
+
+function PeerCard({ peer, starred, onStar, onCompare }) {
+  return (
+    <div className={`peer-card${starred ? ' peer-card--starred' : ''}`}>
+      <div className="peer-card-info">
+        <strong className="peer-card-name">{peer.name}</strong>
+        <span className="peer-card-email">{peer.maskedEmail}</span>
+        <div className="peer-card-stats">
+          <span className="peer-stat">{peer.totalSp} SP</span>
+          {peer.rank && <span className="peer-stat">Rank #{peer.rank}</span>}
+          {peer.level != null && <span className="peer-stat">Lv {peer.level}</span>}
+          {peer.trophyLeague && <span className="peer-stat peer-league">{peer.trophyLeague}</span>}
+        </div>
+      </div>
+      <div className="peer-card-actions">
+        <button
+          className={`star-btn${starred ? ' starred' : ''}`}
+          onClick={onStar}
+          title={starred ? 'Unstar peer' : 'Star this peer'}
+        >{starred ? '★' : '☆'}</button>
+        <button className="secondary compare-btn" onClick={onCompare}>vs</button>
+      </div>
+    </div>
+  );
+}
+
+function PeerCompareModal({ me, cohort, peer, onClose }) {
+  const metrics = [
+    {
+      label: 'Spurti Points',
+      mine: me.totalSp,
+      theirs: peer.totalSp,
+      better: 'higher',
+      format: v => `${v} SP`
+    },
+    {
+      label: 'Rank',
+      mine: me.rank,
+      theirs: peer.rank,
+      better: 'lower',
+      format: v => v ? `#${v}` : '—'
+    },
+    {
+      label: 'Level',
+      mine: me.level,
+      theirs: peer.level,
+      better: 'higher',
+      format: v => v != null ? `Level ${v}` : '—'
+    },
+    {
+      label: 'Trophy League',
+      mine: me.trophyLeague,
+      theirs: peer.trophyLeague,
+      better: null,
+      format: v => v || '—'
+    },
+    {
+      label: 'vs Cohort Avg',
+      mine: me.totalSp - (cohort?.averageSp || 0),
+      theirs: peer.totalSp - (cohort?.averageSp || 0),
+      better: 'higher',
+      format: v => v >= 0 ? `+${v} SP` : `${v} SP`
+    }
+  ];
+
+  function indicator(mine, theirs, better) {
+    if (better === null || mine == null || theirs == null) return { me: '', peer: '' };
+    const mineN = Number(mine);
+    const theirsN = Number(theirs);
+    if (isNaN(mineN) || isNaN(theirsN)) return { me: '', peer: '' };
+    if (mineN === theirsN) return { me: '─', peer: '─' };
+    const meWins = better === 'higher' ? mineN > theirsN : mineN < theirsN;
+    return meWins
+      ? { me: <span className="cmp-win">↑</span>, peer: <span className="cmp-lose">↓</span> }
+      : { me: <span className="cmp-lose">↓</span>, peer: <span className="cmp-win">↑</span> };
+  }
+
+  return (
+    <div className="overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <section className="modal compare-modal">
+        <div className="modal-head">
+          <h2>Progress Comparison</h2>
+          <button className="icon" onClick={onClose}>x</button>
+        </div>
+        <div className="compare-cols-header">
+          <div className="compare-col-label">YOU</div>
+          <div className="compare-metric-label"></div>
+          <div className="compare-col-label peer-col-label">{peer.name.split(' ')[0]}</div>
+        </div>
+        <div className="compare-rows">
+          {metrics.map(({ label, mine, theirs, better, format }) => {
+            const ind = indicator(mine, theirs, better);
+            return (
+              <div className="compare-row" key={label}>
+                <div className="compare-cell compare-cell--me">
+                  <span className="compare-val">{format(mine)}</span>
+                  <span className="compare-ind">{ind.me}</span>
+                </div>
+                <div className="compare-metric">{label}</div>
+                <div className="compare-cell compare-cell--peer">
+                  <span className="compare-ind">{ind.peer}</span>
+                  <span className="compare-val">{format(theirs)}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="compare-footer">
+          <button className="secondary" onClick={onClose}>Close</button>
+        </div>
+      </section>
+    </div>
+  );
+}
 
 createRoot(document.getElementById('root')).render(<App />);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -461,7 +461,252 @@ input {
     grid-template-columns: 1fr;
   }
   .search-row { grid-template-columns: 1fr; }
+  .peers-lb-row { grid-template-columns: 32px 1fr auto; }
+  .peers-lb-sp, .peers-lb-league { display: none; }
+  .compare-cols-header, .compare-row { grid-template-columns: 1fr 1fr 1fr; }
 }
+
+/* ── Peers Tab ──────────────────────────────────────────────────────────── */
+
+.peers-panel { padding: 20px; margin-bottom: 18px; }
+
+.peers-heading {
+  margin: 0 0 16px;
+  font-size: 22px;
+  color: var(--text);
+}
+
+.peers-search-bar { margin-bottom: 24px; }
+
+.peers-search-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.peers-msg { font-size: 13px; }
+
+.peer-results {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.peers-section {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 2px solid var(--line);
+}
+
+.peers-section-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 16px;
+  font-weight: 900;
+  color: var(--text);
+  margin: 0 0 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.peers-count {
+  background: var(--primary);
+  color: #fff;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0;
+}
+
+/* Peer cards (starred section + search results) */
+.peer-cards { display: grid; gap: 10px; }
+
+.peer-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  background: #fff;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.peer-card:hover { border-color: var(--primary); box-shadow: 0 4px 18px rgba(23, 107, 135, 0.1); }
+.peer-card--starred { border-left: 4px solid #f59e0b; background: #fffdf5; }
+
+.peer-card-info { display: grid; gap: 4px; min-width: 0; }
+
+.peer-card-name {
+  font-size: 15px;
+  font-weight: 850;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.peer-card-email {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.peer-card-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.peer-stat {
+  font-size: 12px;
+  font-weight: 850;
+  color: var(--primary-dark);
+  background: #e9f2f5;
+  border-radius: 999px;
+  padding: 3px 10px;
+}
+
+.peer-league { background: #fef3c7; color: #92400e; }
+
+.peer-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Star button */
+.star-btn {
+  width: 38px;
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fff;
+  font-size: 18px;
+  cursor: pointer;
+  transition: transform 0.15s, background 0.15s, border-color 0.15s;
+  line-height: 1;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.star-btn:hover { border-color: #f59e0b; background: #fffbeb; transform: scale(1.12); }
+.star-btn.starred { background: #fef3c7; border-color: #f59e0b; }
+.star-btn.starred:hover { background: #fee2e2; border-color: var(--red); }
+
+/* Compare button */
+.compare-btn {
+  font-size: 12px;
+  font-weight: 900;
+  min-height: 38px;
+  padding: 0 14px;
+  letter-spacing: 0.04em;
+}
+
+/* Quick-star leaderboard list */
+.peers-lb-list { display: grid; gap: 0; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+
+.peers-lb-row {
+  display: grid;
+  grid-template-columns: 42px minmax(0,1fr) 90px 130px auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  font-size: 14px;
+  transition: background 0.1s;
+}
+.peers-lb-row:last-child { border-bottom: 0; }
+.peers-lb-row:hover { background: #f8fafc; }
+
+.peers-lb-rank { color: var(--muted); font-size: 13px; font-weight: 900; }
+.peers-lb-name { font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.peers-lb-sp { color: var(--primary); font-weight: 850; font-size: 13px; }
+.peers-lb-league { color: var(--muted); font-size: 12px; }
+.peers-lb-actions { display: flex; gap: 6px; align-items: center; }
+
+/* ── Compare Modal ──────────────────────────────────────────────────────── */
+
+.compare-modal {
+  width: min(560px, 100%);
+  padding: 24px;
+}
+
+.compare-cols-header {
+  display: grid;
+  grid-template-columns: 1fr 140px 1fr;
+  gap: 8px;
+  margin: 16px 0 4px;
+}
+
+.compare-col-label {
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary);
+  text-align: center;
+}
+.peer-col-label { color: #7c3aed; }
+
+.compare-metric-label { text-align: center; }
+
+.compare-rows { display: grid; gap: 0; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+
+.compare-row {
+  display: grid;
+  grid-template-columns: 1fr 140px 1fr;
+  gap: 0;
+  border-bottom: 1px solid var(--line);
+  align-items: center;
+}
+.compare-row:last-child { border-bottom: 0; }
+.compare-row:nth-child(odd) { background: #f8fafc; }
+
+.compare-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 14px;
+}
+.compare-cell--me { justify-content: flex-start; }
+.compare-cell--peer { justify-content: flex-end; }
+
+.compare-metric {
+  text-align: center;
+  font-size: 12px;
+  font-weight: 900;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 12px 4px;
+  border-left: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+}
+
+.compare-val {
+  font-size: 15px;
+  font-weight: 850;
+  color: var(--text);
+}
+
+.compare-ind { font-size: 14px; font-weight: 900; }
+.cmp-win { color: var(--green); }
+.cmp-lose { color: var(--red); }
+
+.compare-footer {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+
 
 /* --- Mandatory survey pop-up ------------------------------------------- */
 .survey-overlay {


### PR DESCRIPTION
## ⭐ Peer Tracking System

### Problem
When students want to track specific peers' progress, they had to manually
scroll through the leaderboard every time — slow and inconvenient.

### What this PR adds

#### 🔍 Peer Search
- Search any student by name using the existing `/api/search` endpoint
- Results show SP balance, rank, level, and league at a glance
<img width="1167" height="279" alt="Screenshot from 2026-07-01 14-53-40" src="https://github.com/user-attachments/assets/c05e60e9-5719-4b8f-b88f-45949fa0892c" />

#### ⭐ Star / Bookmark Peers
- Star any peer from search results for quick access
- Starred peers appear in a dedicated section at the top
- Bookmarks persist across sessions via `localStorage`
<img width="1194" height="836" alt="Screenshot from 2026-07-01 14-53-58" src="https://github.com/user-attachments/assets/ab3ea5e2-1150-428e-95b9-015a5987c83a" />

#### 📊 Progress Comparison
- Click **[vs]** on any peer to open a side-by-side comparison modal
- Compares: SP balance, leaderboard rank, level, and trophy league
- Visual win/loss indicators highlight where you lead or trail
<img width="1194" height="836" alt="Screenshot from 2026-07-01 14-54-24" src="https://github.com/user-attachments/assets/0a346ef1-e78d-4f5f-9af5-0f7ee42b16fc" />

### Files changed
- `client/src/main.jsx` — `PeersTab` component, `PeerCompareModal`, localStorage helpers, added ⭐ Peers tab to `StudentView`
- `client/src/styles.css` — peer card grid, star button, compare modal, responsive layout

### No backend changes
All three features work entirely on the frontend using existing APIs —
zero DB schema changes, zero new endpoints.
