### PR TITLE
feat: add SP forecast and pace planner

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -385,6 +385,7 @@ function StudentPulse({ profile, badges, nextActions }) {
         <span>SP trend</span>
         <Sparkline points={trend} />
       </div>
+      <ForecastWidget forecast={profile.student.forecast} currentSp={student.totalSp} />
       <div className="pulse-card wide-pulse">
         <span>What to do next</span>
         <ul className="next-list">{nextActions.map(action => <li key={action}>{action}</li>)}</ul>
@@ -392,7 +393,69 @@ function StudentPulse({ profile, badges, nextActions }) {
     </section>
   );
 }
+function ForecastWidget({ forecast, currentSp }) {
+  const [goalInput, setGoalInput] = useState('');
+  const [requiredPace, setRequiredPace] = useState(null);
 
+  const { completedSessions, remainingSessions, avgSpPerSession, projectedFinalSp } = forecast;
+
+  const calculateRequiredPace = () => {
+    const goal = Number(goalInput);
+    if (!Number.isFinite(goal) || goal <= currentSp) {
+      setRequiredPace(null);
+      return;
+    }
+    if (remainingSessions === 0) {
+      setRequiredPace('no-sessions-left');
+      return;
+    }
+    const needed = (goal - currentSp) / remainingSessions;
+    setRequiredPace(Math.round(needed * 10) / 10);
+  };
+
+  return (
+    <div className="pulse-card wide-pulse">
+      <span>SP Forecast</span>
+      <div className="forecast-stats">
+        <div className="forecast-stat">
+          <b>{avgSpPerSession}</b>
+          <em>avg SP / session so far</em>
+        </div>
+        <div className="forecast-stat">
+          <b>{remainingSessions}</b>
+          <em>sessions remaining</em>
+        </div>
+        <div className="forecast-stat">
+          <b>{projectedFinalSp}</b>
+          <em>projected final SP</em>
+        </div>
+      </div>
+      <p className="muted">
+        Based on your pace across {completedSessions} completed sessions, you're on track to finish around
+        {' '}<strong>{projectedFinalSp} SP</strong>.
+      </p>
+      <div className="forecast-goal">
+        <input
+          type="number"
+          min="0"
+          value={goalInput}
+          onChange={e => setGoalInput(e.target.value)}
+          placeholder="Enter a target SP"
+        />
+        <button className="secondary" onClick={calculateRequiredPace}>Check pace needed</button>
+      </div>
+      {requiredPace === 'no-sessions-left' && (
+        <p className="error">No sessions remain — this goal isn't reachable this cohort.</p>
+      )}
+      {typeof requiredPace === 'number' && (
+        <p className={requiredPace > avgSpPerSession * 1.5 ? 'error' : 'muted'}>
+          You'll need about <strong>{requiredPace} SP/session</strong> for your remaining {remainingSessions} sessions
+          {requiredPace > avgSpPerSession * 1.5 ? ' — that\'s a big jump from your current pace.' : ' — achievable at a slightly better pace.'}
+        </p>
+      )}
+    </div>
+  );
+}
 function Sparkline({ points }) {
   const values = points.map(p => p.value);
   const min = Math.min(...values, 0);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,39 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+.forecast-stats {
+  display: flex;
+  gap: 16px;
+  margin: 8px 0;
+}
+
+.forecast-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.forecast-stat b {
+  font-size: 1.4em;
+}
+
+.forecast-stat em {
+  font-style: normal;
+  color: #999;
+  font-size: 0.85em;
+}
+
+.forecast-goal {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.forecast-goal input {
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid #444;
+  background: #1a1a1a;
+  color: #fff;
+  flex: 1;
+}

--- a/server/server.js
+++ b/server/server.js
@@ -178,13 +178,14 @@ function excusedPayload(student) {
 async function studentPayload(student) {
   const email = student.email;
   const activeFilter = { status: { $ne: 'excused' } };
-  const [transactions, polls, attendance, rankInfo, leaderboard, allStudents] = await Promise.all([
+  const [transactions, polls, attendance, rankInfo, leaderboard, allStudents, sessions] = await Promise.all([
     SPTransaction.find({ email }).sort({ dateTime: 1, createdAt: 1 }).lean(),
     PollRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     AttendanceRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     rankFor(email),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
-    Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
+    Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean(),
+    Session.find().lean()
   ]);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
@@ -195,6 +196,24 @@ async function studentPayload(student) {
   // Spurti Levels & Trophy Leagues — derived from existing SP (lifetime highest + current).
   const highestSpEver = Math.max(Number(student.highestSpEver) || 0, Number(student.totalSp) || 0);
   const myGroup = leaderboardGroup(student.internshipStartDate);
+  // SP Forecast — projects final SP based on the student's average earning
+  // pace across completed sessions, and how much pace is needed to hit a goal.
+  const now = new Date();
+  const completedSessions = sessions.filter(s => new Date(s.endDateTime) <= now);
+  const remainingSessions = sessions.filter(s => new Date(s.endDateTime) > now);
+  const earnedFromSessions = transactions
+    .filter(tx => tx.category === 'attendance' || tx.category === 'poll')
+    .reduce((sum, tx) => sum + Number(tx.appliedDelta || 0), 0);
+  const avgSpPerSession = completedSessions.length
+    ? Math.round((earnedFromSessions / completedSessions.length) * 10) / 10
+    : 0;
+  const projectedFinalSp = Math.round(student.totalSp + (avgSpPerSession * remainingSessions.length));
+  const forecast = {
+    completedSessions: completedSessions.length,
+    remainingSessions: remainingSessions.length,
+    avgSpPerSession,
+    projectedFinalSp
+  };
   const groupStudents = allStudents.filter(s => leaderboardGroup(s.internshipStartDate) === myGroup);
   const mapRow = (row, index) => ({
     rank: index + 1,
@@ -225,7 +244,8 @@ async function studentPayload(student) {
       leaderboardGroup: myGroup,
       leaderboardGroupLabel: groupLabel(myGroup),
       surveyCompleted: Boolean(student.surveyCompleted),
-      poll2Completed: Boolean(student.poll2Completed)
+      poll2Completed: Boolean(student.poll2Completed),
+      forecast
     },
     transactions,
     polls,


### PR DESCRIPTION
## What this does
Adds a forward-looking SP forecast to the student dashboard:
- Calculates average SP earned per completed session
- Projects final SP by the end of the internship based on current pace
- Lets students enter a target SP and see the pace needed per remaining session to reach it

## Changes
- `server/server.js`: added session-based forecast calculation (completed/remaining sessions, avg pace, projection) in `studentPayload`
- `client/src/main.jsx`: added `ForecastWidget` component showing pace stats and a goal-based pace calculator
- `client/src/styles.css`: styling for the forecast widget