### PR TITLE
feat: add weekly SP pulse — Autopsy digest + Pass the Torch

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -255,9 +255,17 @@ function SearchModal({ onClose, onStudent }) {
 
 function StudentView({ profile, onBack }) {
   const [tab, setTab] = useState('bank');
+  const [torchData, setTorchData] = useState(undefined);
   const { student } = profile;
   const badges = useMemo(() => buildBadges(profile), [profile]);
   const nextActions = useMemo(() => buildNextActions(profile), [profile]);
+
+  useEffect(() => {
+    fetch(`${API}/torch`)
+      .then(res => res.json())
+      .then(data => setTorchData(data))
+      .catch(() => setTorchData(null));
+  }, []);
   return (
     <main className="page compact">
       <header className="topbar">
@@ -269,11 +277,11 @@ function StudentView({ profile, onBack }) {
         <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
       <LevelStatus student={student} />
-      <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
+      <StudentPulse profile={profile} badges={badges} nextActions={nextActions} torchData={torchData} />
       <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
-      {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
+      {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} torchData={torchData} />}
     </main>
   );
 }
@@ -312,7 +320,7 @@ function LevelStatus({ student }) {
   );
 }
 
-function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
+function LeaderboardTabs({ overall = [], group = [], groupLabel, torchData }) {
   const [type, setType] = useState('overall');
   const rows = type === 'overall' ? overall : group;
   return (
@@ -328,18 +336,26 @@ function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
         <p className="muted">Showing students onboarded in your group: {groupLabel}</p>}
       <table className="table">
         <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>Level</th><th>SP</th></tr></thead>
-        <tbody>{rows.map(row => (
+        <tbody>{rows.map(row => {
+          const isTorch = torchData?.torch && row.name === torchData.torch.name;
+          return (
           <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}>
-            <td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.level}</td><td>{row.totalSp}</td>
+            <td>{row.rank}</td>
+            <td>
+              {row.name}
+              {isTorch && <em className="torch-badge">Torch Holder</em>}
+            </td>
+            <td>{row.maskedEmail}</td><td>{row.level}</td><td>{row.totalSp}</td>
           </tr>
-        ))}</tbody>
+          );
+        })}</tbody>
       </table>
     </section>
   );
 }
 
-function StudentPulse({ profile, badges, nextActions }) {
-  const { student, cohort, attendance, polls, transactions } = profile;
+function StudentPulse({ profile, badges, nextActions, torchData }) {
+  const { student, cohort, attendance, polls, transactions, weeklyPulse } = profile;
   const qualified = attendance.filter(a => a.qualified).length;
   const pollAttempted = polls.reduce((sum, p) => sum + p.attemptedQuestions, 0);
   const pollTotal = polls.reduce((sum, p) => sum + p.totalQuestions, 0);
@@ -380,6 +396,8 @@ function StudentPulse({ profile, badges, nextActions }) {
         <span>What to do next</span>
         <ul className="next-list">{nextActions.map(action => <li key={action}>{action}</li>)}</ul>
       </div>
+      <WeeklyPulseCard weeklyPulse={weeklyPulse} />
+      <WeeklyTorchCard torchData={torchData} currentEmail={student.email} />
     </section>
   );
 }
@@ -394,6 +412,86 @@ function Sparkline({ points }) {
         const pct = max === min ? 50 : ((point.value - min) / (max - min)) * 100;
         return <i key={`${point.label}-${index}`} title={`${point.label}: ${point.value} SP`} style={{ height: `${Math.max(6, pct)}%` }} />;
       })}
+    </div>
+  );
+}
+
+function WeeklyPulseCard({ weeklyPulse }) {
+  if (!weeklyPulse) {
+    return (
+      <div className="pulse-card wide-pulse weekly-pulse-card">
+        <span>Weekly SP Pulse</span>
+        <p className="muted">Loading pulse...</p>
+      </div>
+    );
+  }
+
+  const { netSp, lost, byCategory, topLossReasons } = weeklyPulse;
+
+  return (
+    <div className="pulse-card wide-pulse weekly-pulse-card">
+      <span>Weekly SP Pulse</span>
+      <div className="weekly-pulse-content">
+        {lost === 0 || topLossReasons.length === 0 ? (
+          <p className="pulse-good-news">You gained {netSp} SP this week — no losses. Nice run.</p>
+        ) : (
+          <div className="pulse-losses">
+            <p>You lost {lost} SP this week</p>
+            <ul className="loss-list">
+              {topLossReasons.map((item, idx) => (
+                <li key={idx}><strong>-{item.amount}</strong> <em>{item.reason} ({item.sessionLabel})</em></li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <div className="compare-list category-breakdown">
+          {Object.entries(byCategory).map(([cat, data]) => (
+            <b key={cat}>{cat}: {data.netSp > 0 ? '+' : ''}{data.netSp} SP</b>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WeeklyTorchCard({ torchData, currentEmail }) {
+  if (torchData === undefined) {
+    return (
+      <div className="pulse-card wide-pulse torch-card">
+        <span>Weekly Torch</span>
+        <p className="muted">Loading torch data...</p>
+      </div>
+    );
+  }
+
+  const torch = torchData?.torch;
+
+  if (!torch) {
+    return (
+      <div className="pulse-card wide-pulse torch-card">
+        <span>Weekly Torch</span>
+        <p className="muted">No one has gained SP yet this week.</p>
+      </div>
+    );
+  }
+
+  const isHolder = torch.email === currentEmail;
+
+  return (
+    <div className={`pulse-card wide-pulse torch-card ${isHolder ? 'torch-holder' : ''}`}>
+      <span>Weekly Torch</span>
+      {isHolder ? (
+        <div className="torch-content">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="torch-icon">
+             <path d="M12 2C8 6 8 10 12 14c4-4 4-8 0-12z" />
+             <path d="M12 14v8" />
+             <path d="M10 22h4" />
+          </svg>
+          <p>You're holding the torch this week! (+{torch.netSp} SP)</p>
+        </div>
+      ) : (
+        <p><strong>{torch.name}</strong> holds the torch this week (+{torch.netSp} SP).</p>
+      )}
     </div>
   );
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -396,7 +396,7 @@ function StudentPulse({ profile, badges, nextActions, torchData }) {
         <ul className="next-list">{nextActions.map(action => <li key={action}>{action}</li>)}</ul>
       </div>
       <WeeklyPulseCard weeklyPulse={weeklyPulse} />
-      <WeeklyTorchCard torchData={torchData} currentEmail={student.email} />
+      <WeeklyTorchCard torchData={torchData} />
     </section>
   );
 }
@@ -455,7 +455,7 @@ function WeeklyPulseCard({ weeklyPulse }) {
   );
 }
 
-function WeeklyTorchCard({ torchData, currentEmail }) {
+function WeeklyTorchCard({ torchData }) {
   if (torchData === undefined) {
     return (
       <div className="pulse-card wide-pulse torch-card">
@@ -476,7 +476,7 @@ function WeeklyTorchCard({ torchData, currentEmail }) {
     );
   }
 
-  const isHolder = torch.email === currentEmail;
+  const isHolder = torch.isCurrentUser;
 
   return (
     <div className={`pulse-card wide-pulse torch-card ${isHolder ? 'torch-holder' : ''}`}>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -281,7 +281,7 @@ function StudentView({ profile, onBack }) {
       <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
-      {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} torchData={torchData} />}
+      {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
     </main>
   );
 }
@@ -320,7 +320,7 @@ function LevelStatus({ student }) {
   );
 }
 
-function LeaderboardTabs({ overall = [], group = [], groupLabel, torchData }) {
+function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
   const [type, setType] = useState('overall');
   const rows = type === 'overall' ? overall : group;
   return (
@@ -337,13 +337,12 @@ function LeaderboardTabs({ overall = [], group = [], groupLabel, torchData }) {
       <table className="table">
         <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>Level</th><th>SP</th></tr></thead>
         <tbody>{rows.map(row => {
-          const isTorch = torchData?.torch && row.maskedEmail === torchData.torch.maskedEmail;
           return (
           <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}>
             <td>{row.rank}</td>
             <td>
               {row.name}
-              {isTorch && <em className="torch-badge">Torch Holder</em>}
+              {row.isTorchHolder && <em className="torch-badge">Torch Holder</em>}
             </td>
             <td>{row.maskedEmail}</td><td>{row.level}</td><td>{row.totalSp}</td>
           </tr>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -337,7 +337,7 @@ function LeaderboardTabs({ overall = [], group = [], groupLabel, torchData }) {
       <table className="table">
         <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>Level</th><th>SP</th></tr></thead>
         <tbody>{rows.map(row => {
-          const isTorch = torchData?.torch && row.name === torchData.torch.name;
+          const isTorch = torchData?.torch && row.maskedEmail === torchData.torch.maskedEmail;
           return (
           <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}>
             <td>{row.rank}</td>
@@ -426,13 +426,15 @@ function WeeklyPulseCard({ weeklyPulse }) {
     );
   }
 
-  const { netSp, lost, byCategory, topLossReasons } = weeklyPulse;
+  const { netSp, gained, lost, byCategory, topLossReasons } = weeklyPulse;
 
   return (
     <div className="pulse-card wide-pulse weekly-pulse-card">
       <span>Weekly SP Pulse</span>
       <div className="weekly-pulse-content">
-        {lost === 0 || topLossReasons.length === 0 ? (
+        {gained === 0 && lost === 0 ? (
+          <p className="pulse-good-news">No SP activity recorded yet this week.</p>
+        ) : lost === 0 || topLossReasons.length === 0 ? (
           <p className="pulse-good-news">You gained {netSp} SP this week — no losses. Nice run.</p>
         ) : (
           <div className="pulse-losses">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,75 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* --- Weekly Pulse & Torch ---------------------------------------------- */
+.weekly-pulse-card .pulse-good-news {
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+.pulse-losses {
+  margin-bottom: 12px;
+}
+.loss-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+.loss-list li {
+  display: flex;
+  gap: 8px;
+  font-size: 13px;
+}
+.loss-list strong {
+  color: var(--red);
+  font-size: 13px !important;
+  margin-bottom: 0 !important;
+}
+.loss-list em {
+  font-style: normal;
+  color: var(--muted);
+}
+.category-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+.torch-holder {
+  background: linear-gradient(135deg, #fdf6ec 0%, #faecd6 100%);
+  border-color: #f6d198;
+  box-shadow: 0 4px 20px rgba(161, 92, 7, 0.15);
+}
+.torch-holder > span {
+  color: var(--amber);
+}
+.torch-content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.torch-content p {
+  margin: 0;
+  color: var(--amber);
+  font-weight: 600;
+}
+.torch-icon {
+  color: var(--amber);
+}
+.torch-badge {
+  display: inline-block;
+  margin-left: 8px;
+  font-style: normal;
+  background: linear-gradient(135deg, #fcebc5, #f5d078);
+  color: var(--amber);
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 850;
+  vertical-align: middle;
+  box-shadow: 0 2px 8px rgba(161, 92, 7, 0.1);
+}

--- a/server/server.js
+++ b/server/server.js
@@ -333,6 +333,9 @@ api.get('/torch', async (_req, res) => {
   }));
 
   const torch = weeklyTorchHolder(deltaRows);
+  if (torch) {
+    torch.maskedEmail = maskEmail(torch.email);
+  }
 
   res.json({ windowDays, torch });
 });

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { weeklySpBreakdown, weeklyTorchHolder } from './services/weeklyPulse.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -164,6 +165,7 @@ async function studentPayload(student) {
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
   ]);
+  const weeklyPulse = weeklySpBreakdown(transactions);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
   const top10Cutoff = allStudents[9]?.totalSp || null;
@@ -205,6 +207,7 @@ async function studentPayload(student) {
       surveyCompleted: Boolean(student.surveyCompleted)
     },
     transactions,
+    weeklyPulse,
     polls,
     attendance,
     cohort: {
@@ -302,6 +305,36 @@ api.get('/leaderboard', async (req, res) => {
     level: levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0)),
     trophyLeague: leagueBand(s.totalSp)
   })));
+});
+
+api.get('/torch', async (_req, res) => {
+  const windowDays = 7;
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+
+  const activeStudents = await Student.find({ status: { $ne: 'excused' } })
+    .select('email name')
+    .lean();
+
+  const aggregation = await SPTransaction.aggregate([
+    { $match: { dateTime: { $gte: cutoff, $lte: now } } },
+    { $group: { _id: "$email", netSp: { $sum: "$appliedDelta" } } }
+  ]);
+
+  const deltaMap = new Map();
+  for (const row of aggregation) {
+    deltaMap.set(row._id, row.netSp);
+  }
+
+  const deltaRows = activeStudents.map(s => ({
+    email: s.email,
+    name: s.name,
+    netSp: deltaMap.get(s.email) || 0
+  }));
+
+  const torch = weeklyTorchHolder(deltaRows);
+
+  res.json({ windowDays, torch });
 });
 
 api.post('/ping', async (req, res) => {

--- a/server/server.js
+++ b/server/server.js
@@ -292,22 +292,7 @@ api.post('/confirm', async (req, res) => {
   res.json(await studentPayload(student));
 });
 
-api.get('/leaderboard', async (req, res) => {
-  const type = String(req.query.leaderboardType || 'overall');
-  const filter = { status: { $ne: 'excused' } };
-  if (type === 'my_onboarding_group' && req.query.group) filter.leaderboardGroup = String(req.query.group);
-  const students = await Student.find(filter).sort({ totalSp: -1, name: 1 }).limit(50).lean();
-  res.json(students.map((s, i) => ({
-    rank: i + 1,
-    name: s.name,
-    maskedEmail: maskEmail(s.email),
-    totalSp: s.totalSp,
-    level: levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0)),
-    trophyLeague: leagueBand(s.totalSp)
-  })));
-});
-
-api.get('/torch', async (_req, res) => {
+async function getWeeklyTorchHolderEmail() {
   const windowDays = 7;
   const now = new Date();
   const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
@@ -332,11 +317,35 @@ api.get('/torch', async (_req, res) => {
     netSp: deltaMap.get(s.email) || 0
   }));
 
-  const torch = weeklyTorchHolder(deltaRows);
+  return { windowDays, torch: weeklyTorchHolder(deltaRows) };
+}
+
+api.get('/leaderboard', async (req, res) => {
+  const type = String(req.query.leaderboardType || 'overall');
+  const filter = { status: { $ne: 'excused' } };
+  if (type === 'my_onboarding_group' && req.query.group) filter.leaderboardGroup = String(req.query.group);
+  
+  const [students, { torch }] = await Promise.all([
+    Student.find(filter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
+    getWeeklyTorchHolderEmail()
+  ]);
+
+  res.json(students.map((s, i) => ({
+    rank: i + 1,
+    name: s.name,
+    maskedEmail: maskEmail(s.email),
+    totalSp: s.totalSp,
+    level: levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0)),
+    trophyLeague: leagueBand(s.totalSp),
+    isTorchHolder: torch ? s.email === torch.email : false
+  })));
+});
+
+api.get('/torch', async (_req, res) => {
+  const { windowDays, torch } = await getWeeklyTorchHolderEmail();
   if (torch) {
     torch.maskedEmail = maskEmail(torch.email);
   }
-
   res.json({ windowDays, torch });
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -341,12 +341,20 @@ api.get('/leaderboard', async (req, res) => {
   })));
 });
 
-api.get('/torch', async (_req, res) => {
+api.get('/torch', async (req, res) => {
+  const requesterEmail = await studentEmailFromRequest(req);
   const { windowDays, torch } = await getWeeklyTorchHolderEmail();
+  
+  let safeTorch = null;
   if (torch) {
-    torch.maskedEmail = maskEmail(torch.email);
+    safeTorch = {
+      name: torch.name,
+      maskedEmail: maskEmail(torch.email),
+      netSp: torch.netSp,
+      isCurrentUser: requesterEmail === torch.email
+    };
   }
-  res.json({ windowDays, torch });
+  res.json({ windowDays, torch: safeTorch });
 });
 
 api.post('/ping', async (req, res) => {

--- a/server/services/weeklyPulse.js
+++ b/server/services/weeklyPulse.js
@@ -1,0 +1,82 @@
+/**
+ * Spurti Weekly SP Pulse.
+ *
+ * These are DERIVED VIEWS over the existing SP system — pure functions, no DB,
+ * no side effects. SP transactions and balances are never changed here.
+ * Calculates rolling 7-day breakdown of a student's SP and determines the weekly torch holder.
+ */
+
+export function weeklySpBreakdown(transactions = [], options = {}) {
+  const referenceDate = options.referenceDate || new Date();
+  const windowDays = options.windowDays || 7;
+  
+  const cutoffTime = referenceDate.getTime() - (windowDays * 24 * 60 * 60 * 1000);
+
+  const windowTransactions = (transactions || []).filter(tx => {
+    const txTime = new Date(tx.dateTime).getTime();
+    return txTime >= cutoffTime && txTime <= referenceDate.getTime();
+  });
+
+  const categoryMap = {};
+  let overallNet = 0;
+  let overallGained = 0;
+  let overallLost = 0;
+  
+  const debits = [];
+
+  for (const tx of windowTransactions) {
+    const delta = Number(tx.appliedDelta) || 0;
+    const cat = tx.category || 'unknown';
+
+    if (!categoryMap[cat]) {
+      categoryMap[cat] = { netSp: 0, credits: 0, debits: 0 };
+    }
+
+    categoryMap[cat].netSp += delta;
+    overallNet += delta;
+
+    if (delta > 0) {
+      categoryMap[cat].credits += delta;
+      overallGained += delta;
+    } else if (delta < 0) {
+      categoryMap[cat].debits += Math.abs(delta);
+      overallLost += Math.abs(delta);
+      debits.push({
+        reason: tx.reason,
+        sessionLabel: tx.sessionLabel || '',
+        amount: Math.abs(delta)
+      });
+    }
+  }
+
+  // topLossReasons: the 3 biggest single debits, most-negative first.
+  debits.sort((a, b) => b.amount - a.amount);
+  const topLossReasons = debits.slice(0, 3);
+
+  return {
+    windowDays,
+    netSp: overallNet,
+    gained: overallGained,
+    lost: overallLost,
+    byCategory: categoryMap,
+    topLossReasons
+  };
+}
+
+export function weeklyTorchHolder(deltaRows = []) {
+  if (!deltaRows || deltaRows.length === 0) return null;
+
+  let winner = null;
+
+  for (const row of deltaRows) {
+    if (row.netSp > 0) {
+      if (!winner || row.netSp > winner.netSp) {
+        // If there's a tie for highest netSp, pick the first one encountered implicitly
+        // by strictly checking `row.netSp > winner.netSp`
+        winner = row;
+      }
+    }
+  }
+
+  return winner;
+}


### PR DESCRIPTION
What
- Adds `weeklyPulse` to the student profile payload: a 7-day rolling
  breakdown of SP gained/lost by category, plus the top specific
  transactions that cost the most (SP Autopsy).
- Adds GET /api/torch: the active student with the highest net SP
  gain in the last 7 days (Pass the Torch — resets weekly since it's
  delta, not total, so it's not always the same student).
- Adds UI: a "Weekly SP Pulse" card and a "Weekly Torch" card on the
  student dashboard, plus a torch badge on the leaderboard row of
  whoever currently holds it.

Why
SP Bank currently only shows a flat, reactive transaction log — no
proactive "here's what happened this week" view. Autopsy turns
existing debit data into an actionable digest instead of a reactive
ledger line. Torch gives short-term-improving students something to
compete for that isn't locked to permanent rank.

How
- server/services/weeklyPulse.js: two pure derived-view functions
  (weeklySpBreakdown, weeklyTorchHolder), following the same pattern
  as services/levels.js and services/streaks.js (#8). No DB access
  inside the service, no side effects.
- weeklySpBreakdown wired into the existing studentPayload() function
  — reuses the `transactions` array already fetched there, no new
  query.
- weeklyTorchHolder fed by a single MongoDB aggregation ($group +
  $sum) in a new GET /api/torch route — aggregated server-side, not
  pulling every transaction into Node, so it scales at current cohort
  size. Read-only route, no writes, no SP is awarded by this feature
  — Torch is purely a display of each student's existing weekly SP
  delta, not a reward mechanism.
- Ties in weeklyTorchHolder resolve to whichever student is
  encountered first in the query — documented in code comment, a
  reasonable default for a low-stakes edge case.
- Torch holder matched on the leaderboard via maskedEmail (reusing
  the existing maskEmail() helper), not name, to avoid collisions
  across ~1,300 students with possibly duplicate names.
- Zero schema changes, zero new npm dependencies, zero existing
  response keys or routes modified — purely additive.

Testing
Manually verified with test SPTransaction data covering all cases:
- Zero activity this week → neutral "No SP activity recorded yet"
  message (not falsely framed as a positive or negative week)
- Gains only, no losses → positive framing
- Mixed gains/losses → loss-transparency breakdown with real
  topLossReasons entries
- Torch: no gainer this week → neutral empty state
- Torch: a student holding it → correct name/netSp shown, and the
  correct leaderboard row gets the torch badge

Security note: the initial implementation matched the weekly Torch Holder 
by comparing masked email strings client-side, which had a real collision 
risk for short usernames sharing a domain (e.g. "ab12@x.com" and 
"ab34@x.com" could mask identically). This was fixed by computing the 
match server-side using unmasked email comparison, exposed to the client 
only as a boolean (isTorchHolder / isCurrentUser). A related issue where 
GET /api/torch returned the torch holder's raw email to any caller was 
also fixed — the route now returns only maskedEmail plus a server-computed 
isCurrentUser boolean.