### PR TITLE
feat(student): Click any SP transaction to see exactly why it was scored — turn the SpBank into a feedback tool

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -280,7 +280,7 @@ function StudentView({ profile, onBack }) {
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
       <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
-      {tab === 'bank' && <SpBank transactions={profile.transactions} />}
+      {tab === 'bank' && <SpBank transactions={profile.transactions} explanations={profile.explanations || {}} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
     </main>
@@ -432,21 +432,54 @@ function Tabs({ tab, setTab, tabs }) {
   return <nav className="tabs">{tabs.map(([key, label]) => <button key={key} className={tab === key ? 'active' : ''} onClick={() => setTab(key)}>{label}</button>)}</nav>;
 }
 
-function SpBank({ transactions }) {
+function SpBank({ transactions, explanations = {} }) {
+  const [openId, setOpenId] = useState(null);
+  const toggle = (id) => setOpenId(prev => prev === id ? null : id);
   return (
     <section className="panel">
       <h2>SP Bank Statement</h2>
       <div className="bank">
         <div className="bank-header"><span>Date & time</span><span>Credit</span><span>Debit</span><span>Balance</span><span>Reason</span></div>
-        {transactions.map(tx => (
-          <div className="bank-row" key={tx._id}>
-            <span>{new Date(tx.dateTime).toLocaleString()}</span>
-            <strong className="credit">{tx.appliedDelta > 0 ? `+${tx.appliedDelta}` : ''}</strong>
-            <strong className="debit">{tx.appliedDelta < 0 ? tx.appliedDelta : ''}</strong>
-            <b>{tx.balanceAfter}</b>
-            <p>{tx.reason}</p>
-          </div>
-        ))}
+        {transactions.map(tx => {
+          const ex = explanations[String(tx._id)];
+          const isOpen = openId === String(tx._id);
+          return (
+            <div className="bank-row-wrap" key={tx._id}>
+              <div
+                className={ex ? 'bank-row bank-row-clickable' : 'bank-row'}
+                onClick={ex ? () => toggle(String(tx._id)) : undefined}
+                role={ex ? 'button' : undefined}
+                aria-expanded={ex ? isOpen : undefined}
+                title={ex ? 'Click to see how this was scored' : undefined}
+              >
+                <span>{new Date(tx.dateTime).toLocaleString()}</span>
+                <strong className="credit">{tx.appliedDelta > 0 ? `+${tx.appliedDelta}` : ''}</strong>
+                <strong className="debit">{tx.appliedDelta < 0 ? tx.appliedDelta : ''}</strong>
+                <b>{tx.balanceAfter}</b>
+                <p>{tx.reason}</p>
+              </div>
+              {ex && isOpen && (
+                <div className={`bank-explain bank-explain-${ex.category}`}>
+                  <div className="bank-explain-head">{ex.headline}</div>
+                  <div className="bank-explain-detail">{ex.detail}</div>
+                  <div className="bank-explain-recommendation">
+                    <strong>What to do differently:</strong> {ex.recommendation}
+                  </div>
+                  {ex.rubric && ex.rubric.rule !== 'unknown' && (
+                    <details className="bank-explain-rubric">
+                      <summary>Show rubric numbers</summary>
+                      <table className="table">
+                        <tbody>{Object.entries(ex.rubric.values).map(([k, v]) => (
+                          <tr key={k}><td>{k}</td><td>{String(v)}</td></tr>
+                        ))}</tbody>
+                      </table>
+                    </details>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </section>
   );
@@ -593,7 +626,7 @@ function AdminView({ admin, auth, onBack }) {
       {tab === 'live' && <LiveAnalytics active={active} />}
       {tab === 'analytics' && <Analytics data={analytics} />}
       {tab === 'students' && <AllStudentsPanel stats={stats} onStudent={loadStudent} auth={auth} />}
-      {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} /></section></div>}
+      {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} explanations={studentProfile.explanations || {}} /></section></div>}
     </main>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -291,10 +291,92 @@ input {
   border-bottom: 1px solid var(--line);
 }
 .bank-header { background: #f8fafc; font-size: 12px; font-weight: 900; color: var(--muted); text-transform: uppercase; }
-.bank-row:last-child { border-bottom: 0; }
+.bank-row-wrap { border-bottom: 1px solid var(--line); }
+.bank-row-wrap:last-child { border-bottom: 0; }
+.bank-row { background: #fff; transition: background 0.12s; }
+.bank-row-clickable { cursor: pointer; }
+.bank-row-clickable:hover { background: #f5fbfd; }
+.bank-row-clickable::after {
+  content: '?';
+  position: absolute;
+  right: 14px;
+  top: 11px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.bank-row-clickable { position: relative; }
+.bank-row-clickable:hover::after { opacity: 1; }
 .bank-row p { margin: 0; color: #334155; line-height: 1.4; }
 .credit { color: var(--green); }
 .debit { color: var(--red); }
+
+/* Why-did-this-happen explainer panel (feature/why-did-i-lose-sp) */
+.bank-explain {
+  background: #fbfdff;
+  border-top: 1px solid var(--line);
+  padding: 12px 14px 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #1e293b;
+}
+.bank-explain-attendance {
+  background: linear-gradient(180deg, #fff7f7 0%, #fbfdff 100%);
+  border-left: 3px solid var(--red);
+}
+.bank-explain-poll {
+  background: linear-gradient(180deg, #fff8eb 0%, #fbfdff 100%);
+  border-left: 3px solid var(--amber);
+}
+.bank-explain-initial,
+.bank-explain-manual {
+  background: #fbfdff;
+  border-left: 3px solid var(--primary);
+}
+.bank-explain-head {
+  font-weight: 800;
+  font-size: 14px;
+  margin-bottom: 6px;
+  color: var(--text);
+}
+.bank-explain-detail {
+  margin-bottom: 8px;
+  color: #475569;
+}
+.bank-explain-recommendation {
+  background: #f1f5f9;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  margin-top: 6px;
+}
+.bank-explain-recommendation strong {
+  color: var(--primary);
+  margin-right: 4px;
+}
+.bank-explain-rubric {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.bank-explain-rubric summary { cursor: pointer; user-select: none; }
+.bank-explain-rubric summary:hover { color: var(--primary); }
+.bank-explain-rubric .table {
+  margin-top: 6px;
+  font-size: 11px;
+}
+.bank-explain-rubric .table td {
+  padding: 4px 8px;
+}
 
 .cards { display: grid; gap: 12px; }
 .card {

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { explainTransactions } from './services/spExplanation.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -230,6 +231,10 @@ async function studentPayload(student) {
     transactions,
     polls,
     attendance,
+    // Human-readable explanation for each transaction. Keyed by txn _id
+    // (string). Lets the SpBank tab tell students WHY they gained/lost SP
+    // for each row instead of forcing them to guess from the rubric.
+    explanations: explainTransactions(transactions),
     cohort: {
       averageSp,
       top10Cutoff,

--- a/server/services/spExplanation.js
+++ b/server/services/spExplanation.js
@@ -1,0 +1,256 @@
+/**
+ * server/services/spExplanation.js
+ *
+ * Pure helper that turns any SPTransaction into a structured, human-readable
+ * explanation of how it was scored. Built to close the feedback loop in
+ * PRODUCT.md's "Awareness" pillar: students see a debit in the SpBank and
+ * don't know why. This module tells them, in plain language.
+ *
+ * ZERO side effects. ZERO DB access. Pass in a transaction (and optionally
+ * a session), get back an explanation object. Fully unit-testable without
+ * Mongoose.
+ *
+ * Handles both rubrics currently in the production ledger:
+ *   - New band rubric (pipeline/sp-rubric-build-mirror.cjs): produces
+ *     deltas of 0/3/5/10 only. Reason text contains
+ *     "present X of Y min (Z%) within official …" or
+ *     "answered X of Y poll questions (Z%)".
+ *   - Old CSV rubric (server/scripts/lib/ingestion.js): can produce
+ *     deltas of -5 (attendance debit). Reason text contains
+ *     "attended X/Y minutes (Z%). Required 75%, credited/debited …".
+ *
+ * Exhaustive tests in server/tests/sp-explanation.test.js.
+ */
+
+/**
+ * @typedef {Object} Rubric
+ * @property {string} rule    Identifier for the rubric that produced this txn
+ * @property {Object} values  The specific numeric inputs/outputs of the rubric
+ */
+
+/**
+ * @typedef {Object} Explanation
+ * @property {string} category         Transaction category (attendance/poll/initial/manual)
+ * @property {string} headline         One-line summary (shown as the panel title)
+ * @property {string} detail           Multi-line body (the "what happened" explanation)
+ * @property {string} recommendation   Actionable next-step (the "what to do differently")
+ * @property {Object|null} rubric     Underlying rubric values; null for non-scored txns
+ */
+
+/** Reasons a transaction might NOT have a parseable rubric. */
+const UNKNOWN = 'unknown';
+
+// ── Regex patterns for the two rubric flavors ──────────────────────────
+
+// New band rubric (pipeline): "<label> (<date>): present X of Y min (Z%) within … -> D SP."
+const NEW_ATTENDANCE_RE = /present\s+(\d+)\s+of\s+(\d+)\s+min\s+\(([\d.]+)%\)/;
+
+// New band rubric (poll): "<label> (<date>): answered X of Y poll questions (Z%) -> D SP."
+const NEW_POLL_RE = /answered\s+(\d+)\s+of\s+(\d+)\s+poll\s+questions\s+\(([\d.]+)%\)/;
+
+// Old CSV rubric (server/scripts/lib/ingestion.js):
+//   "<label>: attended X/Y minutes (Z%). Required 75%, credited +5 SP."
+//   "<label>: attended X/Y minutes (Z%). Required 75%, debited -5 SP."
+const OLD_ATTENDANCE_RE = /attended\s+(\d+)\/(\d+)\s+minutes\s+\(([\d.]+)%\)/;
+
+// ── Per-category explainers ─────────────────────────────────────────────
+
+function explainAttendance(txn) {
+  const delta = Number(txn.appliedDelta || 0);
+
+  // Try the new band-rubric format first.
+  let m = String(txn.reason || '').match(NEW_ATTENDANCE_RE);
+  if (m) {
+    const attended = Number(m[1]);
+    const total = Number(m[2]);
+    const pct = Number(m[3]);
+    return buildAttendanceBandExplanation(attended, total, pct, delta);
+  }
+
+  // Fall back to the old CSV-rubric format (pre-mirror).
+  m = String(txn.reason || '').match(OLD_ATTENDANCE_RE);
+  if (m) {
+    const attended = Number(m[1]);
+    const total = Number(m[2]);
+    const pct = Number(m[3]);
+    return buildOldAttendanceExplanation(attended, total, pct, delta);
+  }
+
+  // Unparseable — give a generic but honest answer.
+  return {
+    category: 'attendance',
+    headline: `Attendance adjustment — ${formatDelta(delta)}`,
+    detail: txn.reason || 'No detail recorded for this transaction.',
+    recommendation: 'Show up to the full 09:05-11:00 IST window to avoid attendance adjustments.',
+    rubric: { rule: UNKNOWN, values: {} }
+  };
+}
+
+function buildAttendanceBandExplanation(attended, total, pct, delta) {
+  const band = bandFor(pct);
+  return {
+    category: 'attendance',
+    headline: `Attendance ${band.label} band — ${formatDelta(delta)}`,
+    detail: `You attended ${attended} of ${total} min (${pct.toFixed(1)}%) of the official session window. The attendance band rubric awards ${delta < 0 ? 'a debit when below 50%' : 'credit only above 50%'}.`,
+    recommendation: recommendationForAttendanceBand(delta, band),
+    rubric: {
+      rule: 'attendance-band',
+      values: {
+        attended,
+        totalMinutes: total,
+        pct,
+        band: band.label,
+        bandLow: band.low,
+        bandHigh: band.high,
+        delta
+      }
+    }
+  };
+}
+
+function buildOldAttendanceExplanation(attended, total, pct, delta) {
+  const required = Math.round(total * 0.75);
+  const shortBy = Math.max(0, required - attended);
+  return {
+    category: 'attendance',
+    headline: delta < 0 ? `Attendance debit — ${formatDelta(delta)}` : `Attendance credit — ${formatDelta(delta)}`,
+    detail: `You attended ${attended} of ${total} min (${pct.toFixed(1)}%). The old CSV rubric required ${required} min (75%) to qualify — you were ${shortBy} min short.`,
+    recommendation: delta < 0
+      ? 'The new band rubric would have given 0 SP instead of debiting — attend the full 09:05-11:00 IST window to avoid deductions going forward.'
+      : 'You qualified under the old rubric. Stay for the full window to keep getting credit.',
+    rubric: {
+      rule: 'attendance-csv-75pct',
+      values: { attended, totalMinutes: total, pct, required, shortBy, delta }
+    }
+  };
+}
+
+function explainPoll(txn) {
+  const delta = Number(txn.appliedDelta || 0);
+  const m = String(txn.reason || '').match(NEW_POLL_RE);
+  if (!m) {
+    return {
+      category: 'poll',
+      headline: `Poll adjustment — ${formatDelta(delta)}`,
+      detail: txn.reason || 'No detail recorded for this transaction.',
+      recommendation: 'Answer every poll that appears during the session — they pop up every 10-15 minutes.',
+      rubric: { rule: UNKNOWN, values: {} }
+    };
+  }
+  const answered = Number(m[1]);
+  const total = Number(m[2]);
+  const pct = Number(m[3]);
+  const band = bandFor(pct);
+  return {
+    category: 'poll',
+    headline: `Poll ${band.label} band — ${formatDelta(delta)}`,
+    detail: `You answered ${answered} of ${total} poll questions (${pct.toFixed(1)}%). The poll band rubric requires 75% to earn any credit.`,
+    recommendation: recommendationForPollBand(delta, band, answered, total),
+    rubric: {
+      rule: 'poll-band',
+      values: {
+        answered,
+        totalQuestions: total,
+        pct,
+        band: band.label,
+        bandLow: band.low,
+        bandHigh: band.high,
+        delta
+      }
+    }
+  };
+}
+
+function explainInitial(txn) {
+  return {
+    category: 'initial',
+    headline: `${formatDelta(txn.appliedDelta)} — initial credit`,
+    detail: 'Every intern who starts the program receives +100 SP as their initial motivation balance. This is awarded automatically on your internship start date.',
+    recommendation: 'No action needed — this is a one-time starting balance. The pipeline uses the date you joined the cohort.',
+    rubric: null
+  };
+}
+
+function explainManual(txn) {
+  return {
+    category: 'manual',
+    headline: `${formatDelta(txn.appliedDelta)} — admin adjustment`,
+    detail: txn.reason || 'Manual adjustment by an admin (e.g. misconduct deduction, participation bonus, or correction).',
+    recommendation: 'Contact your admin if this looks wrong. Manual adjustments appear in your ledger but are not auto-reversible from the student side.',
+    rubric: null
+  };
+}
+
+// ── Registry ────────────────────────────────────────────────────────────
+
+const EXPLANATORS = {
+  attendance: explainAttendance,
+  poll: explainPoll,
+  initial: explainInitial,
+  manual: explainManual
+};
+
+/**
+ * Explain any SPTransaction. Returns null if the category is unknown
+ * (e.g. future categories like 'tip' until they're added here).
+ */
+export function explainTransaction(txn) {
+  if (!txn || !txn.category) return null;
+  const fn = EXPLANATORS[txn.category];
+  if (!fn) return null;
+  return fn(txn);
+}
+
+/**
+ * Explain a batch of transactions. Returns a plain OBJECT keyed by
+ * transaction id (string). Plain object — not a Map — because the
+ * JSON serializer would stringify Map as '{}'.
+ *
+ * Skips any transaction whose explainer returns null (unknown category).
+ */
+export function explainTransactions(txns) {
+  const out = {};
+  if (!Array.isArray(txns)) return out;
+  for (const t of txns) {
+    if (!t || t._id == null) continue;
+    const e = explainTransaction(t);
+    if (e) out[String(t._id)] = e;
+  }
+  return out;
+}
+
+// ── Internal helpers (exported only for tests) ─────────────────────────
+
+/** Map a percentage to its band label + low/high thresholds. */
+export function bandFor(pct) {
+  if (pct >= 90) return { label: '90%+', low: 90, high: 100 };
+  if (pct >= 75) return { label: '75-89%', low: 75, high: 89 };
+  if (pct >= 50) return { label: '50-74%', low: 50, high: 74 };
+  return { label: '<50%', low: 0, high: 49 };
+}
+
+/** Format a delta as "+5 SP" / "-5 SP" / "0 SP". */
+export function formatDelta(delta) {
+  const d = Number(delta || 0);
+  if (d > 0) return `+${d} SP`;
+  if (d < 0) return `${d} SP`;
+  return '0 SP';
+}
+
+/** Recommendation text given the attendance delta + band. */
+function recommendationForAttendanceBand(delta, band) {
+  if (delta >= 10) return 'Full attendance credit. Keep showing up to the full 09:05-11:00 IST window — that\'s the only way to stay in the 90%+ band.';
+  if (delta >= 5) return 'Partial credit. Join 10 minutes earlier or stay 10 minutes later to push above 90% next time.';
+  if (delta >= 3) return 'Minimal credit. The 75% threshold requires about 90 of 120 minutes — set a recurring alarm at 08:55 to join with buffer.';
+  if (delta === 0) return 'Below the 50% threshold — you didn\'t earn anything. Set a daily reminder at 09:00 and stay until 11:00 to easily clear 90%.';
+  return 'Debited under the old rubric. The new band rubric would have given 0 SP instead of -5 — attend the full window to avoid deductions.';
+}
+
+/** Recommendation text given the poll delta + band + counts. */
+function recommendationForPollBand(delta, band, answered, total) {
+  if (delta >= 10) return 'Full poll credit. You answered nearly every question — keep doing that.';
+  if (delta >= 5) return 'Partial credit. Polls appear every 10-15 min during the session — watch for the popup and click within 30 seconds.';
+  if (delta >= 3) return 'Minimal credit. The 75% threshold means about 12 of 16 questions. Most polls only stay open for 30-60 seconds, so click immediately when you see the prompt.';
+  if (delta === 0) return `No poll credit — you answered ${answered} of ${total}. Polls pop up at random times during the session; you cannot earn retroactive credit. Watch the Zoom chat for "[Poll]" lines.`;
+  return 'Negative poll delta is rare under the current rubric. Check the reason text above for the specific penalty.';
+}

--- a/server/tests/sp-explanation.test.js
+++ b/server/tests/sp-explanation.test.js
@@ -1,0 +1,426 @@
+/**
+ * server/tests/sp-explanation.test.js
+ *
+ * Exhaustive tests for server/services/spExplanation.js.
+ *
+ * Covers every category, every delta sign (positive / zero / negative),
+ * every band boundary (90% / 75% / 50%), both rubric flavors (new band
+ * rubric + old CSV rubric), missing/malformed reason text, and the batch
+ * helper.
+ *
+ * Run: node --test server/tests/sp-explanation.test.js
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  explainTransaction,
+  explainTransactions,
+  bandFor,
+  formatDelta,
+} from '../services/spExplanation.js';
+
+// Helper builders — keep fixtures readable.
+const tx = (overrides) => ({
+  _id: overrides._id || 'tx1',
+  category: overrides.category,
+  appliedDelta: overrides.appliedDelta,
+  reason: overrides.reason,
+  dateTime: overrides.dateTime || new Date('2026-07-04T10:00:00Z'),
+  sessionLabel: overrides.sessionLabel || 'Day 1 (1 Jul)'
+});
+
+// ── formatDelta ──────────────────────────────────────────────────────────
+
+test('formatDelta: positive integer', () => {
+  assert.equal(formatDelta(5), '+5 SP');
+});
+test('formatDelta: negative integer', () => {
+  assert.equal(formatDelta(-3), '-3 SP');
+});
+test('formatDelta: zero', () => {
+  assert.equal(formatDelta(0), '0 SP');
+});
+test('formatDelta: null/undefined fall back to 0', () => {
+  assert.equal(formatDelta(null), '0 SP');
+  assert.equal(formatDelta(undefined), '0 SP');
+});
+
+// ── bandFor ─────────────────────────────────────────────────────────────
+
+test('bandFor: 100% -> 90%+', () => {
+  const b = bandFor(100);
+  assert.equal(b.label, '90%+');
+  assert.equal(b.low, 90); assert.equal(b.high, 100);
+});
+test('bandFor: 90% boundary -> 90%+', () => {
+  assert.equal(bandFor(90).label, '90%+');
+});
+test('bandFor: 89.9% -> 75-89%', () => {
+  assert.equal(bandFor(89.9).label, '75-89%');
+});
+test('bandFor: 75% boundary -> 75-89%', () => {
+  assert.equal(bandFor(75).label, '75-89%');
+});
+test('bandFor: 74.9% -> 50-74%', () => {
+  assert.equal(bandFor(74.9).label, '50-74%');
+});
+test('bandFor: 50% boundary -> 50-74%', () => {
+  assert.equal(bandFor(50).label, '50-74%');
+});
+test('bandFor: 49.9% -> <50%', () => {
+  assert.equal(bandFor(49.9).label, '<50%');
+});
+test('bandFor: 0% -> <50%', () => {
+  assert.equal(bandFor(0).label, '<50%');
+});
+
+// ── explainTransaction: category routing ───────────────────────────────
+
+test('explainTransaction: null returns null', () => {
+  assert.equal(explainTransaction(null), null);
+});
+test('explainTransaction: undefined returns null', () => {
+  assert.equal(explainTransaction(undefined), null);
+});
+test('explainTransaction: missing category returns null', () => {
+  assert.equal(explainTransaction({ appliedDelta: 5 }), null);
+});
+test('explainTransaction: unknown category returns null', () => {
+  // 'tip' is a future category (ABHISHEK27Y #16) not yet in our registry
+  assert.equal(explainTransaction({ category: 'tip', appliedDelta: 5, reason: 'foo' }), null);
+});
+
+// ── explainTransaction: initial ────────────────────────────────────────
+
+test('explainTransaction: initial +100', () => {
+  const r = explainTransaction(tx({
+    _id: 'i1', category: 'initial', appliedDelta: 100,
+    reason: 'Base Spurti Points (100) credited on internship start date 2026-05-15.'
+  }));
+  assert.equal(r.category, 'initial');
+  assert.match(r.headline, /\+100 SP/);
+  assert.match(r.headline, /initial credit/i);
+  assert.equal(r.rubric, null);
+  assert.match(r.recommendation, /no action needed/i);
+});
+
+test('explainTransaction: initial with custom amount', () => {
+  // (defensive — if some day we change the base from 100, this still works)
+  const r = explainTransaction(tx({ category: 'initial', appliedDelta: 50 }));
+  assert.match(r.headline, /\+50 SP/);
+});
+
+// ── explainTransaction: manual ──────────────────────────────────────────
+
+test('explainTransaction: manual positive with reason', () => {
+  const r = explainTransaction(tx({
+    category: 'manual', appliedDelta: 5, reason: 'Bonus for outstanding question in session 5.'
+  }));
+  assert.equal(r.category, 'manual');
+  assert.match(r.headline, /\+5 SP/);
+  assert.match(r.detail, /outstanding question/);
+  assert.match(r.recommendation, /contact your admin/i);
+  assert.equal(r.rubric, null);
+});
+
+test('explainTransaction: manual negative (deduction)', () => {
+  const r = explainTransaction(tx({
+    category: 'manual', appliedDelta: -3, reason: 'Camera off for whole session per instructor.'
+  }));
+  assert.match(r.headline, /-3 SP/);
+  assert.match(r.detail, /camera off/i);
+});
+
+test('explainTransaction: manual with empty reason', () => {
+  const r = explainTransaction(tx({ category: 'manual', appliedDelta: 2, reason: '' }));
+  assert.match(r.detail, /manual adjustment by an admin/i);
+});
+
+// ── explainTransaction: attendance (new band rubric) ───────────────────
+
+test('attendance: 100% band -> +10', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 10,
+    reason: 'Day 1 (1 Jul): present 120 of 120 min (100%) within official 09:05-11:00 IST window -> +10 SP.'
+  }));
+  assert.equal(r.category, 'attendance');
+  assert.match(r.headline, /90%\+ band/);
+  assert.match(r.headline, /\+10 SP/);
+  assert.equal(r.rubric.rule, 'attendance-band');
+  assert.equal(r.rubric.values.attended, 120);
+  assert.equal(r.rubric.values.totalMinutes, 120);
+  assert.equal(r.rubric.values.pct, 100);
+  assert.equal(r.rubric.values.delta, 10);
+  assert.match(r.recommendation, /full attendance credit/i);
+});
+
+test('attendance: 90% boundary -> +10', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 10,
+    reason: 'Day 1: present 108 of 120 min (90.0%) ... -> +10 SP.'
+  }));
+  assert.match(r.headline, /90%\+/);
+  assert.equal(r.rubric.values.pct, 90);
+});
+
+test('attendance: 75-89% band -> +5', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 5,
+    reason: 'Day 2: present 100 of 120 min (83.3%) ... -> +5 SP.'
+  }));
+  assert.match(r.headline, /75-89% band/);
+  assert.match(r.headline, /\+5 SP/);
+  assert.match(r.recommendation, /partial credit/i);
+  assert.equal(r.rubric.values.pct, 83.3);
+});
+
+test('attendance: 75% boundary -> +5', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 5,
+    reason: 'Day 3: present 90 of 120 min (75.0%) ... -> +5 SP.'
+  }));
+  assert.match(r.headline, /75-89%/);
+});
+
+test('attendance: 50-74% band -> +3', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 3,
+    reason: 'Day 4: present 80 of 120 min (66.7%) ... -> +3 SP.'
+  }));
+  assert.match(r.headline, /50-74% band/);
+  assert.match(r.headline, /\+3 SP/);
+  assert.match(r.recommendation, /minimal credit/i);
+});
+
+test('attendance: 50% boundary -> +3', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 3,
+    reason: 'Day 5: present 60 of 120 min (50.0%) ... -> +3 SP.'
+  }));
+  assert.match(r.headline, /50-74%/);
+});
+
+test('attendance: <50% -> 0 SP', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 0,
+    reason: 'Day 6: present 40 of 120 min (33.3%) ... -> 0 SP.'
+  }));
+  assert.match(r.headline, /<50%/);
+  assert.match(r.headline, /0 SP/);
+  assert.match(r.recommendation, /below the 50% threshold/i);
+  assert.equal(r.rubric.values.delta, 0);
+});
+
+test('attendance: 0% (absent) -> 0 SP', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 0,
+    reason: 'Day 7: present 0 of 120 min (0.0%) ... -> 0 SP.'
+  }));
+  assert.equal(r.rubric.values.pct, 0);
+  assert.equal(r.rubric.values.delta, 0);
+});
+
+// ── explainTransaction: attendance (old CSV rubric fallback) ────────────
+
+test('attendance (old CSV): credited +5 when above 75%', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 5,
+    reason: 'Day 1 (1 Jul): attended 100/120 minutes (83.3%). Required 75%, credited +5 SP.'
+  }));
+  assert.equal(r.rubric.rule, 'attendance-csv-75pct');
+  assert.match(r.headline, /attendance credit/i);
+  assert.match(r.headline, /\+5 SP/);
+  assert.equal(r.rubric.values.attended, 100);
+  assert.equal(r.rubric.values.totalMinutes, 120);
+  assert.equal(r.rubric.values.required, 90); // 75% of 120
+  assert.equal(r.rubric.values.shortBy, 0);
+});
+
+test('attendance (old CSV): debited -5 when below 75%', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: -5,
+    reason: 'Day 2 (2 Jul): attended 60/120 minutes (50.0%). Required 75%, debited -5 SP.'
+  }));
+  assert.match(r.headline, /attendance debit/i);
+  assert.match(r.headline, /-5 SP/);
+  assert.equal(r.rubric.values.required, 90);
+  assert.equal(r.rubric.values.shortBy, 30); // 90 - 60
+  assert.match(r.recommendation, /new band rubric would have given 0 SP/i);
+});
+
+test('attendance (old CSV): debited exactly at 0%', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: -5,
+    reason: 'Day 8: attended 0/120 minutes (0.0%). Required 75%, debited -5 SP.'
+  }));
+  assert.equal(r.rubric.values.shortBy, 90); // required=90, attended=0
+});
+
+// ── explainTransaction: attendance (unparseable) ───────────────────────
+
+test('attendance: unparseable reason -> generic but honest answer', () => {
+  const r = explainTransaction(tx({
+    category: 'attendance', appliedDelta: 0,
+    reason: 'some weird format we don\'t recognize'
+  }));
+  assert.equal(r.rubric.rule, 'unknown');
+  assert.match(r.headline, /attendance adjustment/i);
+  assert.match(r.recommendation, /show up to the full 09:05-11:00 ist window/i);
+});
+
+test('attendance: missing reason -> generic answer', () => {
+  const r = explainTransaction(tx({ category: 'attendance', appliedDelta: 0 }));
+  assert.equal(r.rubric.rule, 'unknown');
+});
+
+test('attendance: empty reason -> generic answer', () => {
+  const r = explainTransaction(tx({ category: 'attendance', appliedDelta: 0, reason: '' }));
+  assert.equal(r.rubric.rule, 'unknown');
+});
+
+// ── explainTransaction: poll ────────────────────────────────────────────
+
+test('poll: 100% answered -> +10', () => {
+  const r = explainTransaction(tx({
+    category: 'poll', appliedDelta: 10,
+    reason: 'Day 1 (1 Jun): answered 16 of 16 poll questions (100.0%) -> +10 SP.'
+  }));
+  assert.equal(r.category, 'poll');
+  assert.match(r.headline, /90%\+ band/);
+  assert.match(r.headline, /\+10 SP/);
+  assert.equal(r.rubric.rule, 'poll-band');
+  assert.equal(r.rubric.values.answered, 16);
+  assert.equal(r.rubric.values.totalQuestions, 16);
+});
+
+test('poll: 75-89% -> +5', () => {
+  const r = explainTransaction(tx({
+    category: 'poll', appliedDelta: 5,
+    reason: 'Day 2: answered 13 of 16 poll questions (81.3%) -> +5 SP.'
+  }));
+  assert.match(r.headline, /75-89%/);
+  assert.match(r.recommendation, /partial/i);
+});
+
+test('poll: 50-74% -> +3', () => {
+  const r = explainTransaction(tx({
+    category: 'poll', appliedDelta: 3,
+    reason: 'Day 3: answered 9 of 16 poll questions (56.3%) -> +3 SP.'
+  }));
+  assert.match(r.headline, /50-74%/);
+});
+
+test('poll: <50% -> 0 SP', () => {
+  const r = explainTransaction(tx({
+    category: 'poll', appliedDelta: 0,
+    reason: 'Day 4: answered 4 of 16 poll questions (25.0%) -> 0 SP.'
+  }));
+  assert.match(r.headline, /<50%/);
+  assert.match(r.headline, /0 SP/);
+  assert.match(r.recommendation, /pop up at random times/i);
+});
+
+test('poll: 0% -> 0 SP', () => {
+  const r = explainTransaction(tx({
+    category: 'poll', appliedDelta: 0,
+    reason: 'Day 5: answered 0 of 16 poll questions (0.0%) -> 0 SP.'
+  }));
+  assert.equal(r.rubric.values.answered, 0);
+  assert.equal(r.rubric.values.pct, 0);
+});
+
+test('poll: unparseable reason -> generic answer', () => {
+  const r = explainTransaction(tx({ category: 'poll', appliedDelta: 5, reason: 'unparseable' }));
+  assert.equal(r.rubric.rule, 'unknown');
+  assert.match(r.recommendation, /answer every poll/i);
+});
+
+// ── explainTransactions (batch helper) ─────────────────────────────────
+
+test('explainTransactions: empty array -> empty object', () => {
+  assert.deepEqual(explainTransactions([]), {});
+});
+
+test('explainTransactions: null -> empty object', () => {
+  assert.deepEqual(explainTransactions(null), {});
+});
+
+test('explainTransactions: non-array -> empty object', () => {
+  assert.deepEqual(explainTransactions('foo'), {});
+});
+
+test('explainTransactions: skips txns without _id', () => {
+  const out = explainTransactions([
+    { category: 'initial', appliedDelta: 100, reason: 'foo' } // no _id
+  ]);
+  assert.deepEqual(out, {});
+});
+
+test('explainTransactions: skips unknown categories', () => {
+  const out = explainTransactions([
+    { _id: 'a', category: 'tip', appliedDelta: 5, reason: 'foo' },
+    { _id: 'b', category: 'initial', appliedDelta: 100, reason: 'foo' }
+  ]);
+  assert.ok(!out.a, 'unknown category should be skipped');
+  assert.ok(out.b, 'known category should be included');
+});
+
+test('explainTransactions: stringifies _id to use as key', () => {
+  // In JS, all object keys are strings (numeric 42 normalizes to "42").
+  // The helper explicitly does String(t._id) so the JSON serializer
+  // receives the right type. We verify by reading back via Object.keys
+  // (which always returns strings) and via JSON round-trip.
+  const out = explainTransactions([
+    { _id: 42, category: 'initial', appliedDelta: 100, reason: 'x' }
+  ]);
+  const keys = Object.keys(out);
+  assert.equal(keys.length, 1);
+  assert.equal(keys[0], '42', 'key should be the stringified _id');
+  const round = JSON.parse(JSON.stringify(out));
+  assert.ok(round['42'], 'key should survive JSON round-trip');
+});
+
+test('explainTransactions: preserves order via object keys (insertion order)', () => {
+  const out = explainTransactions([
+    { _id: 'z', category: 'initial', appliedDelta: 100, reason: 'a' },
+    { _id: 'a', category: 'initial', appliedDelta: 100, reason: 'b' },
+    { _id: 'm', category: 'initial', appliedDelta: 100, reason: 'c' }
+  ]);
+  assert.deepEqual(Object.keys(out), ['z', 'a', 'm']);
+});
+
+test('explainTransactions: mixed batch of 5 categories', () => {
+  const out = explainTransactions([
+    { _id: '1', category: 'initial', appliedDelta: 100, reason: 'init' },
+    { _id: '2', category: 'attendance', appliedDelta: 10, reason: 'Day 1: present 120 of 120 min (100.0%) -> +10 SP.' },
+    { _id: '3', category: 'poll', appliedDelta: 5, reason: 'Day 1: answered 13 of 16 poll questions (81.3%) -> +5 SP.' },
+    { _id: '4', category: 'manual', appliedDelta: -3, reason: 'camera off' },
+    { _id: '5', category: 'tip', appliedDelta: 1, reason: 'future category' }
+  ]);
+  assert.ok(out['1']);
+  assert.ok(out['2']);
+  assert.ok(out['3']);
+  assert.ok(out['4']);
+  assert.ok(!out['5'], 'tip not in registry yet');
+});
+
+// ── Sanity: every explainer returns a 4-key shape ──────────────────────
+
+test('every explainer returns category, headline, detail, recommendation', () => {
+  const fixtures = [
+    { _id: 'a', category: 'initial', appliedDelta: 100, reason: 'init' },
+    { _id: 'b', category: 'attendance', appliedDelta: 10, reason: 'Day: present 120 of 120 min (100%) -> +10 SP.' },
+    { _id: 'c', category: 'attendance', appliedDelta: -5, reason: 'Day: attended 60/120 minutes (50.0%). Required 75%, debited -5 SP.' },
+    { _id: 'd', category: 'poll', appliedDelta: 0, reason: 'Day: answered 0 of 16 poll questions (0.0%) -> 0 SP.' },
+    { _id: 'e', category: 'manual', appliedDelta: 5, reason: 'bonus' }
+  ];
+  for (const f of fixtures) {
+    const r = explainTransaction(f);
+    for (const key of ['category', 'headline', 'detail', 'recommendation']) {
+      assert.ok(key in r, `missing key ${key} for category ${f.category}`);
+      assert.ok(typeof r[key] === 'string' && r[key].length > 0, `empty ${key} for ${f.category}`);
+    }
+  }
+});


### PR DESCRIPTION
This turns the SpBank tab from a raw ledger into an actual feedback tool.

## What it does

Right now when a student looks at the SpBank and sees `-5 SP`, they have no idea why. They might think the scoring is broken, or that they were unfairly penalized, or they just ignore it because the math doesn't help them. This PR fixes that by adding a **per-transaction explanation** that pops open when you click any row.

The panel tells you:
- Which **band** you landed in (90%+ / 75-89% / 50-74% / <50%)
- Exactly **what your numbers were** (you attended 67 of 120 min, that's 55.8%)
- A **concrete next step** to fix it (e.g. "set a recurring alarm at 08:55 so you can join by 09:00 with buffer")

## Where it works

The SpBank tab in the student dashboard. Every transaction row becomes clickable. A small "?" badge appears on hover so students discover the feature exists. The expanding panel is color-coded by category:
- **Red border** for attendance
- **Amber border** for poll
- **Blue border** for initial credit / manual adjustment

The same explanation shape is also returned by `/api/admin/student/:id`, so admins viewing a student profile also see explanations.

## Use cases unlocked

| Student thought | What they now see |
|---|---|
| "Why did I lose 5 SP yesterday?" | "Attendance 50-74% band — you attended 67 of 120 min. The 75% threshold requires about 90 of 120 min — set a recurring alarm at 08:55." |
| "Why no poll credit today?" | "Poll <50% band — you answered 4 of 16. Polls pop up at random times during the session; watch the Zoom chat for [Poll] lines." |
| "Why did I get 0 SP on Day 12?" | "Attendance <50% band. Below the 50% threshold — you didn't earn anything. Set a daily reminder at 09:00 and stay until 11:00 to easily clear 90%." |
| "What does 'manual adjustment' mean?" | "Manual adjustment by an admin. Contact your admin if this looks wrong — manual adjustments appear in your ledger but are not auto-reversible from the student side." |

## What's in the code

**`server/services/spExplanation.js`** (NEW, 256 lines) — pure helper module:
- `explainTransaction(txn)` → `{ category, headline, detail, recommendation, rubric }` or `null`
- `explainTransactions(txns)` → plain object keyed by `_id`
- `formatDelta(n)` → `+5 SP` / `-5 SP` / `0 SP`
- `bandFor(pct)` → `90%+` / `75-89%` / `50-74%` / `<50%`

Handles **both rubrics** currently in production — the new band rubric (`+0/+3/+5/+10`) AND the old CSV rubric (`-5` attendance debit) — so it works for every transaction already in the database.

**`server/server.js`** — one-line wiring in `studentPayload`: `explanations: explainTransactions(transactions)`. Zero extra DB queries because the transactions array was already fetched for the profile.

**`client/src/main.jsx`** — `<SpBank>` gains `useState` to track which row is expanded, makes rows clickable when an explanation exists, renders the color-coded panel.

**`client/src/styles.css`** — `.bank-explain`, `.bank-explain-attendance` (red), `.bank-explain-poll` (amber), `.bank-explain-initial/manual` (blue), `.bank-row-clickable:hover::after` "?" badge, `.bank-explain-rubric` collapsible details.

## How I tested it

- `node --check server/server.js` passes
- `node --check server/services/spExplanation.js` passes
- `node --test server/tests/sp-explanation.test.js` passes **50/50** in ~130ms
- `npm --prefix client run build` passes (172.45 kB JS / 53.90 kB gzip)

The 50-test suite covers:
- `formatDelta`: positive, negative, zero, null fallback (4)
- `bandFor`: every percentage + every boundary — 90 / 75 / 50 (8)
- Category routing: null, missing, unknown, valid (4)
- `initial` category: +100, custom amount (2)
- `manual` category: positive, negative, empty reason (3)
- Attendance new band rubric: 100%, 90% boundary, 75-89%, 75% boundary, 50-74%, 50% boundary, <50%, 0% (8)
- Attendance old CSV rubric: credited, debited, 0% debit (3)
- Attendance unparseable: weird reason, missing, empty (3)
- Poll: 100%, 75-89%, 50-74%, <50%, 0%, unparseable (6)
- Batch helper: empty, null, non-array, no `_id`, unknown category, stringified `_id` keys, order preservation, mixed 5-category batch (8)
- Shape sanity: every explainer returns 4 required string keys (1)

## Stats

- **+815 / -13 lines** across 5 files
- **256 lines** of pure service module
- **426 lines** of tests
- **60 lines** of client UI changes
- **89 lines** of CSS
- **5 lines** of server wiring (one line + imports + comment)
- **Zero schema changes**
- **Zero new npm packages**
- **Zero new client-side dependencies** (uses React state + CSS variables)

## Why the recommendations are concrete

I deliberately wrote specific, time-bound recommendations instead of generic advice. Compare:

| ❌ Generic (what you'd normally see) | ✅ This PR |
|---|---|
| "Attend more sessions." | "Set a recurring alarm at 08:55 so you can join by 09:00 with buffer." |
| "Participate more in polls." | "Polls appear every 10-15 min during the session — click within 30 seconds." |
| "Talk to your admin." | "Contact your admin if this looks wrong. Manual adjustments are visible in your full ledger but are not auto-reversible from the student side." |

This is the small touch that makes the feature actually useful — students get a next step they can take tomorrow, not a vague exhortation.

## Notes for the mentor

- The helper is pure and stateless. Zero DB cost added per request.
- Plain object (not Map) is returned by the batch helper because `JSON.stringify(Map)` returns `{}` — that would silently break the client. Verified by the "stringified _id keys" test (test passes numeric ID `42` through `JSON.parse(JSON.stringify())` round-trip and checks the key survives).
- Both rubrics are supported — works for every transaction already in the database regardless of when it was scored.
- "Unknown" category (e.g. future `tip` when ABHISHEK27Y's #16 lands) returns `null` and is silently skipped — the helper won't crash when new categories are added to the schema.
- Zero database migration required.
- Zero new npm dependency.
- Mobile responsive: the existing breakpoint already collapses the table cleanly; the new expanded panel inherits standard padding.
