### PR TITLE
feat: SP trajectory chart + at-risk early warning system

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -279,8 +279,10 @@ function StudentView({ profile, onBack }) {
       </header>
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['heatmap','Heatmap'], ['trajectory','Trajectory'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
+      {tab === 'heatmap' && <SpHeatmap transactions={profile.transactions} />}
+      {tab === 'trajectory' && <SpTrajectory />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
     </main>
@@ -404,6 +406,94 @@ function Sparkline({ points }) {
         return <i key={`${point.label}-${index}`} title={`${point.label}: ${point.value} SP`} style={{ height: `${Math.max(6, pct)}%` }} />;
       })}
     </div>
+  );
+}
+
+function SpTrajectory() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${API}/student/trajectory`)
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (loading) return <section className="panel"><p className="muted">Loading trajectory...</p></section>;
+  if (!data || data.myPoints.length === 0) return <section className="panel"><p className="muted">Not enough data to show trajectory yet.</p></section>;
+
+  const W = 640, H = 240, padL = 44, padR = 16, padT = 12, padB = 36;
+  const plotW = W - padL - padR;
+  const plotH = H - padT - padB;
+
+  const allValues = [...data.myPoints.map(p => p.balance), ...data.cohortAverages.map(c => c.avgBalance)];
+  const minV = Math.min(...allValues, 0);
+  const maxV = Math.max(...allValues, 1);
+  const range = maxV - minV || 1;
+
+  const toX = (i, total) => padL + (i / (total - 1 || 1)) * plotW;
+  const toY = v => padT + plotH - ((v - minV) / range) * plotH;
+
+  const myLabels = data.myPoints.map(p => p.session);
+  const cohortLabels = data.cohortAverages.map(c => c.session);
+  const allLabels = [...new Set([...myLabels, ...cohortLabels])].sort();
+
+  const pathPoints = (pts) => pts.map((p, i) => {
+    const xi = allLabels.indexOf(p.session);
+    return `${i === 0 ? 'M' : 'L'}${toX(xi, allLabels.length)},${toY(p.balance)}`;
+  }).join(' ');
+
+  const areaPath = (pts) => {
+    if (!pts.length) return '';
+    const line = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${toX(allLabels.indexOf(p.session), allLabels.length)},${toY(p.balance)}`).join(' ');
+    const last = pts[pts.length - 1];
+    const first = pts[0];
+    const lastX = toX(allLabels.indexOf(last.session), allLabels.length);
+    const firstX = toX(allLabels.indexOf(first.session), allLabels.length);
+    return `${line} L${lastX},${padT + plotH} L${firstX},${padT + plotH} Z`;
+  };
+
+  const yTicks = Array.from({ length: 5 }, (_, i) => Math.round(minV + (range / 4) * i));
+  const gridColor = '#e2e8f0';
+
+  return (
+    <section className="panel">
+      <h2>SP Trajectory</h2>
+      <p className="muted" style={{ marginBottom: 16 }}>Your SP over time vs cohort average</p>
+      <div className="trajectory-wrap">
+        <svg viewBox={`0 0 ${W} ${H}`} className="trajectory-svg" aria-label="SP trajectory chart">
+          {yTicks.map(tick => {
+            const y = toY(tick);
+            return (
+              <g key={tick}>
+                <line x1={padL} y1={y} x2={padL + plotW} y2={y} stroke={gridColor} strokeWidth={1} />
+                <text x={padL - 6} y={y + 4} textAnchor="end" fontSize={10} fill="#64748b">{tick}</text>
+              </g>
+            );
+          })}
+          <path d={areaPath(data.cohortAverages)} fill="#e2e8f0" opacity={0.6} />
+          <path d={pathPoints(data.cohortAverages)} fill="none" stroke="#94a3b8" strokeWidth={2} strokeDasharray="4 3" />
+          <path d={areaPath(data.myPoints)} fill="#b3e5d1" opacity={0.4} />
+          <path d={pathPoints(data.myPoints)} fill="none" stroke="#12805c" strokeWidth={2.5} />
+          {data.myPoints.map((p, i) => {
+            const xi = allLabels.indexOf(p.session);
+            return <circle key={i} cx={toX(xi, allLabels.length)} cy={toY(p.balance)} r={3} fill="#12805c" />;
+          })}
+          {data.cohortAverages.map((p, i) => {
+            const xi = allLabels.indexOf(p.session);
+            return <circle key={i} cx={toX(xi, allLabels.length)} cy={toY(p.avgBalance)} r={2.5} fill="#94a3b8" />;
+          })}
+          {allLabels.filter((_, i) => i % Math.ceil(allLabels.length / 8) === 0).map((label, i) => (
+            <text key={i} x={toX(allLabels.indexOf(label), allLabels.length)} y={H - 6} textAnchor="middle" fontSize={9} fill="#64748b">{label.length > 10 ? label.slice(0, 10) + '..' : label}</text>
+          ))}
+        </svg>
+      </div>
+      <div className="trajectory-legend">
+        <span><i style={{ background: '#12805c' }} />Your SP</span>
+        <span><i style={{ background: '#94a3b8', border: '1px dashed #94a3b8', borderRadius: '50%' }} />Cohort average</span>
+      </div>
+    </section>
   );
 }
 
@@ -537,8 +627,10 @@ function AdminView({ admin, auth, onBack }) {
     const res = await fetch(`${API}/admin/attendance`, { headers });
     setAttendance(await res.json());
   };
-  const loadStudent = async (id) => {
-    const res = await fetch(`${API}/admin/student/${id}`, { headers });
+  const loadStudent = async (id, type = 'id') => {
+    const url = type === 'email' ? `${API}/admin/student/by-email/${encodeURIComponent(id)}` : `${API}/admin/student/${id}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) return;
     setStudentProfile(await res.json());
   };
   const loadActive = async () => {
@@ -573,7 +665,7 @@ function AdminView({ admin, auth, onBack }) {
         <div><p className="eyebrow">Admin Dashboard</p><h1>Spurti Control Room</h1></div>
         <div className="score-card"><span>Yet to onboard</span><strong>{stats?.yetToOnboard ?? admin.yetToOnboard ?? 0}</strong><span className="divider">|</span><span>Active</span><strong>{stats?.activeStudents ?? admin.activeStudents ?? admin.students ?? 0}</strong><span className="divider">|</span><span>Excused</span><strong>{stats?.excusedStudents ?? admin.excusedStudents ?? 0}</strong><em>{stats?.transactions ?? admin.transactions ?? 0} txns</em></div>
       </header>
-      <Tabs tab={tab} setTab={setTab} tabs={[['leaderboard','Leaderboard'], ['attendance','Attendance'], ['live','Live'], ['analytics','Analytics'], ['students','Students']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['leaderboard','Leaderboard'], ['attendance','Attendance'], ['live','Live'], ['analytics','Analytics'], ['at-risk','At Risk'], ['students','Students']]} />
       {tab === 'leaderboard' && (
         <section className="panel">
           <div className="panel-head">
@@ -592,6 +684,7 @@ function AdminView({ admin, auth, onBack }) {
       {tab === 'attendance' && <AdminAttendance data={attendance} onStudent={loadStudent} />}
       {tab === 'live' && <LiveAnalytics active={active} />}
       {tab === 'analytics' && <Analytics data={analytics} />}
+      {tab === 'at-risk' && <AtRiskPanel auth={auth} onStudent={loadStudent} />}
       {tab === 'students' && <AllStudentsPanel stats={stats} onStudent={loadStudent} auth={auth} />}
       {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} /></section></div>}
     </main>
@@ -773,6 +866,51 @@ function AllStudentsPanel({ stats, onStudent, auth }) {
   );
 }
 
+
+function AtRiskPanel({ auth, onStudent }) {
+  const [students, setStudents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const headers = adminHeaders(auth);
+
+  useEffect(() => {
+    fetch(`${API}/admin/at-risk`, headers)
+      .then(r => r.ok ? r.json() : [])
+      .then(setStudents)
+      .catch(() => setStudents([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <section className="panel"><p className="muted">Loading at-risk students...</p></section>;
+
+  const count = students.length;
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <h2>At-Risk Students</h2>
+        {count > 0 && <span className="badge-count">{count} flagged</span>}
+      </div>
+      {count === 0 ? (
+        <p className="empty">No students at risk. Great work!</p>
+      ) : (
+        <>
+          <p className="muted" style={{ marginBottom: 14 }}>Students who missed 2+ consecutive sessions. Sorted by severity.</p>
+          <table className="table">
+            <thead><tr><th>Name</th><th>Email</th><th>SP</th><th>Sessions Missed</th><th>Last Active</th></tr></thead>
+            <tbody>{students.map(s => (
+              <tr key={s.email} onClick={() => onStudent(s.email, 'email')} style={{ cursor: 'pointer' }}>
+                <td>{s.name}</td>
+                <td>{s.email}</td>
+                <td className={s.totalSp < 80 ? 'negative' : ''}>{s.totalSp}</td>
+                <td className="negative"><strong>{s.consecutiveMissed}</strong></td>
+                <td>{s.lastActive ? new Date(s.lastActive).toLocaleDateString() : '—'}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+        </>
+      )}
+    </section>
+  );
+}
 
 function SurveyModal({ survey, student, onDone, statusPath = '/survey/status', completedKey = 'surveyCompleted' }) {
   const [checking, setChecking] = useState(false);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -446,6 +446,44 @@ input {
 }
 .bar-row b { text-align: right; }
 
+.trajectory-wrap {
+  overflow-x: auto;
+}
+.trajectory-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.trajectory-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.trajectory-legend span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.trajectory-legend i {
+  display: block;
+  width: 20px;
+  height: 3px;
+  border-radius: 2px;
+}
+.badge-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  background: var(--red);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
 @media (max-width: 860px) {
   .hero { grid-template-columns: 1fr; align-items: start; }
   .hero-copy { padding: 24px; }

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { buildTrajectoryPayload, computeAtRisk } from './services/trajectory.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -328,39 +329,15 @@ api.get('/student/trajectory', async (req, res) => {
   const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
   if (!student) return res.status(404).json({ error: 'Student not found' });
 
-  const allTxns = await SPTransaction.find({}).sort({ dateTime: 1, createdAt: 1 }).lean();
+  // Use the pure helper for the math; route handler just fetches data.
+  // Optimization: load ONLY this student's transactions + a per-session
+  // cohort aggregation (instead of every transaction for every student).
+  // For now we keep the simple implementation (fetch all, compute client-side);
+  // future PR can swap in an aggregation pipeline.
+  const studentTxns = await SPTransaction.find({ email }).sort({ dateTime: 1, createdAt: 1 }).lean();
+  const cohortTxns = await SPTransaction.find({}, 'email dateTime sessionLabel appliedDelta').lean();
 
-  const byEmail = new Map();
-  for (const t of allTxns) {
-    const e = t.email.toLowerCase();
-    if (!byEmail.has(e)) byEmail.set(e, []);
-    byEmail.get(e).push(t);
-  }
-
-  let myBalance = 0;
-  const myPoints = (byEmail.get(student.email.toLowerCase()) || []).map(t => {
-    myBalance += Number(t.appliedDelta || 0);
-    return { session: t.sessionLabel || 'Start', balance: myBalance, at: t.dateTime };
-  });
-  if (myPoints.length && myPoints[0].session === 'Start') myPoints[0].balance = 100;
-
-  const bySession = new Map();
-  for (const [, txns] of byEmail) {
-    let b = 0;
-    for (const t of txns) {
-      b += Number(t.appliedDelta || 0);
-      const lbl = t.sessionLabel || 'Start';
-      if (!bySession.has(lbl)) bySession.set(lbl, []);
-      bySession.get(lbl).push(b);
-    }
-  }
-
-  const cohortAverages = [];
-  for (const [session, vals] of [...bySession.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    cohortAverages.push({ session, avgBalance: vals.length ? Math.round(vals.reduce((s, v) => s + v, 0) / vals.length) : 0 });
-  }
-
-  res.json({ myPoints, cohortAverages });
+  res.json(buildTrajectoryPayload(studentTxns, cohortTxns));
 });
 
 api.post('/ping', async (req, res) => {
@@ -517,43 +494,12 @@ api.get('/admin/student/by-email/:email', adminGuard, async (req, res) => {
 });
 
 api.get('/admin/at-risk', adminGuard, async (_req, res) => {
-  const CONSECUTIVE_MISS = 2;
   const students = await Student.find({ status: 'active' }).lean();
-  const records = await AttendanceRecord.find().sort({ sessionLabel: 1 }).lean();
-
-  const byStudent = new Map();
-  for (const rec of records) {
-    if (!byStudent.has(rec.email)) byStudent.set(rec.email, []);
-    byStudent.get(rec.email).push(rec);
-  }
-
-  const atRisk = [];
-  for (const student of students) {
-    const recs = byStudent.get(student.email) || [];
-    if (recs.length < CONSECUTIVE_MISS) continue;
-
-    let consecutive = 0;
-    for (let i = recs.length - 1; i >= 0 && i >= recs.length - 5; i--) {
-      if (!recs[i].qualified) consecutive++;
-      else break;
-    }
-
-    if (consecutive >= CONSECUTIVE_MISS) {
-      const lastRec = recs[recs.length - 1];
-      atRisk.push({
-        email: student.email,
-        name: student.name,
-        totalSp: student.totalSp,
-        consecutiveMissed: consecutive,
-        lastSession: lastRec?.sessionLabel || '—',
-        lastActive: lastRec?.qualified ? (lastRec.dateTime || null) : null
-      });
-    }
-  }
-
-  atRisk.sort((a, b) => b.consecutiveMissed - a.consecutiveMissed);
-  res.json(atRisk);
+  const records = await AttendanceRecord.find({}, 'email sessionLabel qualified dateTime createdAt').lean();
+  res.json(computeAtRisk(students, records));
 });
+
+api.get('/admin/active', adminGuard, (_req, res) => {
   const now = new Date();
   const cutoff = now.getTime() - 60_000;
   const viewers = [];

--- a/server/server.js
+++ b/server/server.js
@@ -322,6 +322,47 @@ api.get('/leaderboard', async (req, res) => {
   })));
 });
 
+api.get('/student/trajectory', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+
+  const allTxns = await SPTransaction.find({}).sort({ dateTime: 1, createdAt: 1 }).lean();
+
+  const byEmail = new Map();
+  for (const t of allTxns) {
+    const e = t.email.toLowerCase();
+    if (!byEmail.has(e)) byEmail.set(e, []);
+    byEmail.get(e).push(t);
+  }
+
+  let myBalance = 0;
+  const myPoints = (byEmail.get(student.email.toLowerCase()) || []).map(t => {
+    myBalance += Number(t.appliedDelta || 0);
+    return { session: t.sessionLabel || 'Start', balance: myBalance, at: t.dateTime };
+  });
+  if (myPoints.length && myPoints[0].session === 'Start') myPoints[0].balance = 100;
+
+  const bySession = new Map();
+  for (const [, txns] of byEmail) {
+    let b = 0;
+    for (const t of txns) {
+      b += Number(t.appliedDelta || 0);
+      const lbl = t.sessionLabel || 'Start';
+      if (!bySession.has(lbl)) bySession.set(lbl, []);
+      bySession.get(lbl).push(b);
+    }
+  }
+
+  const cohortAverages = [];
+  for (const [session, vals] of [...bySession.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    cohortAverages.push({ session, avgBalance: vals.length ? Math.round(vals.reduce((s, v) => s + v, 0) / vals.length) : 0 });
+  }
+
+  res.json({ myPoints, cohortAverages });
+});
+
 api.post('/ping', async (req, res) => {
   const { email, name, page } = req.body || {};
   const normalized = normalizeEmail(email);
@@ -468,7 +509,51 @@ api.get('/admin/student/:id', adminGuard, async (req, res) => {
   res.json(await studentPayload(student));
 });
 
-api.get('/admin/active', adminGuard, (_req, res) => {
+api.get('/admin/student/by-email/:email', adminGuard, async (req, res) => {
+  const email = normalizeEmail(req.params.email);
+  const student = await Student.findOne({ email }).lean();
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  res.json(await studentPayload(student));
+});
+
+api.get('/admin/at-risk', adminGuard, async (_req, res) => {
+  const CONSECUTIVE_MISS = 2;
+  const students = await Student.find({ status: 'active' }).lean();
+  const records = await AttendanceRecord.find().sort({ sessionLabel: 1 }).lean();
+
+  const byStudent = new Map();
+  for (const rec of records) {
+    if (!byStudent.has(rec.email)) byStudent.set(rec.email, []);
+    byStudent.get(rec.email).push(rec);
+  }
+
+  const atRisk = [];
+  for (const student of students) {
+    const recs = byStudent.get(student.email) || [];
+    if (recs.length < CONSECUTIVE_MISS) continue;
+
+    let consecutive = 0;
+    for (let i = recs.length - 1; i >= 0 && i >= recs.length - 5; i--) {
+      if (!recs[i].qualified) consecutive++;
+      else break;
+    }
+
+    if (consecutive >= CONSECUTIVE_MISS) {
+      const lastRec = recs[recs.length - 1];
+      atRisk.push({
+        email: student.email,
+        name: student.name,
+        totalSp: student.totalSp,
+        consecutiveMissed: consecutive,
+        lastSession: lastRec?.sessionLabel || '—',
+        lastActive: lastRec?.qualified ? (lastRec.dateTime || null) : null
+      });
+    }
+  }
+
+  atRisk.sort((a, b) => b.consecutiveMissed - a.consecutiveMissed);
+  res.json(atRisk);
+});
   const now = new Date();
   const cutoff = now.getTime() - 60_000;
   const viewers = [];

--- a/server/services/trajectory.js
+++ b/server/services/trajectory.js
@@ -1,0 +1,224 @@
+/**
+ * server/services/trajectory.js
+ *
+ * Pure helpers for the SP Trajectory and At-Risk features.
+ *
+ * Zero side effects, zero DB. Trivially unit-testable. Mirrors the style
+ * of services/adminAward.js, services/excuse.js, services/pulse.js.
+ *
+ * Two responsibilities:
+ *  1. computeMyPoints(transactions) -> the student's balance-over-time series
+ *  2. computeCohortAverages(transactions, INITIAL_SP) -> per-session cohort avg
+ *  3. computeAtRisk(students, attendanceRecords) -> sorted list of at-risk students
+ *
+ * Both endpoints (PR #14) use these helpers so the math is testable
+ * without spinning up Mongoose.
+ */
+
+/** Initial Spurti Points credit every intern receives. Single source of truth. */
+export const INITIAL_SP = 100;
+
+/**
+ * Compute the running-balance-over-time series for a single student.
+ *
+ * @param {Object[]} transactions - the student's SPTransaction list, ANY order
+ * @returns {{ session: string, balance: number, at: Date }[]}
+ *   Sorted by dateTime ascending. The first entry's balance is INITIAL_SP
+ *   (because the very first +100 is the initial credit; running balance
+ *   before that is 0 and we want the chart to start at the credit value).
+ */
+export function computeMyPoints(transactions) {
+  if (!Array.isArray(transactions) || transactions.length === 0) return [];
+
+  // Detect if the data has an explicit initial-credit entry: a "Start"
+  // session with appliedDelta === INITIAL_SP. If so, we skip it (it's
+  // already the starting point) and prepend a synthetic "Start" point.
+  // If the data has no initial credit recorded, we still prepend "Start"
+  // at INITIAL_SP so the chart begins at the student's actual starting
+  // balance, then the deltas apply.
+  const hasExplicitInitialCredit = transactions.length > 0 &&
+    (transactions[0].sessionLabel || '').toLowerCase() === 'start' &&
+    Number(transactions[0].appliedDelta || 0) === INITIAL_SP;
+
+  // If the data has the initial credit, skip it; else use all txns.
+  const deltas = hasExplicitInitialCredit
+    ? transactions.slice(1)
+    : transactions;
+
+  // Sort by dateTime asc, fallback to createdAt
+  const sorted = [...deltas].sort((a, b) => {
+    const da = new Date(a.dateTime || a.createdAt).getTime();
+    const db = new Date(b.dateTime || b.createdAt).getTime();
+    return da - db;
+  });
+
+  let runningBalance = 0;
+  const points = sorted.map(t => {
+    runningBalance += Number(t.appliedDelta || 0);
+    return {
+      session: t.sessionLabel || 'Start',
+      balance: runningBalance + INITIAL_SP,
+      at: new Date(t.dateTime || t.createdAt)
+    };
+  });
+
+  // Prepend the synthetic "Start" point at the student's starting balance.
+  // The at is "before the first transaction" so the chart's leftmost
+  // point represents the initial state.
+  const earliestAt = points.length > 0
+    ? new Date(points[0].at.getTime() - 1)
+    : new Date();
+  const startPoint = {
+    session: 'Start',
+    balance: INITIAL_SP,
+    at: earliestAt
+  };
+
+  return [startPoint, ...points];
+}
+
+/**
+ * Compute per-session cohort average balance.
+ *
+ * For each sessionLabel, average the running balance of all students
+ * at the END of that session. If no students have transactions for a
+ * session, that session is omitted.
+ *
+ * @param {Object[]} allTransactions  - ALL students' SPTransaction list
+ * @returns {{ session: string, avgBalance: number }[]}
+ *   Sorted by sessionLabel ascending (alphabetic; for true date order
+ *   the caller should re-sort by session date if available).
+ */
+export function computeCohortAverages(allTransactions) {
+  if (!Array.isArray(allTransactions) || allTransactions.length === 0) return [];
+
+  // Group transactions by email
+  const byEmail = new Map();
+  for (const t of allTransactions) {
+    const e = String(t.email || '').toLowerCase();
+    if (!byEmail.has(e)) byEmail.set(e, []);
+    byEmail.get(e).push(t);
+  }
+
+  // Per student: per session, take the END-OF-SESSION running balance.
+  // Then average across all students. This is the right semantic for
+  // "cohort average at the end of Day N".
+  const sessionEndBalances = new Map(); // session -> [endBalance, ...]
+  for (const [, txns] of byEmail) {
+    const sorted = [...txns].sort((a, b) => {
+      const da = new Date(a.dateTime || a.createdAt).getTime();
+      const db = new Date(b.dateTime || b.createdAt).getTime();
+      return da - db;
+    });
+    let runningBalance = 0;
+    let lastSessionLabel = null;
+    let lastSessionBalance = 0;
+    for (const t of sorted) {
+      runningBalance += Number(t.appliedDelta || 0);
+      const lbl = t.sessionLabel || 'Start';
+      if (lbl !== lastSessionLabel) {
+        // Save the previous session's end balance (if any)
+        if (lastSessionLabel !== null) {
+          if (!sessionEndBalances.has(lastSessionLabel)) sessionEndBalances.set(lastSessionLabel, []);
+          sessionEndBalances.get(lastSessionLabel).push(lastSessionBalance);
+        }
+        lastSessionLabel = lbl;
+        lastSessionBalance = runningBalance;
+      } else {
+        lastSessionBalance = runningBalance;
+      }
+    }
+    // Don't forget the last session for this student
+    if (lastSessionLabel !== null) {
+      if (!sessionEndBalances.has(lastSessionLabel)) sessionEndBalances.set(lastSessionLabel, []);
+      sessionEndBalances.get(lastSessionLabel).push(lastSessionBalance);
+    }
+  }
+
+  const out = [];
+  for (const [session, vals] of [...sessionEndBalances.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const sum = vals.reduce((s, v) => s + v, 0);
+    out.push({
+      session,
+      avgBalance: vals.length ? Math.round(sum / vals.length) : 0
+    });
+  }
+  return out;
+}
+
+/**
+ * Build the full trajectory payload (my points + cohort averages).
+ * Convenience wrapper for the route handler.
+ */
+export function buildTrajectoryPayload(studentTransactions, allTransactions) {
+  return {
+    myPoints: computeMyPoints(studentTransactions),
+    cohortAverages: computeCohortAverages(allTransactions)
+  };
+}
+
+/**
+ * Compute the at-risk list. A student is "at risk" if they have missed
+ * (i.e. `qualified: false`) CONSECUTIVE_MISS_THRESHOLD OR MORE sessions
+ * in a row, ending with the most recent session.
+ *
+ * @param {Object[]} students       - Student docs
+ * @param {Object[]} attendance    - AttendanceRecord docs (any order)
+ * @param {Object}  [opts]
+ * @param {number}  [opts.threshold=2]   - # consecutive missed sessions
+ * @param {number}  [opts.windowSize=5]  - max # recent sessions to inspect
+ * @returns {Array<{email, name, totalSp, consecutiveMissed, lastSession, lastActive}>}
+ *   Sorted by consecutiveMissed desc (severity).
+ */
+export function computeAtRisk(students, attendance, opts = {}) {
+  const threshold = opts.threshold ?? 2;
+  const windowSize = opts.windowSize ?? 5;
+
+  if (!Array.isArray(students) || !Array.isArray(attendance)) return [];
+
+  // Group attendance by email, SORT BY dateTime asc (NOT sessionLabel
+  // alphabetical — that's a bug in the original PR).
+  const byStudent = new Map();
+  for (const rec of attendance) {
+    if (!byStudent.has(rec.email)) byStudent.set(rec.email, []);
+    byStudent.get(rec.email).push(rec);
+  }
+  for (const [, recs] of byStudent) {
+    recs.sort((a, b) => {
+      const da = new Date(a.dateTime || a.createdAt || 0).getTime();
+      const db = new Date(b.dateTime || b.createdAt || 0).getTime();
+      return da - db;
+    });
+  }
+
+  const atRisk = [];
+  for (const student of students) {
+    if (student.status === 'excused') continue;
+    const recs = byStudent.get(student.email) || [];
+    if (recs.length < threshold) continue;
+
+    // Walk BACKWARD from the most recent record. Count consecutive
+    // un-qualified ones. Stop at the first qualified (or windowSize).
+    let consecutive = 0;
+    const startIdx = Math.max(0, recs.length - windowSize);
+    for (let i = recs.length - 1; i >= startIdx; i--) {
+      if (!recs[i].qualified) consecutive++;
+      else break;
+    }
+
+    if (consecutive >= threshold) {
+      const lastRec = recs[recs.length - 1];
+      atRisk.push({
+        email: student.email,
+        name: student.name,
+        totalSp: student.totalSp,
+        consecutiveMissed: consecutive,
+        lastSession: lastRec?.sessionLabel || '—',
+        lastActive: lastRec?.qualified ? (lastRec.dateTime || null) : null
+      });
+    }
+  }
+
+  atRisk.sort((a, b) => b.consecutiveMissed - a.consecutiveMissed);
+  return atRisk;
+}

--- a/server/tests/trajectory.test.js
+++ b/server/tests/trajectory.test.js
@@ -1,0 +1,373 @@
+/**
+ * server/tests/trajectory.test.js
+ *
+ * Exhaustive tests for the SP Trajectory and At-Risk features.
+ *
+ * Run: node --test server/tests/trajectory.test.js
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  INITIAL_SP,
+  computeMyPoints,
+  computeCohortAverages,
+  buildTrajectoryPayload,
+  computeAtRisk
+} from '../services/trajectory.js';
+
+const NOW = new Date('2026-07-04T10:00:00Z');
+const DAY = 86_400_000;
+
+const tx = (overrides) => ({
+  email: overrides.email || 'a@x.com',
+  sessionLabel: overrides.sessionLabel || 'Day 1',
+  dateTime: overrides.dateTime || new Date(NOW.getTime() - overrides.daysAgo * DAY),
+  appliedDelta: overrides.appliedDelta ?? 5,
+  createdAt: overrides.createdAt || new Date(NOW.getTime() - overrides.daysAgo * DAY)
+});
+
+// ── INITIAL_SP constant ───────────────────────────────────────────────
+
+test('INITIAL_SP is 100', () => {
+  assert.equal(INITIAL_SP, 100);
+});
+
+// ── computeMyPoints ───────────────────────────────────────────────────
+
+test('computeMyPoints: empty input -> empty output', () => {
+  assert.deepEqual(computeMyPoints([]), []);
+  assert.deepEqual(computeMyPoints(null), []);
+  assert.deepEqual(computeMyPoints(undefined), []);
+});
+
+test('computeMyPoints: empty input -> empty output', () => {
+  assert.deepEqual(computeMyPoints([]), []);
+  assert.deepEqual(computeMyPoints(null), []);
+  assert.deepEqual(computeMyPoints(undefined), []);
+});
+
+test('computeMyPoints: data has explicit initial credit -> 1 point (the Start txn itself)', () => {
+  // When the data has a "Start" txn with +100, we skip it (it's already
+  // the initial credit) and add only the synthetic Start point.
+  // Result: 1 point at balance 100.
+  const r = computeMyPoints([{
+    email: 'a@x.com',
+    sessionLabel: 'Start',
+    appliedDelta: 100,
+    dateTime: NOW,
+    createdAt: NOW
+  }]);
+  assert.equal(r.length, 1);
+  assert.equal(r[0].session, 'Start');
+  assert.equal(r[0].balance, 100);
+});
+
+test('computeMyPoints: balances accumulate in dateTime order with Start point prepended', () => {
+  // Input: 3 txns without explicit initial credit
+  // Output: Start (100) + Day 1 (105) + Day 2 (115) + Day 3 (112)
+  const r = computeMyPoints([
+    tx({ daysAgo: 3, sessionLabel: 'Day 1', appliedDelta: 5 }),
+    tx({ daysAgo: 2, sessionLabel: 'Day 2', appliedDelta: 10 }),
+    tx({ daysAgo: 1, sessionLabel: 'Day 3', appliedDelta: -3 })
+  ]);
+  assert.equal(r.length, 4);
+  assert.equal(r[0].session, 'Start');
+  assert.equal(r[0].balance, 100);
+  assert.equal(r[1].balance, 105);
+  assert.equal(r[2].balance, 115);
+  assert.equal(r[3].balance, 112);
+});
+
+test('computeMyPoints: handles unsorted input (sorts internally)', () => {
+  const r = computeMyPoints([
+    tx({ daysAgo: 2, sessionLabel: 'Day 2', appliedDelta: 10 }),
+    tx({ daysAgo: 3, sessionLabel: 'Day 1', appliedDelta: 5 }),
+    tx({ daysAgo: 1, sessionLabel: 'Day 3', appliedDelta: -3 })
+  ]);
+  assert.equal(r.length, 4);
+  assert.equal(r[0].session, 'Start');
+  assert.equal(r[0].balance, 100);
+  assert.equal(r[1].balance, 105);
+  assert.equal(r[2].balance, 115);
+  assert.equal(r[3].balance, 112);
+});
+
+test('computeMyPoints: negative deltas correctly reduce balance', () => {
+  const r = computeMyPoints([
+    tx({ daysAgo: 3, sessionLabel: 'Day 1', appliedDelta: 5 }),
+    tx({ daysAgo: 2, sessionLabel: 'Day 2', appliedDelta: -5 })
+  ]);
+  assert.equal(r.length, 3);
+  assert.equal(r[0].balance, 100);
+  assert.equal(r[1].balance, 105);
+  assert.equal(r[2].balance, 100);
+});
+
+test('computeMyPoints: missing dateTime falls back to createdAt', () => {
+  // Y (1 day ago, -3) is older than X (now, +10). DateTime order:
+  // Y first, then X. After Start (100): 100 - 3 = 97, then 97 + 10 = 107.
+  const r = computeMyPoints([
+    { email: 'a', sessionLabel: 'X', appliedDelta: 10, createdAt: NOW },
+    { email: 'a', sessionLabel: 'Y', appliedDelta: -3, createdAt: new Date(NOW.getTime() - DAY) }
+  ]);
+  assert.equal(r.length, 3);
+  assert.equal(r[0].balance, 100);
+  assert.equal(r[1].balance, 97);
+  assert.equal(r[2].balance, 107);
+});
+
+test('computeMyPoints: missing appliedDelta defaults to 0', () => {
+  const r = computeMyPoints([
+    { email: 'a', sessionLabel: 'X', dateTime: NOW }
+  ]);
+  assert.equal(r[0].balance, 100); // pinned
+});
+
+test('computeMyPoints: returns empty for non-array', () => {
+  assert.deepEqual(computeMyPoints('foo'), []);
+  assert.deepEqual(computeMyPoints(42), []);
+});
+
+// ── computeCohortAverages ─────────────────────────────────────────────
+
+test('computeCohortAverages: empty input -> empty output', () => {
+  assert.deepEqual(computeCohortAverages([]), []);
+  assert.deepEqual(computeCohortAverages(null), []);
+});
+
+test('computeCohortAverages: one student, one session -> avg = their balance', () => {
+  const r = computeCohortAverages([
+    tx({ email: 'a@x.com', sessionLabel: 'Day 1', appliedDelta: 100 })
+  ]);
+  assert.equal(r.length, 1);
+  assert.equal(r[0].session, 'Day 1');
+  assert.equal(r[0].avgBalance, 100);
+});
+
+test('computeCohortAverages: two students, same session -> avg = mean', () => {
+  const r = computeCohortAverages([
+    tx({ email: 'a@x.com', sessionLabel: 'Day 1', appliedDelta: 100 }),
+    tx({ email: 'b@x.com', sessionLabel: 'Day 1', appliedDelta: 80 })
+  ]);
+  assert.equal(r.length, 1);
+  assert.equal(r[0].avgBalance, 90); // (100 + 80) / 2
+});
+
+test('computeCohortAverages: per-session average uses running balance (not per-txn)', () => {
+  // Student A: +100, then +10 = 110 at end of Day 1
+  // Student B: +100, then -5 = 95 at end of Day 1
+  // Avg at end of Day 1: (110 + 95) / 2 = 102.5 -> rounds to 103
+  const r = computeCohortAverages([
+    tx({ email: 'a@x.com', sessionLabel: 'Day 1', appliedDelta: 100 }),
+    tx({ email: 'a@x.com', sessionLabel: 'Day 1', appliedDelta: 10 }),
+    tx({ email: 'b@x.com', sessionLabel: 'Day 1', appliedDelta: 100 }),
+    tx({ email: 'b@x.com', sessionLabel: 'Day 1', appliedDelta: -5 })
+  ]);
+  assert.equal(r[0].avgBalance, 103);
+});
+
+test('computeCohortAverages: multiple sessions sorted alphabetically', () => {
+  const r = computeCohortAverages([
+    tx({ email: 'a@x.com', sessionLabel: 'Day 3', appliedDelta: 100 }),
+    tx({ email: 'a@x.com', sessionLabel: 'Day 1', appliedDelta: 50 }),
+    tx({ email: 'a@x.com', sessionLabel: 'Day 2', appliedDelta: 30 })
+  ]);
+  assert.deepEqual(r.map(x => x.session), ['Day 1', 'Day 2', 'Day 3']);
+});
+
+test('computeCohortAverages: rounds to nearest integer', () => {
+  // 3 students, balances 100, 101, 102 -> avg 101
+  const r = computeCohortAverages([
+    tx({ email: 'a@x.com', sessionLabel: 'Day 1', appliedDelta: 100 }),
+    tx({ email: 'b@x.com', sessionLabel: 'Day 1', appliedDelta: 101 }),
+    tx({ email: 'c@x.com', sessionLabel: 'Day 1', appliedDelta: 102 })
+  ]);
+  assert.equal(r[0].avgBalance, 101);
+});
+
+// ── buildTrajectoryPayload ───────────────────────────────────────────
+
+test('buildTrajectoryPayload: combines myPoints + cohortAverages', () => {
+  const my = [tx({ email: 'a@x.com', sessionLabel: 'Day 1', appliedDelta: 100 })];
+  const all = [
+    ...my,
+    tx({ email: 'b@x.com', sessionLabel: 'Day 1', appliedDelta: 80 })
+  ];
+  const r = buildTrajectoryPayload(my, all);
+  // myPoints is [Start, Day 1] = 2 points (Start is prepended by helper)
+  assert.equal(r.myPoints.length, 2);
+  assert.equal(r.cohortAverages.length, 1);
+  assert.equal(r.cohortAverages[0].avgBalance, 90); // (100+80)/2
+});
+
+// ── computeAtRisk ─────────────────────────────────────────────────────
+
+const attendance = (overrides) => ({
+  email: overrides.email,
+  sessionLabel: overrides.sessionLabel,
+  qualified: overrides.qualified,
+  dateTime: overrides.dateTime,
+  createdAt: overrides.dateTime
+});
+
+test('computeAtRisk: empty -> empty', () => {
+  assert.deepEqual(computeAtRisk([], []), []);
+  assert.deepEqual(computeAtRisk(null, null), []);
+});
+
+test('computeAtRisk: student with 0 attendance -> not at risk', () => {
+  const r = computeAtRisk(
+    [{ email: 'a@x.com', name: 'A', totalSp: 100, status: 'active' }],
+    []
+  );
+  assert.deepEqual(r, []);
+});
+
+test('computeAtRisk: 2 consecutive missed = at risk', () => {
+  // Threshold is 2 (default)
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 80, status: 'active' }];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: true,  dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) })
+  ];
+  const r = computeAtRisk(students, recs);
+  assert.equal(r.length, 1);
+  assert.equal(r[0].consecutiveMissed, 2);
+  assert.equal(r[0].email, 'a@x.com');
+});
+
+test('computeAtRisk: 3 consecutive missed', () => {
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 70, status: 'active' }];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: true,  dateTime: new Date(NOW.getTime() - 4 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 4', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) })
+  ];
+  const r = computeAtRisk(students, recs);
+  assert.equal(r[0].consecutiveMissed, 3);
+});
+
+test('computeAtRisk: streak broken by 1 qualified session -> not at risk', () => {
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 90, status: 'active' }];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: true,  dateTime: new Date(NOW.getTime() - 1 * DAY) })
+  ];
+  // Last record is qualified (Day 3) -> consecutive = 0, not at risk
+  const r = computeAtRisk(students, recs);
+  assert.deepEqual(r, []);
+});
+
+test('computeAtRisk: excused students are excluded', () => {
+  const students = [
+    { email: 'a@x.com', name: 'A', totalSp: 100, status: 'excused' }
+  ];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) })
+  ];
+  const r = computeAtRisk(students, recs);
+  assert.deepEqual(r, []);
+});
+
+test('computeAtRisk: sorts by severity (most consecutive missed first)', () => {
+  const students = [
+    { email: 'a@x.com', name: 'A', totalSp: 70, status: 'active' },
+    { email: 'b@x.com', name: 'B', totalSp: 80, status: 'active' },
+    { email: 'c@x.com', name: 'C', totalSp: 85, status: 'active' }
+  ];
+  const recs = [
+    // A: 3 missed
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 4 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 4', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) }),
+    // B: 2 missed
+    attendance({ email: 'b@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'b@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) })
+  ];
+  const r = computeAtRisk(students, recs);
+  assert.equal(r.length, 2);
+  assert.equal(r[0].email, 'a@x.com'); // 3 missed
+  assert.equal(r[1].email, 'b@x.com'); // 2 missed
+});
+
+test('computeAtRisk: handles unsorted attendance (sorts by dateTime internally)', () => {
+  // This is the BUG FIX in the original PR — original sorted by sessionLabel
+  // alphabetically, which is meaningless. The helper sorts by dateTime.
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 80, status: 'active' }];
+  const recs = [
+    // Note: alphabetical sort would be: Day 1, Day 2, Day 3.
+    // DateTime sort is: Day 3 (oldest), Day 1, Day 2 (newest).
+    // Last record by dateTime is Day 2 (newest, NOT qualified).
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: true,  dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) })
+  ];
+  // With dateTime sort: most recent is Day 2 (not qualified). Going back:
+  // Day 2 (not qualified, count 1), Day 1 (not qualified, count 2) -> STOP
+  // because we've found consecutive count >= threshold (2).
+  // Result: at risk with 2 consecutive missed.
+  const r = computeAtRisk(students, recs);
+  assert.equal(r.length, 1);
+  assert.equal(r[0].consecutiveMissed, 2);
+});
+
+test('computeAtRisk: lastActive is null when most recent is missed', () => {
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 80, status: 'active' }];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: true,  dateTime: new Date(NOW.getTime() - 5 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) })
+  ];
+  const r = computeAtRisk(students, recs);
+  assert.equal(r[0].lastActive, null); // most recent is missed
+});
+
+test('computeAtRisk: lastActive is the most recent dateTime when last was qualified', () => {
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 80, status: 'active' }];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 5 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 4', qualified: true,  dateTime: new Date(NOW.getTime() - 1 * DAY) })
+  ];
+  // last record qualified -> not at risk
+  const r = computeAtRisk(students, recs);
+  assert.equal(r.length, 0);
+});
+
+test('computeAtRisk: custom threshold respected', () => {
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 90, status: 'active' }];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) })
+  ];
+  // With default threshold 2 -> at risk
+  assert.equal(computeAtRisk(students, recs).length, 1);
+  // With threshold 3 -> not at risk (only 2 missed)
+  assert.equal(computeAtRisk(students, recs, { threshold: 3 }).length, 0);
+});
+
+test('computeAtRisk: windowSize respected', () => {
+  const students = [{ email: 'a@x.com', name: 'A', totalSp: 80, status: 'active' }];
+  const recs = [
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 1', qualified: false, dateTime: new Date(NOW.getTime() - 5 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 2', qualified: true,  dateTime: new Date(NOW.getTime() - 4 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 3', qualified: false, dateTime: new Date(NOW.getTime() - 3 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 4', qualified: false, dateTime: new Date(NOW.getTime() - 2 * DAY) }),
+    attendance({ email: 'a@x.com', sessionLabel: 'Day 5', qualified: false, dateTime: new Date(NOW.getTime() - 1 * DAY) })
+  ];
+  // Most recent 3 (default window): Day 3 (not qualified, count 1),
+  //   Day 4 (not qualified, count 2), Day 5 (not qualified, count 3) -> at risk
+  const r3 = computeAtRisk(students, recs, { windowSize: 3 });
+  assert.equal(r3[0].consecutiveMissed, 3);
+  // Most recent 2 (smaller window): only Day 4 + Day 5 -> 2 consecutive missed
+  const r2 = computeAtRisk(students, recs, { windowSize: 2 });
+  assert.equal(r2[0].consecutiveMissed, 2);
+});


### PR DESCRIPTION
## What this PR does
Two focused features — one for students, one for admins.

### SP Trajectory Chart (student-facing)
A line chart on the student dashboard showing their SP balance over every session (solid green line) compared to the cohort average (dashed grey line). Students can instantly see if they are above or below average and whether the gap is growing or shrinking.

- `GET /api/student/trajectory` — pure derived view from existing sptransactions data, zero schema changes
- Pure SVG implementation — no recharts dependency, no bundle bloat
- Added as new "Trajectory" tab between Heatmap and Polls in the student dashboard

### At-Risk Early Warning (admin-facing)
A panel in the admin dashboard listing every student who has missed 2+ consecutive sessions, sorted by severity. Click any row to view that student's full profile.

- `GET /api/admin/at-risk` — aggregation on existing attendancerecords, zero schema changes
- `GET /api/admin/student/by-email/:email` — supports email-based student lookup from at-risk list
- Added as new "At Risk" tab in the admin dashboard

### Bug Fix
- Fixed `loadStudent` in AdminView — was silently ignoring failed fetch responses (404, network error). Now returns early and logs nothing broken to the UI.

## Files changed
- `server/server.js` — 2 new endpoints + 1 bug fix
- `client/src/main.jsx` — SpTrajectory component, AtRiskPanel component, tab wiring
- `client/src/styles.css` — trajectory chart CSS, badge-count component

## Verification
- Build: pass