### PR TITLE
 feat: add attendance streak tracking

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -338,14 +338,55 @@ function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
   );
 }
 
+function StreakCard({ streak }) {
+  if (!streak) {
+    return (
+      <div className="pulse-card streak-card">
+        <span>Streak & Momentum</span>
+        <div className="streak-main">
+          <p className="muted">No sessions yet</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { currentStreak, longestStreak, streakBrokenAt, isActive } = streak;
+
+  return (
+    <div className={`pulse-card streak-card ${isActive ? 'streak-active' : ''}`}>
+      <span>Streak & Momentum</span>
+      <div className="streak-main">
+        <strong>{currentStreak}</strong>
+        <div className="compare-list">
+          <b>Personal Best: {longestStreak}</b>
+        </div>
+      </div>
+      
+      {isActive ? (
+        <div className="badge-row">
+          <em className="streak-flame">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"></path></svg>
+            Active Streak
+          </em>
+        </div>
+      ) : (
+        <p className="muted streak-ended">
+          {streakBrokenAt ? `Streak ended after: ${streakBrokenAt}` : 'No active streak'}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function StudentPulse({ profile, badges, nextActions }) {
-  const { student, cohort, attendance, polls, transactions } = profile;
+  const { student, cohort, attendance, polls, transactions, streak } = profile;
   const qualified = attendance.filter(a => a.qualified).length;
   const pollAttempted = polls.reduce((sum, p) => sum + p.attemptedQuestions, 0);
   const pollTotal = polls.reduce((sum, p) => sum + p.totalQuestions, 0);
   const trend = transactions.map(tx => ({ label: tx.sessionLabel || 'Start', value: tx.balanceAfter }));
   return (
     <section className="pulse-grid">
+      <StreakCard streak={streak} />
       <div className="pulse-card progress-card">
         <span>Standing</span>
         <strong>Rank {student.rank}</strong>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,41 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* --- Streak feature ---------------------------------------------------- */
+.streak-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.streak-main {
+  margin-bottom: 8px;
+}
+.streak-active {
+  background: linear-gradient(135deg, #ffffff 40%, #eaf6fa 100%);
+}
+.streak-flame {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #e9f2f5;
+  color: var(--primary-dark);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 850;
+  animation: flame-pulse 2s infinite ease-in-out;
+}
+.streak-flame svg {
+  color: #d97706;
+}
+@keyframes flame-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(23, 107, 135, 0.2); }
+  50% { box-shadow: 0 0 0 5px rgba(23, 107, 135, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(23, 107, 135, 0); }
+}
+.streak-ended {
+  font-size: 12px;
+  margin: 0;
+  line-height: 1.4;
+}

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { computeStreak } from './services/streaks.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -164,6 +165,7 @@ async function studentPayload(student) {
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
   ]);
+  const streak = computeStreak(attendance);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
   const top10Cutoff = allStudents[9]?.totalSp || null;
@@ -207,6 +209,7 @@ async function studentPayload(student) {
     transactions,
     polls,
     attendance,
+    streak,
     cohort: {
       averageSp,
       top10Cutoff,

--- a/server/services/streaks.js
+++ b/server/services/streaks.js
@@ -1,0 +1,52 @@
+/**
+ * Spurti Attendance Streak Tracking.
+ *
+ * This is a DERIVED VIEW over the existing attendance data — a pure function, no DB,
+ * no side effects. It computes the student's streak status from an already-fetched
+ * array of their attendance records.
+ */
+
+export function computeStreak(attendanceRecords) {
+  if (!attendanceRecords || attendanceRecords.length === 0) {
+    return {
+      currentStreak: 0,
+      longestStreak: 0,
+      streakBrokenAt: null,
+      isActive: false
+    };
+  }
+
+  // Defensively sort the input by sessionLabel ascending without mutating original array.
+  const sorted = [...attendanceRecords].sort((a, b) => {
+    if (a.sessionLabel < b.sessionLabel) return -1;
+    if (a.sessionLabel > b.sessionLabel) return 1;
+    return 0;
+  });
+
+  let currentStreak = 0;
+  let longestStreak = 0;
+  let isActive = false;
+  let streakBrokenAt = null;
+
+  for (const record of sorted) {
+    if (record.qualified) {
+      currentStreak++;
+      isActive = true;
+      streakBrokenAt = null;
+      if (currentStreak > longestStreak) {
+        longestStreak = currentStreak;
+      }
+    } else {
+      currentStreak = 0;
+      isActive = false;
+      streakBrokenAt = record.sessionLabel;
+    }
+  }
+
+  return {
+    currentStreak,
+    longestStreak,
+    streakBrokenAt,
+    isActive
+  };
+}


### PR DESCRIPTION
Title: feat: add attendance streak tracking

What
Adds a `streak` object (currentStreak, longestStreak, streakBrokenAt,
isActive) to the student profile payload, and a new "Streak & Momentum"
card on the student dashboard showing it.

Why
Implements the "Streaks" mechanic named in PRODUCT.md — there was
previously no signal, for students or admins, showing attendance
consistency over time.

How
- server/services/streaks.js: pure derived-view function, follows the
  existing pattern in services/levels.js. No DB access, no side effects.
- Wired into the shared studentPayload() function in server.js (3-line
  diff), so both /api/me, /api/search, and /admin/student/:id get streak
  data automatically. Zero schema changes, zero new queries — reuses the
  attendance array already fetched there.
- client: new StreakCard component in main.jsx, added to the existing
  pulse-grid. Reuses existing .pulse-card/.badge-row CSS conventions,
  new styles scoped under .streak-* classes only — no existing rule
  modified. CSS-only pulse animation on the active state, no new
  dependencies.

Testing
Verified /api/me and /admin/student/:id return the new streak field
with correct values against hand-checked attendance records. Verified
the UI renders correctly for all four states: active streak, broken
streak, no attendance data, and mid-cohort students.