### PR TITLE
refactor(sp-scoring): extract SP rules into config module

### DIFF
--- a/server/scripts/lib/ingestion.js
+++ b/server/scripts/lib/ingestion.js
@@ -7,6 +7,15 @@ import AttendanceRecord from '../../models/AttendanceRecord.js';
 import PollRecord from '../../models/PollRecord.js';
 import SPTransaction from '../../models/SPTransaction.js';
 
+import {
+  INITIAL_SP,
+  ATTENDANCE_THRESHOLD,
+  ATTENDANCE_SP_CREDIT,
+  ATTENDANCE_SP_DEBIT,
+  POLL_ATTEMPTED_SCORE,
+  POLL_MISSED_SCORE,
+} from './spRules.js';
+
 export const KNOWN_SESSIONS = [
   session('15 May Morning', '2026-05-15', 'morning', '2026-05-15T08:27:30', '2026-05-15T12:37:30', 250, '2026-05-15/15_may_attendance_M.csv', '2026-05-15/15 May - orientation poll report - morning.csv'),
   session('15 May Evening', '2026-05-15', 'evening', '2026-05-15T13:29:45', '2026-05-15T17:14:45', 225, '2026-05-15/15_may_attendance_E.csv', '2026-05-15/15 May - orientation poll report - evening.csv'),
@@ -195,9 +204,9 @@ export async function ensureInitialTransaction(student, stats = {}) {
     category: 'initial',
     sessionLabel: '',
     deltaMode: 'absolute',
-    deltaValue: 100,
-    appliedDelta: 100,
-    balanceAfter: 100,
+    deltaValue: INITIAL_SP,
+    appliedDelta: INITIAL_SP,
+    balanceAfter: INITIAL_SP,
     reason: 'Initial Spurti Points credited by system on onboarding.',
     dateTime: student.internshipStartDate
   });
@@ -290,8 +299,8 @@ export async function applySessionForStudents(config, students, rootDir, stats =
     if (attendancePath) {
       const minutes = parsedAttendance.rows.get(student.email) || parsedAttendance.rows.get(student.alternateEmail) || 0;
       const pct = totalMinutes ? Math.round((minutes / totalMinutes) * 100) : 0;
-      const qualified = totalMinutes > 0 && minutes / totalMinutes >= 0.75;
-      const delta = qualified ? 5 : -5;
+      const qualified = totalMinutes > 0 && minutes / totalMinutes >= ATTENDANCE_THRESHOLD;
+      const delta = qualified ? ATTENDANCE_SP_CREDIT : ATTENDANCE_SP_DEBIT;
       const reason = qualified
         ? `${config.label}: attended ${minutes}/${totalMinutes} minutes (${pct}%). Required 75%, credited +5 SP.`
         : `${config.label}: attended ${minutes}/${totalMinutes} minutes (${pct}%). Required 75%, debited -5 SP.`;
@@ -310,7 +319,7 @@ export async function applySessionForStudents(config, students, rootDir, stats =
       const responses = parsedPoll.byEmail.get(student.email) || parsedPoll.byEmail.get(student.alternateEmail) || [];
       const attempted = responses.filter(r => r.attempted).length;
       const missed = Math.max(0, parsedPoll.totalQuestions - attempted);
-      const delta = attempted - missed;
+      const delta = attempted * POLL_ATTEMPTED_SCORE + missed * POLL_MISSED_SCORE;
       const reason = `${config.label}: attempted ${attempted}/${parsedPoll.totalQuestions} poll questions. +${attempted} for attempted, -${missed} for missed = ${delta} SP.`;
       const tx = await createTransactionOnce(student, 'poll', config.label, delta, reason, endDateTime, stats);
       if (tx) {

--- a/server/scripts/lib/spRules.js
+++ b/server/scripts/lib/spRules.js
@@ -1,0 +1,43 @@
+/**
+ * spRules.js — SP scoring configuration
+ *
+ * All numeric constants that participate in Student Points (SP) calculations
+ * are defined here. This module contains ONLY configuration values; no
+ * business logic lives here.
+ *
+ * Import this module wherever SP deltas are computed so that rule changes
+ * can be made in one place without touching business logic.
+ */
+
+// ---------------------------------------------------------------------------
+// Onboarding
+// ---------------------------------------------------------------------------
+
+/** SP balance credited to a student on initial onboarding. */
+export const INITIAL_SP = 100;
+
+// ---------------------------------------------------------------------------
+// Attendance scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum fraction of session minutes a student must attend to qualify
+ * for the attendance credit (e.g. 0.75 = 75%).
+ */
+export const ATTENDANCE_THRESHOLD = 0.75;
+
+/** SP awarded when a student meets or exceeds ATTENDANCE_THRESHOLD. */
+export const ATTENDANCE_SP_CREDIT = 5;
+
+/** SP deducted when a student falls below ATTENDANCE_THRESHOLD. */
+export const ATTENDANCE_SP_DEBIT = -5;
+
+// ---------------------------------------------------------------------------
+// Poll scoring
+// ---------------------------------------------------------------------------
+
+/** SP contributed per poll question that the student attempted. */
+export const POLL_ATTEMPTED_SCORE = 1;
+
+/** SP contributed per poll question that the student missed. */
+export const POLL_MISSED_SCORE = -1;

--- a/server/scripts/lib/spRules.test.js
+++ b/server/scripts/lib/spRules.test.js
@@ -1,0 +1,120 @@
+/**
+ * spRules.test.js — Regression tests for the SP scoring constants extraction.
+ *
+ * Uses Node's built-in test runner (node:test) and assertion library
+ * (node:assert) — zero additional dependencies required.
+ *
+ * Run with:
+ *   node --test server/scripts/lib/spRules.test.js
+ *
+ * Coverage:
+ *  1. Sanity: all exported constants from spRules.js match expected values.
+ *  2. Attendance: above / exactly at / below / zero attendance / zero total-minutes.
+ *  3. Poll scoring: attempted > missed, attempted < missed, all attempted,
+ *     zero attempted, attempted equals missed.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  INITIAL_SP,
+  ATTENDANCE_THRESHOLD,
+  ATTENDANCE_SP_CREDIT,
+  ATTENDANCE_SP_DEBIT,
+  POLL_ATTEMPTED_SCORE,
+  POLL_MISSED_SCORE,
+} from './spRules.js';
+
+// ---------------------------------------------------------------------------
+// Helper: replicate the attendance-delta logic from ingestion.js so we can
+// test it without a database connection.
+// ---------------------------------------------------------------------------
+function attendanceDelta(minutes, totalMinutes) {
+  const qualified = totalMinutes > 0 && minutes / totalMinutes >= ATTENDANCE_THRESHOLD;
+  return qualified ? ATTENDANCE_SP_CREDIT : ATTENDANCE_SP_DEBIT;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: replicate the poll-delta logic from ingestion.js.
+// ---------------------------------------------------------------------------
+function pollDelta(attempted, totalQuestions) {
+  const missed = Math.max(0, totalQuestions - attempted);
+  return attempted * POLL_ATTEMPTED_SCORE + missed * POLL_MISSED_SCORE;
+}
+
+// ===========================================================================
+// 1 — Constants sanity checks
+// ===========================================================================
+
+test('spRules: INITIAL_SP equals 100', () => {
+  assert.equal(INITIAL_SP, 100);
+});
+
+test('spRules: ATTENDANCE_THRESHOLD equals 0.75', () => {
+  assert.equal(ATTENDANCE_THRESHOLD, 0.75);
+});
+
+test('spRules: ATTENDANCE_SP_CREDIT equals 5', () => {
+  assert.equal(ATTENDANCE_SP_CREDIT, 5);
+});
+
+test('spRules: ATTENDANCE_SP_DEBIT equals -5', () => {
+  assert.equal(ATTENDANCE_SP_DEBIT, -5);
+});
+
+test('spRules: POLL_ATTEMPTED_SCORE equals 1', () => {
+  assert.equal(POLL_ATTEMPTED_SCORE, 1);
+});
+
+test('spRules: POLL_MISSED_SCORE equals -1', () => {
+  assert.equal(POLL_MISSED_SCORE, -1);
+});
+
+// ===========================================================================
+// 2 — Attendance delta scenarios
+// ===========================================================================
+
+test('attendance: above threshold (80/100) => delta +5', () => {
+  assert.equal(attendanceDelta(80, 100), 5);
+});
+
+test('attendance: exactly at threshold (75/100) => delta +5 (boundary inclusive)', () => {
+  assert.equal(attendanceDelta(75, 100), 5);
+});
+
+test('attendance: below threshold (70/100) => delta -5', () => {
+  assert.equal(attendanceDelta(70, 100), -5);
+});
+
+test('attendance: zero attendance (0/100) => delta -5', () => {
+  assert.equal(attendanceDelta(0, 100), -5);
+});
+
+test('attendance: zero total minutes => delta -5 (guard: totalMinutes=0 is not qualified)', () => {
+  assert.equal(attendanceDelta(0, 0), -5);
+});
+
+// ===========================================================================
+// 3 — Poll delta scenarios
+// ===========================================================================
+
+test('poll: attempted > missed (3/5) => delta 1', () => {
+  assert.equal(pollDelta(3, 5), 1);
+});
+
+test('poll: attempted < missed (1/5) => delta -3', () => {
+  assert.equal(pollDelta(1, 5), -3);
+});
+
+test('poll: all attempted (5/5) => delta 5', () => {
+  assert.equal(pollDelta(5, 5), 5);
+});
+
+test('poll: zero attempted (0/5) => delta -5', () => {
+  assert.equal(pollDelta(0, 5), -5);
+});
+
+test('poll: attempted equals missed (2/4) => delta 0', () => {
+  assert.equal(pollDelta(2, 4), 0);
+});


### PR DESCRIPTION
## Summary

This PR performs a non-functional refactor of the SP (Student Points) scoring configuration.

It extracts hardcoded SP scoring constants from `server/scripts/lib/ingestion.js` into a dedicated `server/scripts/lib/spRules.js` configuration module while preserving existing runtime behavior.

## Motivation

Centralizing scoring constants improves maintainability, readability, and testability without changing business logic.

## Scope

- Extract SP scoring constants into `spRules.js`
- Replace hardcoded literals in `ingestion.js` with named constants
- Add regression tests for the extracted constants and scoring behavior
- No business logic or scoring behavior changes

## Testing

- `npm install` completed successfully
- Runtime verification completed
- Regression tests executed successfully (16/16 passing)
- Module system verified (ESM)
- Verified no references to the retired chat-scoring pipeline or `ChatRecord.js`
- Confirmed runtime behavior remains unchanged

## Notes

This is a non-functional refactor only.

It does **not** resolve or change SP scoring behavior.

During verification, pre-existing hardcoded `INITIAL_SP` values were identified in `addStudents.js` and `migrate_sp_transactions.js`. Those locations were intentionally left unchanged to keep this PR narrowly scoped. A follow-up PR can consolidate them onto the shared `INITIAL_SP` constant.