### PR TITLE
feat: streak freeze — spend SP to protect an attendance streak from breaking

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -69,7 +69,11 @@ function App() {
   if (view === 'student' && profile) {
     return (
       <>
-        <StudentView profile={profile} onBack={config.allowStudentSearch ? () => setView('landing') : null} />
+        <StudentView 
+          profile={profile} 
+          onBack={config.allowStudentSearch ? () => setView('landing') : null} 
+          onSettings={() => setView('notification-settings')}
+        />
         <SurveyModal
           survey={config.survey}
           student={profile.student}
@@ -77,6 +81,9 @@ function App() {
         />
       </>
     );
+  }
+  if (view === 'notification-settings' && profile) {
+    return <NotificationSettings onBack={() => setView('student')} />;
   }
   if (view === 'excused' && excused) {
     return <ExcusedView data={excused} onBack={config.allowStudentSearch ? () => setView('landing') : null} />;
@@ -253,7 +260,7 @@ function SearchModal({ onClose, onStudent }) {
   );
 }
 
-function StudentView({ profile, onBack }) {
+function StudentView({ profile, onBack, onSettings }) {
   const [tab, setTab] = useState('bank');
   const { student } = profile;
   const badges = useMemo(() => buildBadges(profile), [profile]);
@@ -261,7 +268,10 @@ function StudentView({ profile, onBack }) {
   return (
     <main className="page compact">
       <header className="topbar">
-        {onBack ? <button className="secondary" onClick={onBack}>Back</button> : <span />}
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          {onBack ? <button className="secondary" onClick={onBack}>Back</button> : <span />}
+          <NotificationBell onSettings={onSettings} />
+        </div>
         <div>
           <p className="eyebrow">Student Spurti Bank</p>
           <h1>{student.name}</h1>
@@ -837,5 +847,143 @@ function SurveyModal({ survey, student, onDone }) {
   );
 }
 
+
+function NotificationBell({ onSettings }) {
+  const [notifications, setNotifications] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const fetchNotifs = async () => {
+      try {
+        const res = await fetch(`${API}/notifications`);
+        if (res.ok && active) setNotifications(await res.json());
+      } catch (err) {}
+    };
+    fetchNotifs();
+    const id = setInterval(fetchNotifs, 45000);
+    return () => { active = false; clearInterval(id); };
+  }, []);
+
+  const unreadCount = notifications.filter(n => !n.read).length;
+
+  const markAllRead = async () => {
+    await fetch(`${API}/notifications/read-all`, { method: 'POST' });
+    setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+  };
+
+  const markRead = async (id) => {
+    await fetch(`${API}/notifications/${id}/read`, { method: 'POST' });
+    setNotifications(prev => prev.map(n => n._id === id ? { ...n, read: true } : n));
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button className="secondary" onClick={() => setOpen(!open)} style={{ position: 'relative' }}>
+        🔔 {unreadCount > 0 && <span style={{ background: 'var(--color-primary, #6366f1)', color: 'white', borderRadius: '50%', padding: '2px 6px', fontSize: '12px', marginLeft: '4px' }}>{unreadCount}</span>}
+      </button>
+      {open && (
+        <div className="panel" style={{ position: 'absolute', top: '100%', left: 0, width: '320px', zIndex: 10, marginTop: '8px', padding: '1rem', boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+            <h3 style={{ margin: 0, fontSize: '1rem' }}>Notifications</h3>
+            <button className="secondary" onClick={() => { setOpen(false); onSettings(); }} style={{ fontSize: '0.8rem', padding: '4px 8px' }}>⚙️ Settings</button>
+          </div>
+          {notifications.length === 0 ? <p className="muted" style={{ margin: 0, fontSize: '0.9rem' }}>No notifications</p> : (
+            <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+              {notifications.map(n => (
+                <div key={n._id} onClick={() => markRead(n._id)} style={{ padding: '0.75rem 0', borderBottom: '1px solid #eee', cursor: 'pointer', opacity: n.read ? 0.6 : 1 }}>
+                  <p style={{ margin: '0 0 0.25rem 0', fontWeight: n.read ? 'normal' : 'bold', fontSize: '0.9rem' }}>{n.title}</p>
+                  <p style={{ margin: 0, fontSize: '0.8rem', color: '#666' }}>{n.message}</p>
+                </div>
+              ))}
+            </div>
+          )}
+          {unreadCount > 0 && <button className="primary" style={{ width: '100%', marginTop: '1rem' }} onClick={markAllRead}>Mark all as read</button>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NotificationSettings({ onBack }) {
+  const [prefs, setPrefs] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetch(`${API}/notifications/preferences`)
+      .then(r => r.json())
+      .then(setPrefs)
+      .catch(() => {});
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    await fetch(`${API}/notifications/preferences`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ categories: prefs.categories })
+    });
+    setSaving(false);
+    onBack();
+  };
+
+  const toggle = (cat, type) => {
+    setPrefs(p => ({
+      ...p,
+      categories: {
+        ...p.categories,
+        [cat]: { ...p.categories[cat], [type]: !p.categories[cat][type] }
+      }
+    }));
+  };
+
+  if (!prefs) return <main className="page"><section className="panel"><p>Loading preferences...</p></section></main>;
+
+  const labels = {
+    weeklyDigest: 'Weekly Digest',
+    streakReminders: 'Streak Reminders',
+    peerActivity: 'Peer Activity',
+    announcements: 'Announcements'
+  };
+
+  return (
+    <main className="page compact">
+      <section className="panel">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
+          <div>
+            <p className="eyebrow">Settings</p>
+            <h1 style={{ margin: 0 }}>Notification Preferences</h1>
+          </div>
+          <button className="secondary" onClick={onBack}>Back</button>
+        </div>
+        <p className="lead" style={{ marginBottom: '2rem' }}>Control how you want to be notified for each type of activity.</p>
+        
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+          {Object.keys(labels).map(cat => (
+            <div key={cat} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: '1.25rem', borderBottom: '1px solid #eee' }}>
+              <strong style={{ fontSize: '1.05rem' }}>{labels[cat]}</strong>
+              <div style={{ display: 'flex', gap: '1.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', userSelect: 'none' }}>
+                  <input type="checkbox" checked={prefs.categories[cat]?.inApp ?? true} onChange={() => toggle(cat, 'inApp')} />
+                  In-App
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', userSelect: 'none' }}>
+                  <input type="checkbox" checked={prefs.categories[cat]?.email ?? false} onChange={() => toggle(cat, 'email')} />
+                  Email
+                </label>
+              </div>
+            </div>
+          ))}
+        </div>
+        
+        <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end' }}>
+          <button className="primary" onClick={save} disabled={saving}>
+            {saving ? 'Saving...' : 'Save Preferences'}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}
 
 createRoot(document.getElementById('root')).render(<App />);

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -880,25 +880,25 @@ function NotificationBell({ onSettings }) {
   return (
     <div style={{ position: 'relative' }}>
       <button className="secondary" onClick={() => setOpen(!open)} style={{ position: 'relative' }}>
-        🔔 {unreadCount > 0 && <span style={{ background: 'var(--color-primary, #6366f1)', color: 'white', borderRadius: '50%', padding: '2px 6px', fontSize: '12px', marginLeft: '4px' }}>{unreadCount}</span>}
+        🔔 {unreadCount > 0 && <span className="notification-bell-badge">{unreadCount}</span>}
       </button>
       {open && (
-        <div className="panel" style={{ position: 'absolute', top: '100%', left: 0, width: '320px', zIndex: 10, marginTop: '8px', padding: '1rem', boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-            <h3 style={{ margin: 0, fontSize: '1rem' }}>Notifications</h3>
-            <button className="secondary" onClick={() => { setOpen(false); onSettings(); }} style={{ fontSize: '0.8rem', padding: '4px 8px' }}>⚙️ Settings</button>
+        <div className="notification-dropdown">
+          <div className="notification-dropdown-header">
+            <h3 className="notification-dropdown-title">Notifications</h3>
+            <button className="secondary notification-settings-button" onClick={() => { setOpen(false); onSettings(); }}>⚙️ Settings</button>
           </div>
           {notifications.length === 0 ? <p className="muted" style={{ margin: 0, fontSize: '0.9rem' }}>No notifications</p> : (
-            <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+            <div className="notification-item-container">
               {notifications.map(n => (
-                <div key={n._id} onClick={() => markRead(n._id)} style={{ padding: '0.75rem 0', borderBottom: '1px solid #eee', cursor: 'pointer', opacity: n.read ? 0.6 : 1 }}>
-                  <p style={{ margin: '0 0 0.25rem 0', fontWeight: n.read ? 'normal' : 'bold', fontSize: '0.9rem' }}>{n.title}</p>
-                  <p style={{ margin: 0, fontSize: '0.8rem', color: '#666' }}>{n.message}</p>
+                <div key={n._id} onClick={() => markRead(n._id)} className={`notification-item ${n.read ? '' : 'unread'}`}>
+                  <p className="notification-item-title">{n.title}</p>
+                  <p className="notification-item-message">{n.message}</p>
                 </div>
               ))}
             </div>
           )}
-          {unreadCount > 0 && <button className="primary" style={{ width: '100%', marginTop: '1rem' }} onClick={markAllRead}>Mark all as read</button>}
+          {unreadCount > 0 && <button className="primary notification-mark-all" onClick={markAllRead}>Mark all as read</button>}
         </div>
       )}
     </div>
@@ -949,25 +949,25 @@ function NotificationSettings({ onBack }) {
   return (
     <main className="page compact">
       <section className="panel">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
+        <div className="notification-settings-header">
           <div>
             <p className="eyebrow">Settings</p>
-            <h1 style={{ margin: 0 }}>Notification Preferences</h1>
+            <h1>Notification Preferences</h1>
           </div>
           <button className="secondary" onClick={onBack}>Back</button>
         </div>
-        <p className="lead" style={{ marginBottom: '2rem' }}>Control how you want to be notified for each type of activity.</p>
+        <p className="lead notification-settings-lead">Control how you want to be notified for each type of activity.</p>
         
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+        <div className="notification-settings-list">
           {Object.keys(labels).map(cat => (
-            <div key={cat} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: '1.25rem', borderBottom: '1px solid #eee' }}>
-              <strong style={{ fontSize: '1.05rem' }}>{labels[cat]}</strong>
-              <div style={{ display: 'flex', gap: '1.5rem' }}>
-                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', userSelect: 'none' }}>
+            <div key={cat} className="notification-settings-row">
+              <strong className="notification-settings-label">{labels[cat]}</strong>
+              <div className="notification-settings-toggles">
+                <label className="notification-settings-toggle">
                   <input type="checkbox" checked={prefs.categories[cat]?.inApp ?? true} onChange={() => toggle(cat, 'inApp')} />
                   In-App
                 </label>
-                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', userSelect: 'none' }}>
+                <label className="notification-settings-toggle">
                   <input type="checkbox" checked={prefs.categories[cat]?.email ?? false} onChange={() => toggle(cat, 'email')} />
                   Email
                 </label>
@@ -976,7 +976,7 @@ function NotificationSettings({ onBack }) {
           ))}
         </div>
         
-        <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end' }}>
+        <div className="notification-settings-actions">
           <button className="primary" onClick={save} disabled={saving}>
             {saving ? 'Saving...' : 'Save Preferences'}
           </button>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -878,8 +878,8 @@ function NotificationBell({ onSettings }) {
   };
 
   return (
-    <div style={{ position: 'relative' }}>
-      <button className="secondary" onClick={() => setOpen(!open)} style={{ position: 'relative' }}>
+    <div className="notification-bell-wrapper">
+      <button className="secondary notification-bell-button" onClick={() => setOpen(!open)}>
         🔔 {unreadCount > 0 && <span className="notification-bell-badge">{unreadCount}</span>}
       </button>
       {open && (
@@ -888,7 +888,7 @@ function NotificationBell({ onSettings }) {
             <h3 className="notification-dropdown-title">Notifications</h3>
             <button className="secondary notification-settings-button" onClick={() => { setOpen(false); onSettings(); }}>⚙️ Settings</button>
           </div>
-          {notifications.length === 0 ? <p className="muted" style={{ margin: 0, fontSize: '0.9rem' }}>No notifications</p> : (
+          {notifications.length === 0 ? <p className="muted notification-empty-state">No notifications</p> : (
             <div className="notification-item-container">
               {notifications.map(n => (
                 <div key={n._id} onClick={() => markRead(n._id)} className={`notification-item ${n.read ? '' : 'unread'}`}>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -338,14 +338,55 @@ function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
   );
 }
 
+function StreakCard({ streak }) {
+  if (!streak) {
+    return (
+      <div className="pulse-card streak-card">
+        <span>Streak & Momentum</span>
+        <div className="streak-main">
+          <p className="muted">No sessions yet</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { currentStreak, longestStreak, streakBrokenAt, isActive } = streak;
+
+  return (
+    <div className={`pulse-card streak-card ${isActive ? 'streak-active' : ''}`}>
+      <span>Streak & Momentum</span>
+      <div className="streak-main">
+        <strong>{currentStreak}</strong>
+        <div className="compare-list">
+          <b>Personal Best: {longestStreak}</b>
+        </div>
+      </div>
+      
+      {isActive ? (
+        <div className="badge-row">
+          <em className="streak-flame">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"></path></svg>
+            Active Streak
+          </em>
+        </div>
+      ) : (
+        <p className="muted streak-ended">
+          {streakBrokenAt ? `Streak ended after: ${streakBrokenAt}` : 'No active streak'}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function StudentPulse({ profile, badges, nextActions }) {
-  const { student, cohort, attendance, polls, transactions } = profile;
+  const { student, cohort, attendance, polls, transactions, streak } = profile;
   const qualified = attendance.filter(a => a.qualified).length;
   const pollAttempted = polls.reduce((sum, p) => sum + p.attemptedQuestions, 0);
   const pollTotal = polls.reduce((sum, p) => sum + p.totalQuestions, 0);
   const trend = transactions.map(tx => ({ label: tx.sessionLabel || 'Start', value: tx.balanceAfter }));
   return (
     <section className="pulse-grid">
+      <StreakCard streak={streak} />
       <div className="pulse-card progress-card">
         <span>Standing</span>
         <strong>Rank {student.rank}</strong>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -357,11 +357,36 @@ function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
   );
 }
 
-function StreakCard({ streak }) {
+function StreakCard({ streak, student }) {
+  const [freezes, setFreezes] = useState(student?.streakFreezesAvailable || 0);
+  const [buying, setBuying] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setFreezes(student?.streakFreezesAvailable || 0);
+  }, [student?.streakFreezesAvailable]);
+
+  const buyFreeze = async () => {
+    setBuying(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API}/streak-freeze/buy`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to buy');
+      setFreezes(data.streakFreezesAvailable);
+    } catch (err) {
+      setError(err.message);
+    }
+    setBuying(false);
+  };
+
   if (!streak) {
     return (
       <div className="pulse-card streak-card">
-        <span>Streak & Momentum</span>
+        <div className="streak-card-header">
+          <span>Streak & Momentum</span>
+          {freezes > 0 && <span className="streak-freeze-badge">🛡️ {freezes} freeze(s) available</span>}
+        </div>
         <div className="streak-main">
           <p className="muted">No sessions yet</p>
         </div>
@@ -373,7 +398,10 @@ function StreakCard({ streak }) {
 
   return (
     <div className={`pulse-card streak-card ${isActive ? 'streak-active' : ''}`}>
-      <span>Streak & Momentum</span>
+      <div className="streak-card-header">
+        <span>Streak & Momentum</span>
+        {freezes > 0 && <span className="streak-freeze-badge">🛡️ {freezes} freeze(s) available</span>}
+      </div>
       <div className="streak-main">
         <strong>{currentStreak}</strong>
         <div className="compare-list">
@@ -393,6 +421,13 @@ function StreakCard({ streak }) {
           {streakBrokenAt ? `Streak ended after: ${streakBrokenAt}` : 'No active streak'}
         </p>
       )}
+
+      <div className="streak-freeze-action">
+        <button className="streak-freeze-buy" onClick={buyFreeze} disabled={buying}>
+          {buying ? 'Buying...' : 'Buy Freeze (20 SP)'}
+        </button>
+        {error && <span className="streak-freeze-error">{error}</span>}
+      </div>
     </div>
   );
 }
@@ -405,7 +440,7 @@ function StudentPulse({ profile, badges, nextActions }) {
   const trend = transactions.map(tx => ({ label: tx.sessionLabel || 'Start', value: tx.balanceAfter }));
   return (
     <section className="pulse-grid">
-      <StreakCard streak={streak} />
+      <StreakCard streak={streak} student={student} />
       <div className="pulse-card progress-card">
         <span>Standing</span>
         <strong>Rank {student.rank}</strong>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,113 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* Notification Components */
+.notification-bell-badge {
+  background: var(--primary);
+  color: white;
+  border-radius: 50%;
+  padding: 2px 6px;
+  font-size: 12px;
+  margin-left: 4px;
+}
+.notification-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 320px;
+  z-index: 10;
+  margin-top: 8px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.notification-dropdown-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.notification-dropdown-title {
+  margin: 0;
+  font-size: 16px;
+}
+.notification-settings-button {
+  font-size: 12.8px;
+  padding: 4px 8px;
+}
+.notification-item-container {
+  max-height: 300px;
+  overflow-y: auto;
+}
+.notification-item {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+  opacity: 0.6;
+}
+.notification-item.unread {
+  opacity: 1;
+}
+.notification-item-title {
+  margin: 0 0 4px 0;
+  font-weight: normal;
+  font-size: 14.4px;
+}
+.notification-item.unread .notification-item-title {
+  font-weight: bold;
+}
+.notification-item-message {
+  margin: 0;
+  font-size: 12.8px;
+  color: var(--muted);
+}
+.notification-mark-all {
+  width: 100%;
+  margin-top: 16px;
+}
+.notification-settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+.notification-settings-header h1 {
+  margin: 0;
+}
+.notification-settings-lead {
+  margin-bottom: 32px;
+}
+.notification-settings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.notification-settings-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--line);
+}
+.notification-settings-label {
+  font-size: 16.8px;
+}
+.notification-settings-toggles {
+  display: flex;
+  gap: 24px;
+}
+.notification-settings-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+.notification-settings-actions {
+  margin-top: 32px;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -516,6 +516,16 @@ input {
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
 
 /* Notification Components */
+.notification-bell-wrapper {
+  position: relative;
+}
+.notification-bell-button {
+  position: relative;
+}
+.notification-empty-state {
+  margin: 0;
+  font-size: 0.9rem;
+}
 .notification-bell-badge {
   background: var(--primary);
   color: white;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -672,3 +672,37 @@ input {
   margin: 0;
   line-height: 1.4;
 }
+
+.streak-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.streak-freeze-badge {
+  background: var(--panel-hover);
+  color: var(--text);
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: bold;
+  border: 1px solid var(--line);
+}
+
+.streak-freeze-action {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.streak-freeze-buy {
+  font-size: 12px;
+  padding: 6px 12px;
+  align-self: flex-start;
+}
+
+.streak-freeze-error {
+  color: #dc2626;
+  font-size: 12px;
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,41 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* --- Streak feature ---------------------------------------------------- */
+.streak-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.streak-main {
+  margin-bottom: 8px;
+}
+.streak-active {
+  background: linear-gradient(135deg, #ffffff 40%, #eaf6fa 100%);
+}
+.streak-flame {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #e9f2f5;
+  color: var(--primary-dark);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 850;
+  animation: flame-pulse 2s infinite ease-in-out;
+}
+.streak-flame svg {
+  color: #d97706;
+}
+@keyframes flame-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(23, 107, 135, 0.2); }
+  50% { box-shadow: 0 0 0 5px rgba(23, 107, 135, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(23, 107, 135, 0); }
+}
+.streak-ended {
+  font-size: 12px;
+  margin: 0;
+  line-height: 1.4;
+}

--- a/server/config.js
+++ b/server/config.js
@@ -23,6 +23,8 @@ export const SESSION_LABELS = [
   '22 May Evening'
 ];
 
+export const STREAK_FREEZE_COST_SP = 20;
+
 export const SESSION_DURATIONS = {
   '15 May Morning': 250,
   '15 May Evening': 225,

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const notificationSchema = new mongoose.Schema({
+  email: { type: String, required: true, index: true, lowercase: true, trim: true },
+  category: { 
+    type: String, 
+    enum: ['weeklyDigest', 'streakReminders', 'peerActivity', 'announcements'],
+    required: true 
+  },
+  title: { type: String, required: true },
+  message: { type: String, required: true },
+  read: { type: Boolean, default: false, index: true }
+}, { timestamps: true });
+
+export default mongoose.models.Notification || mongoose.model('Notification', notificationSchema);

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
 const notificationSchema = new mongoose.Schema({
-  email: { type: String, required: true, index: true, lowercase: true, trim: true },
+  email: { type: String, required: true, lowercase: true, trim: true },
   category: { 
     type: String, 
     enum: ['weeklyDigest', 'streakReminders', 'peerActivity', 'announcements'],
@@ -9,7 +9,10 @@ const notificationSchema = new mongoose.Schema({
   },
   title: { type: String, required: true },
   message: { type: String, required: true },
-  read: { type: Boolean, default: false, index: true }
+  read: { type: Boolean, default: false }
 }, { timestamps: true });
+
+notificationSchema.index({ email: 1, createdAt: -1 });
+notificationSchema.index({ email: 1, read: 1 });
 
 export default mongoose.models.Notification || mongoose.model('Notification', notificationSchema);

--- a/server/models/NotificationPreference.js
+++ b/server/models/NotificationPreference.js
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+
+const preferenceSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true, index: true, lowercase: true, trim: true },
+  categories: {
+    weeklyDigest: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: false }
+    },
+    streakReminders: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: false }
+    },
+    peerActivity: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: false }
+    },
+    announcements: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: false }
+    }
+  }
+}, { timestamps: true });
+
+export default mongoose.models.NotificationPreference || mongoose.model('NotificationPreference', preferenceSchema);

--- a/server/models/SPTransaction.js
+++ b/server/models/SPTransaction.js
@@ -6,7 +6,7 @@ const spTransactionSchema = new mongoose.Schema({
   category: {
     type: String,
     required: true,
-    enum: ['initial', 'attendance', 'poll', 'manual'],
+    enum: ['initial', 'attendance', 'poll', 'manual', 'streakFreeze'],
     index: true
   },
   sessionLabel: { type: String, default: '', index: true },

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -22,6 +22,8 @@ const studentSchema = new mongoose.Schema({
   surveyCompleted: { type: Boolean, default: false, index: true },
   surveyCompletedAt: { type: Date, default: null },
   lastNotifiedStreakBreak: { type: String, default: null },
+  streakFreezesAvailable: { type: Number, default: 0 },
+  streakProtectedSessions: { type: [String], default: [] },
   // Second perception pop-up ("poll2") — same mechanism as surveyCompleted, but an
   // independent flag so it never disturbs the first survey's completion state.
   poll2Completed: { type: Boolean, default: false, index: true },

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { computeStreak } from './services/streaks.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -164,6 +165,7 @@ async function studentPayload(student) {
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
   ]);
+  const streak = computeStreak(attendance);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
   const top10Cutoff = allStudents[9]?.totalSp || null;
@@ -207,6 +209,7 @@ async function studentPayload(student) {
     transactions,
     polls,
     attendance,
+    streak,
     cohort: {
       averageSp,
       top10Cutoff,

--- a/server/server.js
+++ b/server/server.js
@@ -262,12 +262,17 @@ api.get('/me', async (req, res) => {
   const profile = await studentPayload(student);
   const { streak } = profile;
   
-  if (!streak.isActive && streak.streakBrokenAt && streak.streakBrokenAt !== student.lastNotifiedStreakBreak) {
-    notify(email, 'streakReminders', {
-      title: 'Streak broken',
-      message: `Your attendance streak ended after session ${streak.streakBrokenAt}. Time for a comeback!`
-    }).catch(() => {});
-    Student.updateOne({ _id: student._id }, { $set: { lastNotifiedStreakBreak: streak.streakBrokenAt } }).catch(() => {});
+  if (!streak.isActive && streak.streakBrokenAt) {
+    const claimed = await Student.findOneAndUpdate(
+      { _id: student._id, lastNotifiedStreakBreak: { $ne: streak.streakBrokenAt } },
+      { $set: { lastNotifiedStreakBreak: streak.streakBrokenAt } }
+    );
+    if (claimed) {
+      notify(email, 'streakReminders', {
+        title: 'Streak broken',
+        message: `Your attendance streak ended after session ${streak.streakBrokenAt}. Time for a comeback!`
+      }).catch(() => {});
+    }
   }
 
   res.json({ authenticated: true, profile });

--- a/server/server.js
+++ b/server/server.js
@@ -17,7 +17,7 @@ import Notification from './models/Notification.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import { getOrCreatePreferences, notify } from './services/notifications.js';
 import { computeStreak } from './services/streaks.js';
-import { appendTransaction } from './services/spLedger.js';
+import { appendTransaction, logTransaction } from './services/spLedger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -338,14 +338,14 @@ api.post('/streak-freeze/buy', async (req, res) => {
     return res.status(400).json({ error: 'Not enough SP to buy a streak freeze' });
   }
 
-  await appendTransaction(
+  await logTransaction(
     email,
     'streakFreeze',
     '',
     new Date(),
     -STREAK_FREEZE_COST_SP,
     'Purchased a streak freeze',
-    student.totalSp + STREAK_FREEZE_COST_SP
+    student.totalSp
   ).catch(() => {});
 
   res.json({ streakFreezesAvailable: student.streakFreezesAvailable, totalSp: student.totalSp });

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 
-import { ALLOW_STUDENT_SEARCH, MONGO_URI, PORT, SAMAGAMA_AUTH_URL } from './config.js';
+import { ALLOW_STUDENT_SEARCH, MONGO_URI, PORT, SAMAGAMA_AUTH_URL, STREAK_FREEZE_COST_SP } from './config.js';
 import Student from './models/Student.js';
 import Session from './models/Session.js';
 import AttendanceRecord from './models/AttendanceRecord.js';
@@ -17,6 +17,7 @@ import Notification from './models/Notification.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import { getOrCreatePreferences, notify } from './services/notifications.js';
 import { computeStreak } from './services/streaks.js';
+import { appendTransaction } from './services/spLedger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -190,7 +191,7 @@ async function studentPayload(student) {
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
   ]);
-  const streak = computeStreak(attendance);
+  const streak = computeStreak(attendance, student.streakProtectedSessions || []);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
   const top10Cutoff = allStudents[9]?.totalSp || null;
@@ -230,7 +231,8 @@ async function studentPayload(student) {
       leaderboardGroup: myGroup,
       leaderboardGroupLabel: groupLabel(myGroup),
       surveyCompleted: Boolean(student.surveyCompleted),
-      poll2Completed: Boolean(student.poll2Completed)
+      poll2Completed: Boolean(student.poll2Completed),
+      streakFreezesAvailable: student.streakFreezesAvailable || 0
     },
     transactions,
     polls,
@@ -278,22 +280,75 @@ api.get('/me', async (req, res) => {
   if (student.status === 'excused') return res.json({ authenticated: true, ...excusedPayload(student) });
   
   const profile = await studentPayload(student);
-  const { streak } = profile;
+  let streak = profile.streak;
   
-  if (!streak.isActive && streak.streakBrokenAt) {
+  if (!streak.isActive && streak.streakBrokenAt &&
+      streak.streakBrokenAt !== student.lastNotifiedStreakBreak &&
+      !(student.streakProtectedSessions || []).includes(streak.streakBrokenAt)) {
+
     const claimed = await Student.findOneAndUpdate(
-      { _id: student._id, lastNotifiedStreakBreak: { $ne: streak.streakBrokenAt } },
-      { $set: { lastNotifiedStreakBreak: streak.streakBrokenAt } }
+      {
+        _id: student._id,
+        streakFreezesAvailable: { $gt: 0 },
+        streakProtectedSessions: { $ne: streak.streakBrokenAt }
+      },
+      {
+        $inc: { streakFreezesAvailable: -1 },
+        $addToSet: { streakProtectedSessions: streak.streakBrokenAt }
+      },
+      { new: true }
     );
+
     if (claimed) {
+      streak = computeStreak(profile.attendance, claimed.streakProtectedSessions);
+      profile.streak = streak;
+      profile.student.streakFreezesAvailable = claimed.streakFreezesAvailable;
       notify(email, 'streakReminders', {
-        title: 'Streak broken',
-        message: `Your attendance streak ended after session ${streak.streakBrokenAt}. Time for a comeback!`
+        title: 'Streak freeze used',
+        message: `A streak freeze protected your streak after session ${streak.streakBrokenAt}. You have ${claimed.streakFreezesAvailable} left.`
       }).catch(() => {});
+    } else {
+      const breakClaimed = await Student.findOneAndUpdate(
+        { _id: student._id, lastNotifiedStreakBreak: { $ne: streak.streakBrokenAt } },
+        { $set: { lastNotifiedStreakBreak: streak.streakBrokenAt } }
+      );
+      if (breakClaimed) {
+        notify(email, 'streakReminders', {
+          title: 'Streak broken',
+          message: `Your attendance streak ended after session ${streak.streakBrokenAt}. Time for a comeback!`
+        }).catch(() => {});
+      }
     }
   }
 
   res.json({ authenticated: true, profile });
+});
+
+api.post('/streak-freeze/buy', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Not authenticated' });
+
+  const student = await Student.findOneAndUpdate(
+    { email, totalSp: { $gte: STREAK_FREEZE_COST_SP } },
+    { $inc: { totalSp: -STREAK_FREEZE_COST_SP, streakFreezesAvailable: 1 } },
+    { new: true }
+  );
+
+  if (!student) {
+    return res.status(400).json({ error: 'Not enough SP to buy a streak freeze' });
+  }
+
+  await appendTransaction(
+    email,
+    'streakFreeze',
+    '',
+    new Date(),
+    -STREAK_FREEZE_COST_SP,
+    'Purchased a streak freeze',
+    student.totalSp + STREAK_FREEZE_COST_SP
+  ).catch(() => {});
+
+  res.json({ streakFreezesAvailable: student.streakFreezesAvailable, totalSp: student.totalSp });
 });
 
 api.get('/notifications/preferences', async (req, res) => {
@@ -654,7 +709,7 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
     };
   });
 
-  const categoryTotals = ['initial', 'attendance', 'poll', 'manual'].map(category => {
+  const categoryTotals = ['initial', 'attendance', 'poll', 'manual', 'streakFreeze'].map(category => {
     const rows = activeTransactions.filter(t => t.category === category);
     return {
       category,

--- a/server/server.js
+++ b/server/server.js
@@ -12,7 +12,10 @@ import AttendanceRecord from './models/AttendanceRecord.js';
 import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
+import NotificationPreference from './models/NotificationPreference.js';
+import Notification from './models/Notification.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { getOrCreatePreferences, notify } from './services/notifications.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -248,8 +251,82 @@ api.get('/me', async (req, res) => {
   if (!email) return res.status(401).json({ authenticated: false });
   const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
   if (!student) return res.status(404).json({ authenticated: false, error: 'Student not found' });
+  
+  await getOrCreatePreferences(email);
+
   if (student.status === 'excused') return res.json({ authenticated: true, ...excusedPayload(student) });
   res.json({ authenticated: true, profile: await studentPayload(student) });
+});
+
+api.get('/notifications/preferences', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  const prefs = await getOrCreatePreferences(email);
+  res.json(prefs);
+});
+
+api.put('/notifications/preferences', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  
+  const { categories } = req.body;
+  if (!categories || typeof categories !== 'object') return res.status(400).json({ error: 'Invalid payload' });
+
+  const allowedCategories = ['weeklyDigest', 'streakReminders', 'peerActivity', 'announcements'];
+  const updateQuery = { $set: {} };
+
+  for (const cat of allowedCategories) {
+    if (categories[cat]) {
+      if (typeof categories[cat].inApp === 'boolean') {
+        updateQuery.$set[`categories.${cat}.inApp`] = categories[cat].inApp;
+      }
+      if (typeof categories[cat].email === 'boolean') {
+        updateQuery.$set[`categories.${cat}.email`] = categories[cat].email;
+      }
+    }
+  }
+
+  if (Object.keys(updateQuery.$set).length === 0) return res.status(400).json({ error: 'No valid preferences to update' });
+
+  const prefs = await NotificationPreference.findOneAndUpdate(
+    { email },
+    updateQuery,
+    { new: true }
+  );
+  res.json(prefs);
+});
+
+api.get('/notifications', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  
+  const limit = Math.min(Number(req.query.limit) || 20, 50);
+  const filter = { email };
+  if (req.query.before) filter.createdAt = { $lt: new Date(req.query.before) };
+
+  const notifications = await Notification.find(filter).sort({ createdAt: -1 }).limit(limit).lean();
+  res.json(notifications);
+});
+
+api.post('/notifications/:id/read', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+
+  const notif = await Notification.findOneAndUpdate(
+    { _id: req.params.id, email },
+    { $set: { read: true } },
+    { new: true }
+  );
+  if (!notif) return res.status(404).json({ error: 'Notification not found' });
+  res.json(notif);
+});
+
+api.post('/notifications/read-all', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+
+  await Notification.updateMany({ email, read: false }, { $set: { read: true } });
+  res.json({ ok: true });
 });
 
 api.get('/search', async (req, res) => {

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -2,11 +2,11 @@ import NotificationPreference from '../models/NotificationPreference.js';
 import Notification from '../models/Notification.js';
 
 export async function getOrCreatePreferences(email) {
-  let prefs = await NotificationPreference.findOne({ email });
-  if (!prefs) {
-    prefs = await NotificationPreference.create({ email });
-  }
-  return prefs;
+  return NotificationPreference.findOneAndUpdate(
+    { email },
+    { $setOnInsert: { email } },
+    { new: true, upsert: true }
+  );
 }
 
 export async function notify(email, category, { title, message }) {

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -1,0 +1,27 @@
+import NotificationPreference from '../models/NotificationPreference.js';
+import Notification from '../models/Notification.js';
+
+export async function getOrCreatePreferences(email) {
+  let prefs = await NotificationPreference.findOne({ email });
+  if (!prefs) {
+    prefs = await NotificationPreference.create({ email });
+  }
+  return prefs;
+}
+
+export async function notify(email, category, { title, message }) {
+  const prefs = await getOrCreatePreferences(email);
+  
+  if (prefs.categories[category]?.inApp) {
+    await Notification.create({
+      email,
+      category,
+      title,
+      message
+    });
+  }
+  
+  if (prefs.categories[category]?.email) {
+    // TODO: wire to email service once available
+  }
+}

--- a/server/services/spLedger.js
+++ b/server/services/spLedger.js
@@ -82,10 +82,8 @@ export async function getAllStudentsSummary() {
  * Append a new transaction and update Student.totalSp atomically.
  * Use this when new data arrives (attendance, chat, poll, activity).
  */
-export async function appendTransaction(email, category, sessionLabel, dateTime, delta, reason, currentTotalSp) {
+export async function logTransaction(email, category, sessionLabel, dateTime, delta, reason, balanceAfter) {
   const dt = dateTime instanceof Date ? dateTime : new Date(dateTime);
-  const balanceAfter = (Number(currentTotalSp) || 0) + delta;
-
   const [txn] = await SPTransaction.create([{
     email: email.toLowerCase(),
     category,
@@ -97,6 +95,11 @@ export async function appendTransaction(email, category, sessionLabel, dateTime,
     reason,
     dateTime: dt
   }]);
+  return txn;
+}
+
+export async function appendTransaction(email, category, sessionLabel, dateTime, delta, reason, currentTotalSp) {
+  const balanceAfter = (Number(currentTotalSp) || 0) + delta;
 
   // Atomic update of student totalSp
   await Student.updateOne(
@@ -104,7 +107,7 @@ export async function appendTransaction(email, category, sessionLabel, dateTime,
     { $inc: { totalSp: delta } }
   );
 
-  return txn;
+  return await logTransaction(email, category, sessionLabel, dateTime, delta, reason, balanceAfter);
 }
 
 function maskEmail(email) {

--- a/server/services/spLedger.js
+++ b/server/services/spLedger.js
@@ -82,18 +82,20 @@ export async function getAllStudentsSummary() {
  * Append a new transaction and update Student.totalSp atomically.
  * Use this when new data arrives (attendance, chat, poll, activity).
  */
-export async function appendTransaction(email, category, sessionLabel, sessionDatetime, delta, reason, ingestedFrom) {
-  const sessionDt = sessionDatetime instanceof Date ? sessionDatetime : new Date(sessionDatetime);
+export async function appendTransaction(email, category, sessionLabel, dateTime, delta, reason, currentTotalSp) {
+  const dt = dateTime instanceof Date ? dateTime : new Date(dateTime);
+  const balanceAfter = (Number(currentTotalSp) || 0) + delta;
 
   const [txn] = await SPTransaction.create([{
     email: email.toLowerCase(),
     category,
     sessionLabel,
-    sessionDatetime: sessionDt,
-    delta,
+    deltaMode: 'absolute',
+    deltaValue: delta,
+    appliedDelta: delta,
+    balanceAfter,
     reason,
-    recordedAt: new Date(),
-    ingestedFrom
+    dateTime: dt
   }]);
 
   // Atomic update of student totalSp

--- a/server/services/streaks.js
+++ b/server/services/streaks.js
@@ -1,0 +1,52 @@
+/**
+ * Spurti Attendance Streak Tracking.
+ *
+ * This is a DERIVED VIEW over the existing attendance data — a pure function, no DB,
+ * no side effects. It computes the student's streak status from an already-fetched
+ * array of their attendance records.
+ */
+
+export function computeStreak(attendanceRecords) {
+  if (!attendanceRecords || attendanceRecords.length === 0) {
+    return {
+      currentStreak: 0,
+      longestStreak: 0,
+      streakBrokenAt: null,
+      isActive: false
+    };
+  }
+
+  // Defensively sort the input by sessionLabel ascending without mutating original array.
+  const sorted = [...attendanceRecords].sort((a, b) => {
+    if (a.sessionLabel < b.sessionLabel) return -1;
+    if (a.sessionLabel > b.sessionLabel) return 1;
+    return 0;
+  });
+
+  let currentStreak = 0;
+  let longestStreak = 0;
+  let isActive = false;
+  let streakBrokenAt = null;
+
+  for (const record of sorted) {
+    if (record.qualified) {
+      currentStreak++;
+      isActive = true;
+      streakBrokenAt = null;
+      if (currentStreak > longestStreak) {
+        longestStreak = currentStreak;
+      }
+    } else {
+      currentStreak = 0;
+      isActive = false;
+      streakBrokenAt = record.sessionLabel;
+    }
+  }
+
+  return {
+    currentStreak,
+    longestStreak,
+    streakBrokenAt,
+    isActive
+  };
+}

--- a/server/services/streaks.js
+++ b/server/services/streaks.js
@@ -6,7 +6,7 @@
  * array of their attendance records.
  */
 
-export function computeStreak(attendanceRecords) {
+export function computeStreak(attendanceRecords, protectedSessionLabels = []) {
   if (!attendanceRecords || attendanceRecords.length === 0) {
     return {
       currentStreak: 0,
@@ -28,6 +28,8 @@ export function computeStreak(attendanceRecords) {
   let isActive = false;
   let streakBrokenAt = null;
 
+  const protectedSet = new Set(protectedSessionLabels);
+
   for (const record of sorted) {
     if (record.qualified) {
       currentStreak++;
@@ -36,6 +38,10 @@ export function computeStreak(attendanceRecords) {
       if (currentStreak > longestStreak) {
         longestStreak = currentStreak;
       }
+    } else if (protectedSet.has(record.sessionLabel)) {
+      // Frozen session — does not break the streak, does not extend it either.
+      // Skip entirely: currentStreak, isActive, longestStreak, streakBrokenAt unchanged.
+      continue;
     } else {
       currentStreak = 0;
       isActive = false;


### PR DESCRIPTION
## Description

Depends on #45 (notify() service) and #48 (streak-break detection, Student schema fields,
lastNotifiedStreakBreak pattern) — this branch is stacked on feature/streak-break-alerts.

## What this adds
A student can spend 20 SP to buy a "streak freeze." If their attendance streak would
otherwise break on a missed session, an available freeze automatically protects it instead —
the streak continues rather than resetting to zero, and the student is notified either way
(freeze used, or streak broken as before if no freeze was available).

This is the first feature to genuinely connect three existing systems in this codebase:
attendance streak tracking (#8/#48), the SP economy (sp.js/spLedger.js), and the
notification service (#45) — turning them into one coherent mechanic rather than three
separate features.

## How it works
- `computeStreak()` (server/services/streaks.js) gained an optional second parameter,
  `protectedSessionLabels` — defaults to `[]` so existing behavior is unchanged for any
  other caller. A session in this list is skipped entirely for streak-breaking purposes
  (neither breaks nor extends the streak). Stays a pure function — no DB access added.
- Two new fields on Student: `streakFreezesAvailable` (unused freeze count) and
  `streakProtectedSessions` (session labels already protected, making protection idempotent
  across repeated recomputation).
- Buying a freeze (`POST /streak-freeze/buy`) atomically checks and decrements `totalSp` via
  a `$gte` guard (same pattern as the earlier race-condition fixes in this codebase — prevents
  concurrent purchases from pushing a balance negative).
- Consuming a freeze happens in the `/api/me` handler, right where #48's break-detection
  already lives: if a break is newly detected and a freeze is available, it's claimed
  atomically (`$gt: 0` + `$ne` guard) and the streak is recomputed as protected. If no freeze
  is available, it falls through unchanged to #48's existing break-notification logic.

## Bugs found and fixed along the way
- `appendTransaction` in spLedger.js was dead code (zero existing callers) and broken — it
  wrote fields (`sessionDatetime`, `delta`, `recordedAt`, `ingestedFrom`) that don't exist on
  the actual `SPTransaction` schema, which requires `deltaValue`, `appliedDelta`,
  `balanceAfter`, `dateTime`. Fixed to match the real schema, and split into two functions:
  `logTransaction` (pure ledger write) and `appendTransaction` (atomic apply + log), since the
  freeze-purchase route needed to log a transaction *without* re-applying a delta it had
  already applied atomically itself — calling the original all-in-one version would have
  silently double-charged the student.
- Added `'streakFreeze'` to the `SPTransaction` category enum and to the admin dashboard's
  category breakdown aggregation (`server.js`), so freeze purchases report correctly
  alongside attendance/poll/manual categories.

## Scope
No changes to `computeStreak`'s existing callers' behavior (verified via the default
parameter). No changes to #48's break-notification path other than slotting the freeze-check
ahead of it. UI: a badge + "Buy Freeze (20 SP)" button on the existing StreakCard component,
using class-based styling consistent with #45/#48 (no inline styles).