### PR TITLE
feat: add weekly goal setting and progress tracker Feat/weekly goal tracker

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -385,11 +385,86 @@ function StudentPulse({ profile, badges, nextActions }) {
         <span>SP trend</span>
         <Sparkline points={trend} />
       </div>
+      <WeeklyGoalWidget
+        student={profile.student}
+        weeklyGoal={profile.student.weeklyGoal}
+        onGoalUpdated={(updatedGoal) => {
+          profile.student.weeklyGoal = updatedGoal;
+          window.location.reload();
+        }}
+      />
       <div className="pulse-card wide-pulse">
         <span>What to do next</span>
         <ul className="next-list">{nextActions.map(action => <li key={action}>{action}</li>)}</ul>
       </div>
     </section>
+  );
+}
+
+function WeeklyGoalWidget({ student, weeklyGoal, onGoalUpdated }) {
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(weeklyGoal?.targetSp || '');
+  const [saving, setSaving] = useState(false);
+
+  const target = weeklyGoal?.targetSp || 0;
+  const earned = weeklyGoal?.spEarnedThisWeek || 0;
+  const pct = weeklyGoal?.progressPct || 0;
+
+  const saveGoal = async () => {
+    const value = Number(inputValue);
+    if (!Number.isFinite(value) || value < 0) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`${API}/goal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: student.email, targetSp: value })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        onGoalUpdated(data.student.weeklyGoal);
+        setEditing(false);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="pulse-card wide-pulse">
+      <span>Weekly Goal</span>
+      {target === 0 && !editing ? (
+        <div className="goal-setup">
+          <p className="muted">Set a weekly SP target to track your pace.</p>
+          <button className="secondary" onClick={() => setEditing(true)}>Set a goal</button>
+        </div>
+      ) : editing ? (
+        <div className="goal-setup">
+          <input
+            type="number"
+            min="0"
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            placeholder="Target SP for this week"
+          />
+          <button className="primary" disabled={saving} onClick={saveGoal}>
+            {saving ? 'Saving...' : 'Save goal'}
+          </button>
+          <button className="secondary" onClick={() => setEditing(false)}>Cancel</button>
+        </div>
+      ) : (
+        <div className="goal-progress">
+          <p>{earned} / {target} SP this week</p>
+          <div className="progress-bar">
+            <div className="progress-fill" style={{ width: `${pct}%` }} />
+          </div>
+          <p className="muted">
+            {pct >= 100 ? 'Goal achieved! Great work.' : `${pct}% of the way there.`}
+          </p>
+          <button className="secondary" onClick={() => { setInputValue(target); setEditing(true); }}>Edit goal</button>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,30 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+.goal-setup, .goal-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.goal-setup input {
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid #444;
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  background: #2a2a2a;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: #4caf50;
+  transition: width 0.3s ease;
+}

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -24,7 +24,9 @@ const studentSchema = new mongoose.Schema({
   // Second perception pop-up ("poll2") — same mechanism as surveyCompleted, but an
   // independent flag so it never disturbs the first survey's completion state.
   poll2Completed: { type: Boolean, default: false, index: true },
-  poll2CompletedAt: { type: Date, default: null }
+  poll2CompletedAt: { type: Date, default: null },
+  weeklyGoalSp: { type: Number, default: 0 },
+  weeklyGoalSetAt: { type: Date, default: null }
 }, { timestamps: true });
 
 studentSchema.index({ name: 'text', email: 'text', alternateEmail: 'text' });

--- a/server/server.js
+++ b/server/server.js
@@ -95,6 +95,15 @@ const liveViewers = new Map();
 
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
+// Returns the start (Monday 00:00) of the current week, for weekly goal tracking.
+function weekStart(date = new Date()) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = (day === 0 ? 6 : day - 1);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - diff);
+  return d;
+}
 
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
@@ -194,6 +203,11 @@ async function studentPayload(student) {
   const nextStudent = currentIndex > 0 ? allStudents[currentIndex - 1] : null;
   // Spurti Levels & Trophy Leagues — derived from existing SP (lifetime highest + current).
   const highestSpEver = Math.max(Number(student.highestSpEver) || 0, Number(student.totalSp) || 0);
+  const currentWeekStart = weekStart();
+  const spEarnedThisWeek = transactions
+    .filter(tx => new Date(tx.dateTime) >= currentWeekStart)
+    .reduce((sum, tx) => sum + Number(tx.appliedDelta || 0), 0);
+  const weeklyGoalSp = Number(student.weeklyGoalSp) || 0;
   const myGroup = leaderboardGroup(student.internshipStartDate);
   const groupStudents = allStudents.filter(s => leaderboardGroup(s.internshipStartDate) === myGroup);
   const mapRow = (row, index) => ({
@@ -225,7 +239,13 @@ async function studentPayload(student) {
       leaderboardGroup: myGroup,
       leaderboardGroupLabel: groupLabel(myGroup),
       surveyCompleted: Boolean(student.surveyCompleted),
-      poll2Completed: Boolean(student.poll2Completed)
+      poll2Completed: Boolean(student.poll2Completed),
+      weeklyGoal: {
+        targetSp: weeklyGoalSp,
+        spEarnedThisWeek,
+        progressPct: weeklyGoalSp > 0 ? Math.min(100, Math.round((spEarnedThisWeek / weeklyGoalSp) * 100)) : 0,
+        weekStart: currentWeekStart
+      }
     },
     transactions,
     polls,
@@ -306,7 +326,20 @@ api.post('/confirm', async (req, res) => {
   if (student.status === 'excused') return res.json(excusedPayload(student));
   res.json(await studentPayload(student));
 });
-
+api.post('/goal', async (req, res) => {
+  const { email, targetSp } = req.body || {};
+  const normalized = normalizeEmail(email);
+  const target = Number(targetSp);
+  if (!normalized || !Number.isFinite(target) || target < 0) {
+    return res.status(400).json({ error: 'email and a valid targetSp are required' });
+  }
+  const student = await Student.findOne({ $or: [{ email: normalized }, { alternateEmail: normalized }] });
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  student.weeklyGoalSp = Math.round(target);
+  student.weeklyGoalSetAt = new Date();
+  await student.save();
+  res.json(await studentPayload(student));
+});
 api.get('/leaderboard', async (req, res) => {
   const type = String(req.query.leaderboardType || 'overall');
   const filter = { status: { $ne: 'excused' } };


### PR DESCRIPTION
## What this does
   Adds a weekly goal-setting feature to the student dashboard:
   - Students can set a personal SP target for the current week
   - Dashboard shows progress (SP earned this week / target) with a visual progress bar
   - Goal resets automatically each week (Monday-based)

   ## Changes
   - `server/models/Student.js`: added `weeklyGoalSp` and `weeklyGoalSetAt` fields
   - `server/server.js`: added `POST /api/goal` endpoint, weekly SP calculation logic
   - `client/src/main.jsx`: added `WeeklyGoalWidget` component in the student pulse section
   - `client/src/styles.css`: styling for the goal widget and progress bar