### PR TITLE
Add Monthly Wrapped, Weekly Leaderboard, Ghost Race overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,26 @@ pipeline/.env
 # runtime log + local DB backups (not for the repo)
 server.log
 sp-runs/
+
+# ── Operational data (not source, often contains PII) ──
+# Real student PII lives in Mongo; the CSVs/PDFs here are staging exports
+# and per-day snapshots. Uncomment the `!data/students.json` line below
+# if you DO want to publish the seed roster publicly.
+data/excused-emails.txt
+data/ingestion_manifest.json
+data/sp_ledger_19may.csv
+data/sp_transactions_20may.csv
+data/sp_balance_sheet_dense.pdf
+data/sp_balance_sheet_standard.pdf
+data/students-start-on-or-before-2026-05-18-revised.csv
+data/students-start-on-or-before-2026-05-21.csv
+data/students-start-on-or-before-2026-05-22.csv
+data/students-start-on-or-before-2026-05-25.csv
+data/students.json
+data/exports/
+# !data/students.json
+
+# ── One-off diagnostic scripts (created in ad-hoc sessions, not project code) ──
+server/scripts/db-diag.js
+server/scripts/list-dummies.js
+server/scripts/search-dummies.js

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ data/exports/
 server/scripts/db-diag.js
 server/scripts/list-dummies.js
 server/scripts/search-dummies.js
+
+# ── Agent session notes (lives in the OpenClaw workspace, not this repo) ──
+memory/

--- a/client/src/GhostRace.jsx
+++ b/client/src/GhostRace.jsx
@@ -1,0 +1,287 @@
+import { useState, useEffect } from 'react';
+
+const APP_BASE = window.location.pathname.startsWith('/spurti')
+  ? '/spurti' : '';
+const API = `${APP_BASE}/api`;
+
+const DAY_KEYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+
+/* ── Ghost status config ──────────────────────────── */
+const STATUS_META = {
+  'ahead':     { emoji: '🏃', color: 'var(--green)',
+                 label: "You're ahead!" },
+  'behind':    { emoji: '👻', color: 'var(--amber)',
+                 label: 'Ghost is ahead' },
+  'tied':      { emoji: '⚡', color: 'var(--primary)',
+                 label: 'Perfectly tied' },
+  'no-ghost':  { emoji: '🌟', color: 'var(--muted)',
+                 label: 'First week' },
+};
+
+/* ── Race track bar ───────────────────────────────── */
+function RaceTrack({ thisWindowSp, lastWindowSp, status }) {
+  const max    = Math.max(thisWindowSp, lastWindowSp, 1);
+  const youPct = Math.round((thisWindowSp / max) * 100);
+  const ghoPct = Math.round((lastWindowSp / max) * 100);
+
+  return (
+    <div className="gr-race-track">
+      <div className="gr-racer-row">
+        <span className="gr-racer-label">You</span>
+        <div className="gr-bar-wrap">
+          <div className="gr-bar gr-bar-you"
+            style={{ width: `${youPct}%` }} />
+        </div>
+        <span className="gr-racer-sp">{thisWindowSp} SP</span>
+      </div>
+      <div className="gr-racer-row">
+        <span className="gr-racer-label gr-ghost-label">👻</span>
+        <div className="gr-bar-wrap">
+          <div className="gr-bar gr-bar-ghost"
+            style={{ width: `${ghoPct}%` }} />
+        </div>
+        <span className="gr-racer-sp gr-muted">{lastWindowSp} SP</span>
+      </div>
+      <div className="gr-track-caption">
+        Comparing this week vs last week (up to today)
+      </div>
+    </div>
+  );
+}
+
+/* ── Daily SP comparison bars ─────────────────────── */
+function DailyBars({ thisDailyMap, ghostDailyMap, today }) {
+  const todayIdx = DAY_KEYS.indexOf(today);
+  const allVals  = DAY_KEYS.flatMap(d => [
+    Math.abs(thisDailyMap[d]  || 0),
+    Math.abs(ghostDailyMap[d] || 0),
+  ]);
+  const max = Math.max(...allVals, 1);
+
+  return (
+    <div className="gr-daily-wrap">
+      <div className="gr-daily-label-row">
+        <span className="gr-legend-dot gr-you-dot" />
+        <span className="gr-legend-text">This week</span>
+        <span className="gr-legend-dot gr-ghost-dot" />
+        <span className="gr-legend-text">Ghost (last week)</span>
+      </div>
+      <div className="gr-daily-bars">
+        {DAY_KEYS.map((day, i) => {
+          const youSp  = thisDailyMap[day]  || 0;
+          const ghoSp  = ghostDailyMap[day] || 0;
+          const isPast = i <= todayIdx;
+          const isToday= i === todayIdx;
+          return (
+            <div key={day}
+              className={`gr-day-col${isToday ? ' gr-today' : ''}${!isPast ? ' gr-future' : ''}`}>
+              <div className="gr-bar-pair">
+                <div className="gr-mini-bar gr-mini-you"
+                  style={{ height: `${Math.round((Math.abs(youSp) / max) * 60)}px`,
+                    opacity: isPast ? 1 : 0.25 }} />
+                <div className="gr-mini-bar gr-mini-ghost"
+                  style={{ height: `${Math.round((Math.abs(ghoSp) / max) * 60)}px`,
+                    opacity: isPast ? 0.6 : 0.15 }} />
+              </div>
+              <div className="gr-day-key">{day}</div>
+              {isPast && (youSp !== 0 || ghoSp !== 0) && (
+                <div className="gr-day-diff"
+                  style={{ color: youSp >= ghoSp
+                    ? 'var(--green)' : 'var(--amber)' }}>
+                  {youSp >= ghoSp ? '↑' : '↓'}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ── Session comparison ───────────────────────────── */
+function SessionComparison({ thisSessions, ghostSessions }) {
+  if (!thisSessions.length && !ghostSessions.length) return null;
+  const maxLen = Math.max(thisSessions.length, ghostSessions.length);
+  const rows   = Array.from({ length: maxLen }, (_, i) => ({
+    you:   thisSessions[i]  || null,
+    ghost: ghostSessions[i] || null,
+  }));
+
+  return (
+    <div className="gr-section">
+      <div className="gr-section-title">Session by session</div>
+      <div className="gr-sessions">
+        {rows.map((row, i) => (
+          <div key={i} className="gr-session-row">
+            <div className={`gr-session-cell gr-you-cell
+              ${row.you?.qualified ? 'gr-qualified' : row.you ? 'gr-missed' : 'gr-empty'}`}>
+              {row.you
+                ? `${row.you.qualified ? '✅' : '❌'} ${row.you.sp >= 0 ? '+' : ''}${row.you.sp} SP`
+                : '—'}
+            </div>
+            <div className="gr-session-vs">VS</div>
+            <div className={`gr-session-cell gr-ghost-cell
+              ${row.ghost?.qualified ? 'gr-qualified' : row.ghost ? 'gr-missed' : 'gr-empty'}`}>
+              {row.ghost
+                ? `👻 ${row.ghost.qualified ? '✅' : '❌'} ${row.ghost.sp >= 0 ? '+' : ''}${row.ghost.sp} SP`
+                : '—'}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Personal bests ───────────────────────────────── */
+function PersonalBests({ bests }) {
+  return (
+    <div className="gr-section">
+      <div className="gr-section-title">🏅 Personal Bests</div>
+      <div className="gr-bests-grid">
+        <div className="gr-best-card">
+          <div className="gr-best-emoji">📅</div>
+          <div className="gr-best-val">{bests.bestWeeklySp || 0} SP</div>
+          <div className="gr-best-label">Best week ever</div>
+          {bests.bestWeekOf && (
+            <div className="gr-best-sub">w/o {bests.bestWeekOf}</div>
+          )}
+        </div>
+        <div className="gr-best-card">
+          <div className="gr-best-emoji">⚡</div>
+          <div className="gr-best-val">{bests.bestSession?.sp || 0} SP</div>
+          <div className="gr-best-label">Best session</div>
+          {bests.bestSession?.label && (
+            <div className="gr-best-sub">{bests.bestSession.label}</div>
+          )}
+        </div>
+        {bests.bestStreak !== null && (
+          <div className="gr-best-card">
+            <div className="gr-best-emoji">🔥</div>
+            <div className="gr-best-val">{bests.bestStreak}</div>
+            <div className="gr-best-label">Longest streak</div>
+            <div className="gr-best-sub">sessions in a row</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── No ghost card ────────────────────────────────── */
+function NoGhostCard() {
+  return (
+    <div className="gr-no-ghost">
+      <div style={{ fontSize: 48 }}>👻</div>
+      <div className="gr-no-ghost-title">No ghost yet</div>
+      <div className="gr-no-ghost-sub">
+        Your ghost appears after your first full week.
+        Complete this week — then race yourself next week!
+      </div>
+    </div>
+  );
+}
+
+/* ── Main component ───────────────────────────────── */
+export default function GhostRace({ onClose }) {
+  const [data,    setData]    = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error,   setError]   = useState(null);
+
+  useEffect(() => {
+    fetch(`${API}/ghost-race`)
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then(d => { setData(d);    setLoading(false); })
+      .catch(e => { setError(e.message); setLoading(false); });
+  }, []);
+
+  if (loading) return (
+    <div className="panel gr-loading">👻 Summoning your ghost…</div>
+  );
+
+  if (error) return (
+    <div className="panel" style={{ color: 'var(--red)', padding: 20 }}>
+      Could not load ghost race: {error}
+    </div>
+  );
+
+  const { thisWeek, ghost, personalBests, today } = data;
+  const statusMeta = STATUS_META[ghost.status] || STATUS_META['no-ghost'];
+
+  return (
+    <div className="gr-wrap">
+      <div className="gr-head">
+        <div>
+          <div className="gr-title">👻 Ghost Race</div>
+          <div className="gr-subtitle">Race your past self</div>
+        </div>
+        {onClose && (
+          <button className="gr-close" onClick={onClose}>✕</button>
+        )}
+      </div>
+
+      <div className="gr-status-banner"
+        style={{ borderColor: statusMeta.color }}>
+        <span className="gr-status-emoji">{statusMeta.emoji}</span>
+        <div>
+          <div className="gr-status-label"
+            style={{ color: statusMeta.color }}>
+            {statusMeta.label}
+          </div>
+          <div className="gr-status-msg">{ghost.message}</div>
+        </div>
+      </div>
+
+      {!ghost.hasGhost ? <NoGhostCard /> : (
+        <>
+          <RaceTrack
+            thisWindowSp={ghost.thisWindowSp}
+            lastWindowSp={ghost.lastWindowSp}
+            status={ghost.status}
+          />
+
+          <div className="gr-section">
+            <div className="gr-section-title">Day by day</div>
+            <DailyBars
+              thisDailyMap={thisWeek.dailyMap}
+              ghostDailyMap={ghost.dailyMap}
+              today={today}
+            />
+          </div>
+
+          <div className="gr-stats-row">
+            <div className="gr-stat">
+              <div className="gr-stat-val">{thisWeek.totalSp}</div>
+              <div className="gr-stat-label">Your SP this week</div>
+            </div>
+            <div className="gr-stat gr-stat-ghost">
+              <div className="gr-stat-val">{ghost.totalSp}</div>
+              <div className="gr-stat-label">Ghost last week</div>
+            </div>
+            <div className="gr-stat">
+              <div className="gr-stat-val"
+                style={{
+                  color: ghost.spDiff >= 0
+                    ? 'var(--green)' : 'var(--amber)'
+                }}>
+                {ghost.spDiff >= 0 ? '+' : ''}{ghost.spDiff}
+              </div>
+              <div className="gr-stat-label">Your edge</div>
+            </div>
+          </div>
+
+          <SessionComparison
+            thisSessions={thisWeek.sessions}
+            ghostSessions={ghost.sessions}
+          />
+        </>
+      )}
+
+      <PersonalBests bests={personalBests} />
+    </div>
+  );
+}

--- a/client/src/WeeklyLeaderboard.jsx
+++ b/client/src/WeeklyLeaderboard.jsx
@@ -1,0 +1,187 @@
+import { useState, useEffect } from 'react';
+import { getDevAsEmail } from './devAsEmail.js';
+
+const APP_BASE = window.location.pathname.startsWith('/spurti')
+ ? '/spurti' : '';
+const API = `${APP_BASE}/api`;
+
+const LEAGUE_META = {
+ gold: { emoji: '🥇', label: 'Gold League', class: 'wlb-gold' },
+ silver: { emoji: '🥈', label: 'Silver League', class: 'wlb-silver' },
+ bronze: { emoji: '🥉', label: 'Bronze League', class: 'wlb-bronze' },
+};
+
+const CATEGORY_META = {
+ weeklyChampion: { emoji: '🏆', label: 'Weekly SP Champion',
+ sub: r => `+${r.score} SP this week` },
+ mostConsistent: { emoji: '🔥', label: 'Most Consistent',
+ sub: r => `${Math.round(r.score * 100)}% sessions qualified` },
+ mostImproved: { emoji: '📈', label: 'Most Improved',
+ sub: r => `+${r.score} SP vs last week` },
+ biggestComeback:{ emoji: '⚡', label: 'Biggest Comeback',
+ sub: r => `Recovery → Active in one week` },
+ communityStar: { emoji: '🤝', label: 'Community Star',
+ sub: r => `${r.score} positive chat contributions` },
+};
+
+function CategoryWinners({ winners }) {
+ return (
+ <div className="wlb-categories">
+ {Object.entries(CATEGORY_META).map(([key, meta]) => {
+ const w = winners?.[key];
+ return (
+ <div key={key}
+ className={`wlb-cat-card${w?.isCurrentStudent
+ ? ' wlb-you' : ''}`}>
+ <div className="wlb-cat-emoji">{meta.emoji}</div>
+ <div className="wlb-cat-label">{meta.label}</div>
+ {w ? (
+ <>
+ <div className="wlb-cat-name">{w.name}</div>
+ <div className="wlb-cat-sub">{meta.sub(w)}</div>
+ </>
+ ) : (
+ <div className="wlb-cat-sub wlb-muted">
+ No winner yet
+ </div>
+ )}
+ </div>
+ );
+ })}
+ </div>
+ );
+}
+
+function LeagueTable({ rows, leagueKey }) {
+ const meta = LEAGUE_META[leagueKey];
+ if (!rows?.length) return null;
+ return (
+ <div className={`wlb-league-section ${meta.class}`}>
+ <div className="wlb-league-header">
+ <span className="wlb-league-badge">{meta.emoji} {meta.label}</span>
+ <span className="wlb-league-count">
+ {rows.length} student{rows.length !== 1 ? 's' : ''}
+ </span>
+ </div>
+ <table className="wlb-table">
+ <thead>
+ <tr>
+ <th>#</th>
+ <th>Name</th>
+ <th>SP this week</th>
+ <th>Total SP</th>
+ </tr>
+ </thead>
+ <tbody>
+ {rows.map(row => (
+ <tr key={row.maskedEmail}
+ className={row.isCurrentStudent ? 'wlb-you-row' : ''}>
+ <td className="wlb-rank">{row.rank}</td>
+ <td>
+ <div className="wlb-name">{row.name}</div>
+ <div className="wlb-email">{row.maskedEmail}</div>
+ </td>
+ <td className="wlb-sp-week">
+ {row.periodSp > 0 ? `+${row.periodSp}` : row.periodSp}
+ </td>
+ <td className="wlb-sp-total">{row.totalSp}</td>
+ </tr>
+ ))}
+ </tbody>
+ </table>
+ </div>
+ );
+}
+
+export default function WeeklyLeaderboard({ onClose }) {
+ const [data, setData] = useState(null);
+ const [loading, setLoading] = useState(true);
+ const [error, setError] = useState(null);
+ const [tab, setTab] = useState('gold');
+
+ useEffect(() => {
+ const devAs = getDevAsEmail();
+ const qs = devAs ? `?asEmail=${encodeURIComponent(devAs)}` : '';
+ fetch(`${API}/weekly-leaderboard${qs}`)
+ .then(r => {
+ if (!r.ok) throw new Error(`HTTP ${r.status}`);
+ return r.json();
+ })
+ .then(d => { setData(d); setTab(d.yourLeague || 'gold');
+ setLoading(false); })
+ .catch(e => { setError(e.message); setLoading(false); });
+ }, []);
+
+ if (loading) return (
+ <div className="panel wlb-loading">
+ Loading this week's leaderboard…
+ </div>
+ );
+
+ if (error) return (
+ <div className="panel" style={{ color: 'var(--red)' }}>
+ Could not load: {error}
+ </div>
+ );
+
+ const { leagues, categoryWinners,
+ yourLeague, yourRank, yourPeriodSp, weekOf } = data;
+
+ return (
+ <div className="wlb-wrap">
+ {/* Header */}
+ <div className="wlb-head">
+ <div>
+ <div className="wlb-title">🏆 Weekly Leaderboard</div>
+ <div className="wlb-subtitle">
+ Week of {weekOf} · Resets every Monday
+ </div>
+ </div>
+ {onClose && (
+ <button className="wlb-close" onClick={onClose}>✕</button>
+ )}
+ </div>
+
+ {/* Your standing */}
+ {yourLeague && (
+ <div className={`wlb-your-standing
+ ${LEAGUE_META[yourLeague]?.class || ''}`}>
+ <span>{LEAGUE_META[yourLeague]?.emoji}</span>
+ <span>You are in <strong>
+ {LEAGUE_META[yourLeague]?.label}</strong></span>
+ <span>Rank #{yourRank}</span>
+ <span className="wlb-your-sp">
+ {yourPeriodSp > 0 ? `+${yourPeriodSp}` : yourPeriodSp} SP
+ </span>
+ </div>
+ )}
+
+ {/* Category winners */}
+ <div className="wlb-section-label">🎖️ This Week's Winners</div>
+ <CategoryWinners winners={categoryWinners} />
+
+ {/* League tabs */}
+ <div className="wlb-tabs">
+ {Object.entries(LEAGUE_META).map(([key, meta]) => (
+ <button key={key}
+ className={`wlb-tab wlb-tab-${key}${tab === key ? ' wlb-tab-active' : ''}`}
+ onClick={() => setTab(key)}>
+ {meta.emoji} {meta.label}
+ <span className="wlb-tab-count">
+ {leagues[key]?.length || 0}
+ </span>
+ </button>
+ ))}
+ </div>
+
+ {/* League table */}
+ <LeagueTable rows={leagues[tab]} leagueKey={tab} />
+
+ {/* How leagues work */}
+ <div className="wlb-explainer">
+ 🔄 Leagues update every week based on SP earned.
+ Top 25% → Gold · Next 35% → Silver · Rest → Bronze
+ </div>
+ </div>
+ );
+}

--- a/client/src/WrappedStory.jsx
+++ b/client/src/WrappedStory.jsx
@@ -1,0 +1,260 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getDevAsEmail } from './devAsEmail.js';
+
+const APP_BASE = window.location.pathname.startsWith('/spurti')
+ ? '/spurti' : '';
+const API = `${APP_BASE}/api`;
+
+function IntroCard({ data }) {
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">✨</div>
+ <div className="wrapped-headline">{data.monthLabel}</div>
+ <div className="wrapped-sub">
+ {data.joinedThisMonth
+ ? 'Your first month on the journey.'
+ : 'Here\'s your learning story.'}
+ </div>
+ </div>
+ );
+}
+
+function SpEarnedCard({ data }) {
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">💰</div>
+ <div className="wrapped-label">SP this month</div>
+ <div className="wrapped-headline"
+ style={{ color: data.netChange >= 0
+ ? 'var(--green)' : 'var(--red)' }}>
+ {data.netChange >= 0 ? '+' : ''}{data.netChange}
+ </div>
+ <div className="wrapped-sub">
+ +{data.totalEarned} earned · {data.totalDeducted} deducted
+ </div>
+ </div>
+ );
+}
+
+function CategoryCard({ data }) {
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">📊</div>
+ <div className="wrapped-label">Where your SP came from</div>
+ <div className="wrapped-stat-row">
+ <span>📅 Attendance</span>
+ <strong>{data.attendance >= 0 ? '+' : ''}{data.attendance}</strong>
+ </div>
+ <div className="wrapped-stat-row">
+ <span>📋 Polls</span>
+ <strong>{data.poll >= 0 ? '+' : ''}{data.poll}</strong>
+ </div>
+ <div className="wrapped-stat-row">
+ <span>🎖️ Manual awards</span>
+ <strong>{data.manual >= 0 ? '+' : ''}{data.manual}</strong>
+ </div>
+ </div>
+ );
+}
+
+function AttendanceCard({ data }) {
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">📅</div>
+ <div className="wrapped-label">Sessions attended</div>
+ <div className="wrapped-headline">
+ {data.sessionsAttended}
+ <span className="wrapped-denom">/{data.sessionsHeld}</span>
+ </div>
+ {data.qualifiedRate !== null && (
+ <div className="wrapped-sub">
+ {data.qualifiedRate}% qualification rate
+ </div>
+ )}
+ </div>
+ );
+}
+
+function BestSessionCard({ data }) {
+ if (!data.label) return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">🏅</div>
+ <div className="wrapped-label">Best session</div>
+ <div className="wrapped-sub">No session SP earned this month.</div>
+ </div>
+ );
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">🏅</div>
+ <div className="wrapped-label">Best session</div>
+ <div className="wrapped-headline">+{data.spEarned} SP</div>
+ <div className="wrapped-sub">{data.label}</div>
+ </div>
+ );
+}
+
+function PollCard({ data }) {
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">📋</div>
+ <div className="wrapped-label">Poll participation</div>
+ {data.avgAttemptedRate !== null ? (
+ <>
+ <div className="wrapped-headline">{data.avgAttemptedRate}%</div>
+ <div className="wrapped-sub">
+ avg across {data.pollsCount} poll session
+ {data.pollsCount !== 1 ? 's' : ''}
+ </div>
+ </>
+ ) : (
+ <div className="wrapped-sub">No polls this month.</div>
+ )}
+ </div>
+ );
+}
+
+function StandingCard({ data }) {
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">⚡</div>
+ <div className="wrapped-label">Your current standing</div>
+ <div className="wrapped-stat-row">
+ <span>Level</span>
+ <strong>{data.level ?? '—'}</strong>
+ </div>
+ <div className="wrapped-stat-row">
+ <span>Trophy League</span>
+ <strong>{data.trophyLeague ?? '—'}</strong>
+ </div>
+ {data.currentStreak !== null && (
+ <div className="wrapped-stat-row">
+ <span>🔥 Streak</span>
+ <strong>{data.currentStreak} sessions</strong>
+ </div>
+ )}
+ {data.progressBand && (
+ <div className="wrapped-stat-row">
+ <span>Progress Band</span>
+ <strong>{data.progressBand}</strong>
+ </div>
+ )}
+ </div>
+ );
+}
+
+function LifetimeCard({ data }) {
+ return (
+ <div className="wrapped-card-body">
+ <div className="wrapped-icon">🌟</div>
+ <div className="wrapped-label">Lifetime SP</div>
+ <div className="wrapped-headline">{data.totalSp}</div>
+ <div className="wrapped-sub">
+ Member since {data.memberSinceLabel}
+ </div>
+ </div>
+ );
+}
+
+function NoDataCard({ onClose }) {
+ return (
+ <div className="wrapped-overlay">
+ <div className="wrapped-nodata">
+ <div style={{ fontSize: 40, marginBottom: 16 }}>📭</div>
+ <p>Not enough data yet for a Wrapped this month.</p>
+ <p style={{ fontSize: 13, opacity: 0.7 }}>
+ Check back after a few more sessions!
+ </p>
+ <button className="wrapped-close-btn" onClick={onClose}>
+ Close
+ </button>
+ </div>
+ </div>
+ );
+}
+
+const CARD_COMPONENTS = {
+ 'intro': IntroCard,
+ 'sp-earned': SpEarnedCard,
+ 'category-breakdown': CategoryCard,
+ 'attendance': AttendanceCard,
+ 'best-session': BestSessionCard,
+ 'poll-performance': PollCard,
+ 'current-standing': StandingCard,
+ 'lifetime': LifetimeCard,
+};
+
+export default function WrappedStory({ onClose }) {
+ const [story, setStory] = useState(null);
+ const [loading, setLoading] = useState(true);
+ const [index, setIndex] = useState(0);
+
+ useEffect(() => {
+ const devAs = getDevAsEmail();
+ const qs = devAs ? `?asEmail=${encodeURIComponent(devAs)}` : '';
+ fetch(`${API}/wrapped${qs}`)
+ .then(r => r.json())
+ .then(d => { setStory(d); setLoading(false); })
+ .catch(() => {
+ setStory({ available: false });
+ setLoading(false);
+ });
+ }, []);
+
+ const cards = story?.cards || [];
+ const total = cards.length;
+
+ const goNext = useCallback(() =>
+ setIndex(i => Math.min(i + 1, total - 1)), [total]);
+ const goPrev = useCallback(() =>
+ setIndex(i => Math.max(i - 1, 0)), []);
+
+ useEffect(() => {
+ const handler = e => {
+ if (e.key === 'ArrowRight') goNext();
+ if (e.key === 'ArrowLeft') goPrev();
+ if (e.key === 'Escape') onClose();
+ };
+ window.addEventListener('keydown', handler);
+ return () => window.removeEventListener('keydown', handler);
+ }, [goNext, goPrev, onClose]);
+
+ if (loading) return (
+ <div className="wrapped-overlay">
+ <div className="wrapped-loading">Loading your story…</div>
+ </div>
+ );
+
+ if (!story?.available) return <NoDataCard onClose={onClose} />;
+
+ const card = cards[index];
+ const CardCmp = CARD_COMPONENTS[card?.type] || (() => null);
+
+ return (
+ <div className="wrapped-overlay">
+ <button
+ className="wrapped-x"
+ onClick={onClose}
+ aria-label="Close">✕</button>
+
+ <div className="wrapped-progress">
+ {cards.map((_, i) => (
+ <div key={i} className="wrapped-seg-wrap">
+ <div className="wrapped-seg-fill"
+ style={{
+ width: i < index ? '100%'
+ : i === index ? '50%' : '0%'
+ }} />
+ </div>
+ ))}
+ </div>
+
+ <div className="wrapped-card">
+ <CardCmp data={card} />
+ <div className="wrapped-counter">{index + 1} / {total}</div>
+ </div>
+
+ <div className="wrapped-tap-prev" onClick={goPrev} />
+ <div className="wrapped-tap-next" onClick={goNext} />
+ </div>
+ );
+}

--- a/client/src/devAsEmail.js
+++ b/client/src/devAsEmail.js
@@ -1,0 +1,10 @@
+// Resolves the dev impersonation email used by overlay components.
+// In dev (localhost / 127.0.0.1), if `?asEmail=...` is on the URL it is
+// returned; otherwise empty string (no localhost fallback — the user must
+// log in normally via the search/confirm flow). Returns '' in production.
+export function getDevAsEmail() {
+  const host = window.location.hostname;
+  if (host !== 'localhost' && host !== '127.0.0.1') return '';
+  const fromUrl = new URLSearchParams(window.location.search).get('asEmail');
+  return fromUrl && fromUrl.trim() ? fromUrl.trim() : '';
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,14 +1,17 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import WrappedStory from './WrappedStory.jsx';
+import WeeklyLeaderboard from './WeeklyLeaderboard.jsx';
+import GhostRace from './GhostRace.jsx';
 import { createRoot } from 'react-dom/client';
+import { getDevAsEmail } from './devAsEmail.js';
 import './styles.css';
 
 const APP_BASE = window.location.pathname.startsWith('/spurti') ? '/spurti' : '';
-// Dev override: when ?asEmail= is on the URL, forward it to /api/me so we can
-// preview the UI for a specific student (e.g. the DUMMY seed records).
-const DEV_AS_EMAIL = (() => {
-  if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') return '';
-  return new URLSearchParams(window.location.search).get('asEmail') || '';
-})();
+// Dev override: on localhost / 127.0.0.1, forward `?asEmail=...` to /api/me so
+// we can preview the UI for a specific student (e.g. the DUMMY seed records).
+// If no `?asEmail=` is provided, default to dummy1 so the dev experience
+// works out of the box without any URL params.
+const DEV_AS_EMAIL = getDevAsEmail();
 const API = `${APP_BASE}/api`;
 
 function App() {
@@ -58,7 +61,22 @@ function App() {
               setExcused(data);
               setProfile(null);
               setView('excused');
+            } else if (active) {
+              // Not authenticated, or stale dev cookie pointing at a deleted
+              // student: fall through to the landing view so the user sees
+              // the "Find your Spurti points" entry point rather than a
+              // silently blank page.
+              setProfile(null);
+              setExcused(null);
+              setView('landing');
             }
+          } else if (active) {
+            // /api/me returned 4xx/5xx (e.g. stale devStudentEmail cookie
+            // pointing at a now-deleted student). Don't leave the user
+            // stuck on the loading screen — show the landing view.
+            setProfile(null);
+            setExcused(null);
+            setView('landing');
           }
         }
       } finally {
@@ -270,6 +288,10 @@ function SearchModal({ onClose, onStudent }) {
 
 function StudentView({ profile, onBack }) {
   const [tab, setTab] = useState('bank');
+  const [showWrapped, setShowWrapped] = useState(false);
+  const [showWeekly, setShowWeekly] = useState(false);
+  const [showGhost, setShowGhost] = useState(false);
+
   const { student } = profile;
   const badges = useMemo(() => buildBadges(profile), [profile]);
   const nextActions = useMemo(() => buildNextActions(profile), [profile]);
@@ -282,13 +304,47 @@ function StudentView({ profile, onBack }) {
           <h1>{student.name}</h1>
         </div>
         <div className="score-card"><span className="sp-label"><SpCoinIcon /> SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
+        
       </header>
       <LevelStatus student={student} />
+      <button
+        className="wrapped-entry-btn"
+        onClick={() => setShowWrapped(true)}
+      >
+        ✨ Your Monthly Wrapped
+      </button>
+      <button
+        className="wlb-entry-btn"
+        onClick={() => setShowWeekly(true)}
+      >
+        🏆 This Week's Leaderboard
+      </button>
+      <button
+        className="gr-entry-btn"
+        onClick={() => setShowGhost(true)}
+      >
+        👻 Race Your Ghost
+      </button>
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
       <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
+      {showWrapped && (
+        <WrappedStory onClose={() => setShowWrapped(false)} />
+      )}
+      {showWeekly && (
+        <div className="wlb-overlay">
+          <WeeklyLeaderboard
+            onClose={() => setShowWeekly(false)}
+          />
+        </div>
+      )}
+      {showGhost && (
+        <div className="gr-overlay">
+          <GhostRace onClose={() => setShowGhost(false)} />
+        </div>
+      )}
     </main>
   );
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,6 +3,12 @@ import { createRoot } from 'react-dom/client';
 import './styles.css';
 
 const APP_BASE = window.location.pathname.startsWith('/spurti') ? '/spurti' : '';
+// Dev override: when ?asEmail= is on the URL, forward it to /api/me so we can
+// preview the UI for a specific student (e.g. the DUMMY seed records).
+const DEV_AS_EMAIL = (() => {
+  if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') return '';
+  return new URLSearchParams(window.location.search).get('asEmail') || '';
+})();
 const API = `${APP_BASE}/api`;
 
 function App() {
@@ -41,7 +47,7 @@ function App() {
         setConfig(nextConfig);
 
         if (view !== 'admin-login') {
-          const meRes = await fetch(`${API}/me`);
+          const meRes = await fetch(`${API}/me${DEV_AS_EMAIL ? `?asEmail=${encodeURIComponent(DEV_AS_EMAIL)}` : ''}`);
           if (meRes.ok) {
             const data = await meRes.json();
             if (data.authenticated && data.profile && active) {
@@ -275,7 +281,7 @@ function StudentView({ profile, onBack }) {
           <p className="eyebrow">Student Spurti Bank</p>
           <h1>{student.name}</h1>
         </div>
-        <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
+        <div className="score-card"><span className="sp-label"><SpCoinIcon /> SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
@@ -287,30 +293,781 @@ function StudentView({ profile, onBack }) {
   );
 }
 
+function computeBandFromTimeline(timeline) {
+  // General, data-driven band computation. Used as a fallback when the server
+  // doesn't supply a pre-computed progressBand (or supplies an unknown value).
+  // Mirrors server/services/progress.js PROGRESS_BANDS thresholds.
+  if (!Array.isArray(timeline) || !timeline.length) return null;
+  const flags = timeline.map(d => d === 'qualified');
+  const win = flags.slice(-5);
+  const qualified = win.filter(Boolean).length;
+  const rate = qualified / win.length;
+  let band;
+  if (rate >= 0.85) band = 'Excellent';
+  else if (rate >= 0.50) band = 'Active';
+  else if (rate >= 0.30) band = 'Slowing Down';
+  else band = 'Recovery';
+  const recent = flags.slice(-3);
+  const prev = flags.slice(-6, -3);
+  let trend = 'steady';
+  if (prev.length) {
+    const rr = recent.filter(Boolean).length / recent.length;
+    const pr = prev.filter(Boolean).length / prev.length;
+    const diff = rr - pr;
+    if (diff >= 0.20) trend = 'up';
+    else if (diff <= -0.20) trend = 'down';
+  }
+  return { progressBand: band, progressRate: Math.round(rate * 100), progressTrend: trend };
+}
+
+/* ── Static, photo-realistic tile icons (32x32 viewBox) ── */
+
+function LevelIcon() {
+  return (
+    <svg className="tile-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="lvlHalo" cx="0.5" cy="0.5" r="0.55">
+          <stop offset="0%"  stopColor="#fde68a" stopOpacity="0.5" />
+          <stop offset="60%" stopColor="#f59e0b" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="#92400e" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="lvlStar" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#fef9c3" />
+          <stop offset="35%"  stopColor="#fcd34d" />
+          <stop offset="70%"  stopColor="#f59e0b" />
+          <stop offset="100%" stopColor="#b45309" />
+        </linearGradient>
+        <linearGradient id="lvlStarHi" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#fffbeb" stopOpacity="0.9" />
+          <stop offset="100%" stopColor="#fde68a" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <circle cx="16" cy="16" r="14" fill="url(#lvlHalo)" />
+      {/* 5-pointed star — centered around (16,17) with outer radius 10 */}
+      <path
+        d="M16 6 L19.5 13 L27 14 L21.3 19.2 L22.9 26.6 L16 23 L9.1 26.6 L10.7 19.2 L5 14 L12.5 13 Z"
+        fill="url(#lvlStar)"
+        stroke="#7c2d12"
+        strokeWidth="0.5"
+        strokeLinejoin="round"
+      />
+      {/* highlight on the upper-left facet */}
+      <path
+        d="M16 6 L19.5 13 L12.5 13 Z M16 6 L12.5 13 L10.7 19.2 L5 14 Z"
+        fill="url(#lvlStarHi)"
+        opacity="0.6"
+      />
+    </svg>
+  );
+}
+
+function TrophyIcon() {
+  return (
+    <svg className="tile-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="trophyHalo" cx="0.5" cy="0.5" r="0.55">
+          <stop offset="0%"  stopColor="#fef08a" stopOpacity="0.45" />
+          <stop offset="100%" stopColor="#854d0e" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="trophyCup" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#fef9c3" />
+          <stop offset="40%"  stopColor="#fbbf24" />
+          <stop offset="75%"  stopColor="#f59e0b" />
+          <stop offset="100%" stopColor="#b45309" />
+        </linearGradient>
+        <linearGradient id="trophyShine" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#ffffff" stopOpacity="0.55" />
+          <stop offset="100%" stopColor="#ffffff" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <circle cx="16" cy="14" r="13" fill="url(#trophyHalo)" />
+      {/* left handle */}
+      <path d="M10 8 C 5 8, 5 14, 10 16" fill="none" stroke="url(#trophyCup)" strokeWidth="2.2" strokeLinecap="round" />
+      {/* right handle */}
+      <path d="M22 8 C 27 8, 27 14, 22 16" fill="none" stroke="url(#trophyCup)" strokeWidth="2.2" strokeLinecap="round" />
+      {/* cup body */}
+      <path
+        d="M9 6 H 23 V 14 C 23 18.4, 20 21, 16 21 C 12 21, 9 18.4, 9 14 Z"
+        fill="url(#trophyCup)"
+        stroke="#7c2d12"
+        strokeWidth="0.5"
+        strokeLinejoin="round"
+      />
+      {/* shine */}
+      <path
+        d="M11 7 H 14 V 14 C 14 17, 12.8 18.6, 11 19 Z"
+        fill="url(#trophyShine)"
+      />
+      {/* stem */}
+      <rect x="14.5" y="21" width="3" height="3" fill="url(#trophyCup)" stroke="#7c2d12" strokeWidth="0.4" />
+      {/* base */}
+      <rect x="11" y="24" width="10" height="3" rx="0.6" fill="url(#trophyCup)" stroke="#7c2d12" strokeWidth="0.5" />
+      {/* star on cup */}
+      <circle cx="16" cy="12" r="1.4" fill="#fef3c7" opacity="0.85" />
+    </svg>
+  );
+}
+
+/* Legend tier badges — 4 unique shapes (shield/star/trophy/hex gem), small layout. */
+
+function TierBadgeBronze({ unlocked }) {
+  const metal = unlocked ? ['#fef3c7','#fcd34d','#f59e0b','#b45309'] : ['#f1f5f9','#cbd5e1','#94a3b8','#475569'];
+  const stroke = unlocked ? '#78350f' : '#1e293b';
+  return (
+    <svg className="tier-badge-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="bzMetal" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor={metal[0]} />
+          <stop offset="40%"  stopColor={metal[1]} />
+          <stop offset="80%"  stopColor={metal[2]} />
+          <stop offset="100%" stopColor={metal[3]} />
+        </linearGradient>
+      </defs>
+      <path d="M6 9 Q 6 4, 11 4 H 21 Q 26 4, 26 9 V 18 Q 26 26, 16 28 Q 6 26, 6 18 Z" fill="url(#bzMetal)" stroke={stroke} strokeWidth="0.7" />
+      <path d="M10 11 H 22 V 18" fill="none" stroke={stroke} strokeWidth="0.5" opacity="0.4" />
+      <circle cx="16" cy="16" r="2.6" fill={unlocked ? '#fef3c7' : '#cbd5e1'} stroke={stroke} strokeWidth="0.4" />
+    </svg>
+  );
+}
+
+function TierBadgeSilver({ unlocked }) {
+  const metal = unlocked ? ['#ffffff','#e2e8f0','#cbd5e1','#94a3b8'] : ['#f1f5f9','#cbd5e1','#94a3b8','#475569'];
+  const stroke = unlocked ? '#475569' : '#1e293b';
+  return (
+    <svg className="tier-badge-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="svMetal" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor={metal[0]} />
+          <stop offset="40%"  stopColor={metal[1]} />
+          <stop offset="80%"  stopColor={metal[2]} />
+          <stop offset="100%" stopColor={metal[3]} />
+        </linearGradient>
+      </defs>
+      <path d="M16 4 L19.1 11.4 L27 12.3 L21.2 17.5 L23 25.1 L16 21 L9 25.1 L10.8 17.5 L5 12.3 L12.9 11.4 Z" fill="url(#svMetal)" stroke={stroke} strokeWidth="0.6" strokeLinejoin="round" />
+      <path d="M16 4 L19.1 11.4 L12.9 11.4 Z" fill="#ffffff" opacity={unlocked ? 0.55 : 0.2} />
+      <circle cx="16" cy="16" r="1.6" fill={unlocked ? '#f8fafc' : '#94a3b8'} opacity={unlocked ? 0.9 : 0.4} />
+    </svg>
+  );
+}
+
+function TierBadgeGold({ unlocked }) {
+  const metal = unlocked ? ['#fefce8','#fde047','#eab308','#a16207'] : ['#f1f5f9','#cbd5e1','#94a3b8','#475569'];
+  const stroke = unlocked ? '#713f12' : '#1e293b';
+  return (
+    <svg className="tier-badge-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="gdMetal" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor={metal[0]} />
+          <stop offset="40%"  stopColor={metal[1]} />
+          <stop offset="80%"  stopColor={metal[2]} />
+          <stop offset="100%" stopColor={metal[3]} />
+        </linearGradient>
+      </defs>
+      <path d="M11 5 H 21 V 14 C 21 18, 18 20, 16 20 C 14 20, 11 18, 11 14 Z" fill="url(#gdMetal)" stroke={stroke} strokeWidth="0.6" />
+      <path d="M11 7 C 7 7, 7 13, 11 14" fill="none" stroke={stroke} strokeWidth="1.4" />
+      <path d="M21 7 C 25 7, 25 13, 21 14" fill="none" stroke={stroke} strokeWidth="1.4" />
+      <rect x="14.7" y="20" width="2.6" height="2.6" fill="url(#gdMetal)" stroke={stroke} strokeWidth="0.4" />
+      <rect x="11" y="22.6" width="10" height="2.8" rx="0.5" fill="url(#gdMetal)" stroke={stroke} strokeWidth="0.5" />
+      <path d="M13 6 H 14.5 V 13 Q 13.6 14.6, 13 15.5 Z" fill="#ffffff" opacity={unlocked ? 0.55 : 0.18} />
+    </svg>
+  );
+}
+
+function TierBadgePlatinum({ unlocked }) {
+  const metal = unlocked ? ['#ecfeff','#a5f3fc','#06b6d4','#155e75'] : ['#f1f5f9','#cbd5e1','#94a3b8','#475569'];
+  const stroke = unlocked ? '#155e75' : '#1e293b';
+  return (
+    <svg className="tier-badge-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="ptMetal" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor={metal[0]} />
+          <stop offset="40%"  stopColor={metal[1]} />
+          <stop offset="80%"  stopColor={metal[2]} />
+          <stop offset="100%" stopColor={metal[3]} />
+        </linearGradient>
+        <linearGradient id="ptGem" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%"   stopColor={unlocked ? '#a5f3fc' : '#cbd5e1'} />
+          <stop offset="40%"  stopColor={unlocked ? '#67e8f9' : '#94a3b8'} />
+          <stop offset="100%" stopColor={unlocked ? '#0891b2' : '#475569'} />
+        </linearGradient>
+      </defs>
+      <polygon points="16,3 26,8 26,22 16,27 6,22 6,8" fill="url(#ptMetal)" stroke={stroke} strokeWidth="0.7" strokeLinejoin="round" />
+      <polygon points="16,8 22,11 22,19 16,22 10,19 10,11" fill="url(#ptGem)" stroke={stroke} strokeWidth="0.4" strokeLinejoin="round" />
+      <polygon points="16,8 22,11 16,14.5" fill="#ffffff" opacity={unlocked ? 0.55 : 0.18} />
+      {unlocked && <circle cx="16" cy="15.5" r="1.2" fill="#ffffff" opacity="0.85" />}
+    </svg>
+  );
+}
+
+function TierBadgeIcon({ tier, unlocked }) {
+  switch (tier) {
+    case 'bronze':   return <TierBadgeBronze unlocked={unlocked} />;
+    case 'silver':   return <TierBadgeSilver unlocked={unlocked} />;
+    case 'gold':     return <TierBadgeGold unlocked={unlocked} />;
+    case 'platinum': return <TierBadgePlatinum unlocked={unlocked} />;
+    default:         return <TierBadgeBronze unlocked={unlocked} />;
+  }
+}
+
+
+
+
+
+function GroupIcon() {
+  return (
+    <svg className="tile-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="grpHalo" cx="0.5" cy="0.5" r="0.55">
+          <stop offset="0%"  stopColor="#a5b4fc" stopOpacity="0.4" />
+          <stop offset="100%" stopColor="#312e81" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="grpFront" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#818cf8" />
+          <stop offset="100%" stopColor="#4338ca" />
+        </linearGradient>
+        <linearGradient id="grpBack" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#a5b4fc" />
+          <stop offset="100%" stopColor="#6366f1" />
+        </linearGradient>
+      </defs>
+      <circle cx="16" cy="16" r="14" fill="url(#grpHalo)" />
+      {/* back person (left) */}
+      <circle cx="11" cy="11" r="3.6" fill="url(#grpBack)" stroke="#3730a3" strokeWidth="0.4" />
+      <path d="M5 24 C 5 19, 8 17, 11 17 C 14 17, 17 19, 17 24 Z" fill="url(#grpBack)" stroke="#3730a3" strokeWidth="0.4" />
+      {/* back person (right) */}
+      <circle cx="21" cy="11" r="3.6" fill="url(#grpBack)" stroke="#3730a3" strokeWidth="0.4" />
+      <path d="M15 24 C 15 19, 18 17, 21 17 C 24 17, 27 19, 27 24 Z" fill="url(#grpBack)" stroke="#3730a3" strokeWidth="0.4" />
+      {/* front person (center, larger, brighter) */}
+      <circle cx="16" cy="13" r="4.2" fill="url(#grpFront)" stroke="#312e81" strokeWidth="0.4" />
+      <path d="M8 28 C 8 22, 11.5 20, 16 20 C 20.5 20, 24 22, 24 28 Z" fill="url(#grpFront)" stroke="#312e81" strokeWidth="0.4" />
+      {/* highlights on heads */}
+      <ellipse cx="14.5" cy="11.5" rx="1.2" ry="0.7" fill="#e0e7ff" opacity="0.55" />
+      <ellipse cx="19.5" cy="11.5" rx="1.2" ry="0.7" fill="#e0e7ff" opacity="0.55" />
+      <ellipse cx="14.4" cy="11.7" rx="1.4" ry="0.8" fill="#e0e7ff" opacity="0.6" />
+    </svg>
+  );
+}
+
+function SpCoinIcon() {
+  return (
+    <svg className="sp-coin" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="spCoinHalo" cx="0.5" cy="0.5" r="0.55">
+          <stop offset="0%"   stopColor="#fde68a" stopOpacity="0.55" />
+          <stop offset="60%"  stopColor="#f59e0b" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="#92400e" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="spCoinFace" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#fef9c3" />
+          <stop offset="35%"  stopColor="#fcd34d" />
+          <stop offset="70%"  stopColor="#f59e0b" />
+          <stop offset="100%" stopColor="#b45309" />
+        </linearGradient>
+        <linearGradient id="spCoinShine" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#fffbeb" stopOpacity="0.95" />
+          <stop offset="100%" stopColor="#fde68a" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {/* halo */}
+      <circle cx="16" cy="16" r="15" fill="url(#spCoinHalo)" />
+      {/* outer rim */}
+      <circle cx="16" cy="16" r="12" fill="url(#spCoinFace)" stroke="#451a03" strokeWidth="0.6" />
+      {/* inner rim ridge (darker inset) */}
+      <circle cx="16" cy="16" r="10.4" fill="none" stroke="#b45309" strokeWidth="0.5" opacity="0.65" />
+      {/* shine arc on the upper half */}
+      <path
+        d="M6.5 16 A 9.5 9.5 0 0 1 25.5 16"
+        fill="none"
+        stroke="url(#spCoinShine)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      {/* "SP" letters engraved in serif */}
+      <text
+        x="16"
+        y="20"
+        textAnchor="middle"
+        fontFamily="Georgia, 'Times New Roman', serif"
+        fontSize="11"
+        fontWeight="700"
+        fill="#7c2d12"
+        letterSpacing="0.4"
+      >SP</text>
+      {/* dot accents flanking letters */}
+      <circle cx="9.5" cy="17" r="0.7" fill="#78350f" />
+      <circle cx="22.5" cy="17" r="0.7" fill="#78350f" />
+    </svg>
+  );
+}
+
+function BandIconExcellent() {
+  return (
+    <svg className="tile-icon band band-excellent" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="band3ExHalo" cx="0.5" cy="0.55" r="0.6">
+          <stop offset="0%"   stopColor="#bbf7d0" stopOpacity="0.65" />
+          <stop offset="55%"  stopColor="#34d399" stopOpacity="0.30" />
+          <stop offset="100%" stopColor="#065f46" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="band3ExPetalOuter" x1="0" y1="1" x2="0.5" y2="0">
+          <stop offset="0%"   stopColor="#064e3b" />
+          <stop offset="40%"  stopColor="#047857" />
+          <stop offset="80%"  stopColor="#34d399" />
+          <stop offset="100%" stopColor="#a7f3d0" />
+        </linearGradient>
+        <linearGradient id="band3ExPetalMid" x1="0" y1="1" x2="0.5" y2="0">
+          <stop offset="0%"   stopColor="#065f46" />
+          <stop offset="50%"  stopColor="#10b981" />
+          <stop offset="100%" stopColor="#ecfdf5" />
+        </linearGradient>
+        <linearGradient id="band3ExCore" x1="0" y1="1" x2="0.5" y2="0">
+          <stop offset="0%"   stopColor="#10b981" />
+          <stop offset="60%"  stopColor="#fef9c3" />
+          <stop offset="100%" stopColor="#ffffff" />
+        </linearGradient>
+      </defs>
+      {/* soft halo behind the burst */}
+      <circle cx="16" cy="15" r="13" fill="url(#band3ExHalo)" />
+      {/* center petal — largest, deepest green at base */}
+      <path
+        d="M16 3
+           C 12.5 8, 11.4 12.2, 12.6 16
+           C 13.4 18.6, 15.0 20.0, 16 22
+           C 17.0 20.0, 18.6 18.6, 19.4 16
+           C 20.6 12.2, 19.5 8, 16 3 Z"
+        fill="url(#band3ExPetalOuter)"
+      />
+      {/* upper-left petal */}
+      <path
+        d="M7 7
+           C 7.5 10.5, 9.5 13.6, 12.4 15.6
+           C 14.2 16.8, 16 17.0, 16 17
+           C 15.5 14.6, 13.4 11.2, 10.6 9.0
+           C 9.0 7.8, 7.8 7.0, 7 7 Z"
+        fill="url(#band3ExPetalMid)" opacity="0.92"
+      />
+      {/* upper-right petal */}
+      <path
+        d="M25 7
+           C 24.5 10.5, 22.5 13.6, 19.6 15.6
+           C 17.8 16.8, 16 17.0, 16 17
+           C 16.5 14.6, 18.6 11.2, 21.4 9.0
+           C 23.0 7.8, 24.2 7.0, 25 7 Z"
+        fill="url(#band3ExPetalMid)" opacity="0.92"
+      />
+      {/* lower-left small petal */}
+      <path
+        d="M9.5 22
+           C 11.5 19.5, 13.6 17.6, 15.6 17
+           C 16.4 16.8, 16.6 17.0, 16.6 17
+           C 15.6 19.4, 13.4 22.0, 11 24
+           C 10.0 24.6, 9.5 24, 9.5 22 Z"
+        fill="url(#band3ExPetalMid)" opacity="0.85"
+      />
+      {/* lower-right small petal */}
+      <path
+        d="M22.5 22
+           C 20.5 19.5, 18.4 17.6, 16.4 17
+           C 15.6 16.8, 15.4 17.0, 15.4 17
+           C 16.4 19.4, 18.6 22.0, 21 24
+           C 22.0 24.6, 22.5 24, 22.5 22 Z"
+        fill="url(#band3ExPetalMid)" opacity="0.85"
+      />
+      {/* bright core */}
+      <ellipse cx="16" cy="16.4" rx="2.2" ry="3.0" fill="url(#band3ExCore)" />
+    </svg>
+  );
+}
+
+function BandIconActive() {
+  return (
+    <svg className="tile-icon band band-active" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="band3AcHalo" cx="0.5" cy="0.7" r="0.6">
+          <stop offset="0%"   stopColor="#bfdbfe" stopOpacity="0.55" />
+          <stop offset="55%"  stopColor="#60a5fa" stopOpacity="0.22" />
+          <stop offset="100%" stopColor="#1e3a8a" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="band3AcWaveBody" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0%"   stopColor="#1e3a8a" />
+          <stop offset="40%"  stopColor="#1d4ed8" />
+          <stop offset="75%"  stopColor="#3b82f6" />
+          <stop offset="100%" stopColor="#93c5fd" />
+        </linearGradient>
+        <linearGradient id="band3AcWaveCrest" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0%"   stopColor="#1e40af" />
+          <stop offset="50%"  stopColor="#60a5fa" />
+          <stop offset="100%" stopColor="#dbeafe" />
+        </linearGradient>
+        <linearGradient id="band3AcFoam" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0%"   stopColor="#60a5fa" />
+          <stop offset="60%"  stopColor="#dbeafe" />
+          <stop offset="100%" stopColor="#ffffff" />
+        </linearGradient>
+      </defs>
+      {/* soft halo behind the wave */}
+      <ellipse cx="16" cy="22" rx="14" ry="9" fill="url(#band3AcHalo)" />
+      {/* large sweeping wave body — one continuous path with two peaks */}
+      <path
+        d="M2 21
+           C 5 21, 7 17, 11 17
+           C 15 17, 15 24, 19 24
+           C 23 24, 24 18, 30 18
+           L 30 30
+           L 2 30 Z"
+        fill="url(#band3AcWaveBody)"
+      />
+      {/* second wave layer — slightly behind, deeper */}
+      <path
+        d="M2 25
+           C 6 25, 8 22, 12 22
+           C 16 22, 16 28, 20 28
+           C 24 28, 26 23, 30 23
+           L 30 30
+           L 2 30 Z"
+        fill="#1e3a8a" opacity="0.55"
+      />
+      {/* foam crest on the front wave */}
+      <path
+        d="M2 21
+           C 5 21, 7 17, 11 17
+           C 15 17, 15 24, 19 24
+           C 23 24, 24 18, 30 18"
+        fill="none"
+        stroke="url(#band3AcWaveCrest)"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* bright foam highlights on the wave tops */}
+      <path
+        d="M9 18 Q 11 16, 13 18"
+        fill="none"
+        stroke="url(#band3AcFoam)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      <path
+        d="M17 25 Q 19 23, 21 25"
+        fill="none"
+        stroke="url(#band3AcFoam)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      <path
+        d="M24 19.5 Q 26 17.5, 28 19.5"
+        fill="none"
+        stroke="url(#band3AcFoam)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      {/* tiny spray droplets */}
+      <circle cx="11" cy="13" r="0.9" fill="#dbeafe" />
+      <circle cx="20" cy="20" r="0.9" fill="#dbeafe" />
+      <circle cx="27" cy="14" r="0.9" fill="#dbeafe" />
+    </svg>
+  );
+}
+
+function BandIconSlowingDown() {
+  return (
+    <svg className="tile-icon band band-slowing-down" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="band3SdGlow" cx="0.5" cy="0.85" r="0.55">
+          <stop offset="0%"   stopColor="#fed7aa" stopOpacity="0.55" />
+          <stop offset="55%"  stopColor="#f97316" stopOpacity="0.20" />
+          <stop offset="100%" stopColor="#7c2d12" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="band3SdSmoke" x1="0" y1="1" x2="0.4" y2="0">
+          <stop offset="0%"   stopColor="#57534e" />
+          <stop offset="40%"  stopColor="#a8a29e" />
+          <stop offset="100%" stopColor="#f5f5f4" stopOpacity="0.4" />
+        </linearGradient>
+        <linearGradient id="band3SdEmber" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0%"   stopColor="#7c2d12" />
+          <stop offset="50%"  stopColor="#ea580c" />
+          <stop offset="100%" stopColor="#fde047" />
+        </linearGradient>
+        <linearGradient id="band3SdAsh" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0%"   stopColor="#44403c" />
+          <stop offset="100%" stopColor="#d6d3d1" />
+        </linearGradient>
+      </defs>
+      {/* glow at the base — last bit of warmth */}
+      <ellipse cx="16" cy="27" rx="14" ry="5" fill="url(#band3SdGlow)" />
+      {/* ember bed — last glowing coal */}
+      <path
+        d="M6 27
+           Q 9 22, 16 22
+           Q 23 22, 26 27
+           Q 23 29, 16 29
+           Q 9 29, 6 27 Z"
+        fill="url(#band3SdEmber)"
+      />
+      {/* small ember highlights */}
+      <ellipse cx="13" cy="25.5" rx="2.5" ry="1.4" fill="#fde047" opacity="0.7" />
+      <ellipse cx="19" cy="26"   rx="2.0" ry="1.0" fill="#fb923c" opacity="0.6" />
+      {/* curling smoke — large sweeping S-curve rising upward */}
+      <path
+        d="M16 22
+           C 11 19, 11 14, 14 11
+           C 17 8, 18 5, 16 2"
+        fill="none"
+        stroke="url(#band3SdSmoke)"
+        strokeWidth="5"
+        strokeLinecap="round"
+      />
+      {/* second thinner smoke trail */}
+      <path
+        d="M20 21
+           C 17 18, 18 14, 21 11"
+        fill="none"
+        stroke="url(#band3SdSmoke)"
+        strokeWidth="3"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+      {/* ash flecks scattered around the ember */}
+      <circle cx="4"  cy="23" r="0.8" fill="url(#band3SdAsh)" />
+      <circle cx="7"  cy="20" r="0.7" fill="url(#band3SdAsh)" opacity="0.7" />
+      <circle cx="28" cy="22" r="0.8" fill="url(#band3SdAsh)" />
+      <circle cx="25" cy="19" r="0.6" fill="url(#band3SdAsh)" opacity="0.6" />
+      <circle cx="10" cy="14" r="0.6" fill="url(#band3SdSmoke)" opacity="0.5" />
+      <circle cx="22" cy="13" r="0.5" fill="url(#band3SdSmoke)" opacity="0.5" />
+    </svg>
+  );
+}
+
+function BandIconRecovery() {
+  return (
+    <svg className="tile-icon band band-recovery" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <defs>
+        <radialGradient id="band3RcHalo" cx="0.5" cy="0.65" r="0.6">
+          <stop offset="0%"   stopColor="#bbf7d0" stopOpacity="0.65" />
+          <stop offset="55%"  stopColor="#4ade80" stopOpacity="0.25" />
+          <stop offset="100%" stopColor="#14532d" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id="band3RcDropOuter" x1="0.3" y1="0" x2="0.5" y2="1">
+          <stop offset="0%"   stopColor="#bbf7d0" />
+          <stop offset="40%"  stopColor="#4ade80" />
+          <stop offset="100%" stopColor="#14532d" />
+        </linearGradient>
+        <linearGradient id="band3RcDropInner" x1="0.3" y1="0" x2="0.5" y2="1">
+          <stop offset="0%"   stopColor="#ecfdf5" />
+          <stop offset="60%"  stopColor="#86efac" />
+          <stop offset="100%" stopColor="#16a34a" />
+        </linearGradient>
+        <linearGradient id="band3RcSpark" x1="0" y1="1" x2="0.5" y2="0">
+          <stop offset="0%"   stopColor="#22c55e" />
+          <stop offset="60%"  stopColor="#fef9c3" />
+          <stop offset="100%" stopColor="#ffffff" />
+        </linearGradient>
+      </defs>
+      {/* halo behind the leaf */}
+      <circle cx="16" cy="14" r="13" fill="url(#band3RcHalo)" />
+      {/* outer leaf — large sweeping teardrop path */}
+      <path
+        d="M16 3
+           C 9 7, 5 14, 6 21
+           C 7 27, 14 29, 16 29
+           C 18 29, 25 27, 26 21
+           C 27 14, 23 7, 16 3 Z"
+        fill="url(#band3RcDropOuter)"
+      />
+      {/* inner leaf — same teardrop slightly smaller and brighter */}
+      <path
+        d="M16 7
+           C 11 10, 8.5 14.5, 9.5 19.5
+           C 10.4 24.5, 14.5 26, 16 26
+           C 17.5 26, 21.6 24.5, 22.5 19.5
+           C 23.5 14.5, 21 10, 16 7 Z"
+        fill="url(#band3RcDropInner)"
+        opacity="0.9"
+      />
+      {/* central vein sweeping through the leaf */}
+      <path
+        d="M16 5 C 15.5 12, 15.5 20, 16 28"
+        fill="none"
+        stroke="#14532d"
+        strokeWidth="1.0"
+        strokeLinecap="round"
+        opacity="0.55"
+      />
+      {/* side veins */}
+      <path d="M16 11 Q 13 13, 11 16" fill="none" stroke="#14532d" strokeWidth="0.7" strokeLinecap="round" opacity="0.45" />
+      <path d="M16 11 Q 19 13, 21 16" fill="none" stroke="#14532d" strokeWidth="0.7" strokeLinecap="round" opacity="0.45" />
+      <path d="M16 17 Q 12.5 19, 10.5 22" fill="none" stroke="#14532d" strokeWidth="0.7" strokeLinecap="round" opacity="0.45" />
+      <path d="M16 17 Q 19.5 19, 21.5 22" fill="none" stroke="#14532d" strokeWidth="0.7" strokeLinecap="round" opacity="0.45" />
+      {/* bright highlight near the leaf tip */}
+      <ellipse cx="13" cy="11" rx="2.2" ry="3.0" fill="url(#band3RcSpark)" opacity="0.55" />
+      {/* a single droplet of new growth at the base */}
+      <path
+        d="M16 29.5 C 14 30, 14 32, 16 32 C 18 32, 18 30, 16 29.5 Z"
+        fill="#86efac"
+      />
+    </svg>
+  );
+}
+
+function BandIcon({ band }) {
+  switch (band) {
+    case 'Excellent':    return <BandIconExcellent />;
+    case 'Active':       return <BandIconActive />;
+    case 'Slowing Down': return <BandIconSlowingDown />;
+    case 'Recovery':     return <BandIconRecovery />;
+    default:             return <BandIconActive />;
+  }
+}
+
+
+
+
+
+
+
 function LevelStatus({ student }) {
   const tier = String(student.trophyLeague || 'Bronze').split(' ')[0].toLowerCase();
+  // General, data-driven: compute band locally from streakTimeline so the
+  // tile always reflects the underlying attendance data, regardless of whether
+  // the server supplied a pre-computed progressBand or not. Server value wins
+  // only if local computation has nothing to work with.
+  const localBand = useMemo(
+    () => computeBandFromTimeline(student.streakTimeline),
+    [student.streakTimeline]
+  );
+  const pb = localBand?.progressBand ?? student.progressBand ?? 'Recovery';
+  const pr = localBand?.progressRate ?? student.progressRate ?? 0;
+  const pt = localBand?.progressTrend ?? student.progressTrend ?? 'steady';
   return (
     <section className="level-status">
       <div className="level-tiles">
         <div className="level-tile">
-          <span>Level</span>
+          <span className="tile-label"><LevelIcon /> Level</span>
           <strong>{student.level}</strong>
-          <em>lifetime achievement</em>
+          <div className="xp-bar-wrap" aria-label="Progress to next level">
+            <div className="xp-bar-fill" style={{ width: `${Math.max(0, Math.min(100, student.levelProgress ?? 0))}%` }} />
+          </div>
+          <em>lifetime achievement · {student.levelProgress ?? 0}/100 to L{student.level + 1}{student.weeklyXp != null && student.weeklyXp !== 0 ? <span className="xp-weekly"> · {student.weeklyXp > 0 ? '+' : ''}{student.weeklyXp} this week</span> : null}</em>
         </div>
         <div className={`level-tile league tier-${tier}`}>
-          <span>Trophy League</span>
+          <span className="tile-label"><TrophyIcon /> Trophy League</span>
           <strong>{student.trophyLeague}</strong>
           <em>current performance</em>
         </div>
         <div className="level-tile">
-          <span>Legend Badge</span>
-          <strong>{student.legendBadgeUnlocked ? '🏅 Unlocked' : '🔒 Locked'}</strong>
-          <em>reach 1500 SP once</em>
+          <span className="tile-label">Legend Badge</span>
+          <div className="tier-badge-row" aria-label="Legend badge tiers (lifetime SP milestones)">
+            {(student.legendTiers || []).map(t => (
+              <span
+                key={t.key}
+                className={`tier-badge${t.unlocked ? ' tier-badge-on' : ' tier-badge-off'}`}
+                title={`${t.name} — ${t.threshold}+ SP${t.unlocked ? ' (unlocked)' : ' (locked)'}`}
+              >
+                <TierBadgeIcon tier={t.key} unlocked={t.unlocked} />
+                <small>{t.name}</small>
+              </span>
+            ))}
+          </div>
+          <em>{student.legendBadgeUnlocked
+            ? 'Platinum unlocked (1500 SP) — full legend status'
+            : 'reach 1500 SP to unlock Platinum (legend)'}</em>
         </div>
         <div className="level-tile">
-          <span>Onboarding Group</span>
+          <span className="tile-label"><GroupIcon /> Onboarding Group</span>
           <strong className="group">{student.leaderboardGroupLabel || '—'}</strong>
           <em>biweekly cohort</em>
+        </div>
+        <div className={`level-tile streak-tile${(student.currentStreak ?? 0) === 0 ? ' streak-cold' : (student.currentStreak ?? 0) >= 5 ? ' streak-hot' : ''}`}>
+          <span>Streak</span>
+          <strong>
+            <svg className="streak-flame" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+              <defs>
+                <radialGradient id="flameHalo" cx="0.5" cy="0.7" r="0.6">
+                  <stop offset="0%" stopColor="#fbbf24" stopOpacity="0.45" />
+                  <stop offset="55%" stopColor="#f97316" stopOpacity="0.18" />
+                  <stop offset="100%" stopColor="#dc2626" stopOpacity="0" />
+                </radialGradient>
+                <linearGradient id="flameOuter" x1="0" y1="1" x2="0" y2="0">
+                  <stop offset="0%"   stopColor="#7f1d1d" />
+                  <stop offset="22%"  stopColor="#b91c1c" />
+                  <stop offset="55%"  stopColor="#ef4444" />
+                  <stop offset="78%"  stopColor="#f97316" />
+                  <stop offset="100%" stopColor="#fb923c" />
+                </linearGradient>
+                <linearGradient id="flameMid" x1="0" y1="1" x2="0" y2="0">
+                  <stop offset="0%"   stopColor="#dc2626" />
+                  <stop offset="35%"  stopColor="#f97316" />
+                  <stop offset="70%"  stopColor="#fbbf24" />
+                  <stop offset="100%" stopColor="#fde68a" />
+                </linearGradient>
+                <linearGradient id="flameCore" x1="0" y1="1" x2="0" y2="0">
+                  <stop offset="0%"   stopColor="#f97316" />
+                  <stop offset="50%"  stopColor="#fde047" />
+                  <stop offset="100%" stopColor="#fefce8" />
+                </linearGradient>
+                <linearGradient id="flameHot" x1="0" y1="1" x2="0" y2="0">
+                  <stop offset="0%"   stopColor="#60a5fa" stopOpacity="0.7" />
+                  <stop offset="40%"  stopColor="#fef9c3" />
+                  <stop offset="100%" stopColor="#ffffff" />
+                </linearGradient>
+              </defs>
+              {/* soft halo / glow behind the flame */}
+              <circle cx="16" cy="22" r="13" fill="url(#flameHalo)" />
+              {/* outer flame body — deep red base, fading to orange tip */}
+              <path
+                d="M16 2.6
+                   C 14.6 6.2, 12.4 8.4, 11.6 11.0
+                   C 10.6 14.2, 11.8 16.0, 10.6 18.4
+                   C 9.4 20.8, 7.6 22.2, 7.6 25.0
+                   C 7.6 28.6, 11.2 30.6, 16 30.6
+                   C 20.8 30.6, 24.4 28.6, 24.4 25.0
+                   C 24.4 22.2, 22.8 20.8, 21.6 18.6
+                   C 20.4 16.4, 21.4 14.4, 20.4 11.4
+                   C 19.6 8.8, 17.4 6.4, 16 2.6 Z"
+                fill="url(#flameOuter)"
+              />
+              {/* mid flame — orange to yellow, slightly smaller */}
+              <path
+                d="M16 7.2
+                   C 15.0 9.6, 13.4 11.2, 13.0 13.4
+                   C 12.6 15.6, 13.6 17.0, 13.0 19.0
+                   C 12.4 21.0, 11.0 22.0, 11.0 24.4
+                   C 11.0 26.8, 13.4 28.0, 16 28.0
+                   C 18.6 28.0, 21.0 26.8, 21.0 24.4
+                   C 21.0 22.0, 19.6 21.0, 19.0 19.0
+                   C 18.4 17.0, 19.4 15.6, 19.0 13.4
+                   C 18.6 11.2, 17.0 9.6, 16 7.2 Z"
+                fill="url(#flameMid)"
+              />
+              {/* inner core — bright yellow/white hot spot */}
+              <path
+                d="M16 12.4
+                   C 15.4 14.0, 14.4 15.0, 14.2 16.6
+                   C 14.0 18.0, 14.6 18.8, 14.4 20.2
+                   C 14.2 21.6, 13.4 22.2, 13.4 23.8
+                   C 13.4 25.2, 14.6 26.0, 16 26.0
+                   C 17.4 26.0, 18.6 25.2, 18.6 23.8
+                   C 18.6 22.2, 17.8 21.6, 17.6 20.2
+                   C 17.4 18.8, 18.0 18.0, 17.8 16.6
+                   C 17.6 15.0, 16.6 14.0, 16 12.4 Z"
+                fill="url(#flameCore)"
+              />
+              {/* hottest spot — tiny blue-white base where flame meets air (visible in real fire) */}
+              <ellipse cx="16" cy="24.6" rx="1.6" ry="2.0" fill="url(#flameHot)" opacity="0.85" />
+            </svg>
+            {student.currentStreak ?? 0} <small>· best {student.longestStreak ?? 0}</small>
+          </strong>
+          <div className="streak-dots" aria-label="Session-by-session qualification history (oldest to newest)">
+            {(student.streakTimeline || []).map((dot, idx) => (
+              <span key={idx} className={`streak-dot dot-${dot}`} title={dot === 'qualified' ? 'Qualified' : 'Missed'} />
+            ))}
+          </div>
+          <em>{student.streakFreezesAvailable ?? 0} streak freeze{student.streakFreezesAvailable === 1 ? '' : 's'} available</em>
+        </div>
+        <div className={`level-tile band band-${pb.toLowerCase().replace(/ /g, "-")}`}>
+          <span className="tile-label">Progress Band</span>
+          <strong><BandIcon band={pb} /> {pb}</strong>
+          <em>{pr}% qualified · {pt === 'up' ? 'trending up' : pt === 'down' ? 'trending down' : 'steady'} (last 5 sessions)</em>
         </div>
       </div>
       <p className="level-note">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -666,3 +666,754 @@ input {
   height: 1.5em;
   vertical-align: -0.25em;
 }
+
+/* -- Wrapped entry button -------------------------- */
+.wrapped-entry-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  border-radius: 99px;
+  border: 1.5px solid var(--primary);
+  background: transparent;
+  color: var(--primary);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  margin-bottom: 14px;
+  transition: background 0.15s, color 0.15s;
+}
+.wrapped-entry-btn:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+/* -- Overlay --------------------------------------- */
+.wrapped-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.88);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+}
+
+/* -- Progress bar ---------------------------------- */
+.wrapped-progress {
+  position: absolute;
+  top: 14px;
+  left: 12px;
+  right: 12px;
+  display: flex;
+  gap: 4px;
+  z-index: 10;
+}
+.wrapped-seg-wrap {
+  flex: 1;
+  height: 3px;
+  background: rgba(255,255,255,0.25);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.wrapped-seg-fill {
+  height: 100%;
+  background: #fff;
+  border-radius: 99px;
+  transition: width 0.3s ease;
+}
+
+/* -- Close ----------------------------------------- */
+.wrapped-x {
+  position: absolute;
+  top: 28px;
+  right: 16px;
+  background: rgba(255,255,255,0.12);
+  border: none;
+  color: #fff;
+  font-size: 18px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* -- Card ------------------------------------------ */
+.wrapped-card {
+  background: var(--panel);
+  border-radius: 20px;
+  width: min(88vw, 360px);
+  min-height: min(72vh, 500px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 28px;
+  box-shadow: 0 8px 40px rgba(0,0,0,0.5);
+  position: relative;
+  z-index: 5;
+}
+.wrapped-card-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  width: 100%;
+  gap: 10px;
+}
+.wrapped-icon { font-size: 44px; }
+.wrapped-label { font-size: 13px; color: var(--muted);
+  font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.07em; }
+.wrapped-headline { font-size: 52px; font-weight: 850;
+  color: var(--primary); line-height: 1.1; }
+.wrapped-denom { font-size: 28px; color: var(--muted);
+  font-weight: 400; }
+.wrapped-sub { font-size: 14px; color: var(--muted);
+  line-height: 1.5; }
+.wrapped-counter { position: absolute; bottom: 16px; right: 20px;
+  font-size: 11px; color: var(--muted); }
+.wrapped-stat-row {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  font-size: 14px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line);
+}
+.wrapped-stat-row strong { font-weight: 700; color: var(--text); }
+
+/* -- Tap zones ------------------------------------- */
+.wrapped-tap-prev,
+.wrapped-tap-next {
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 30%;
+  z-index: 4;
+  cursor: pointer;
+}
+.wrapped-tap-prev { left: 0; }
+.wrapped-tap-next { right: 0; }
+
+/* -- States ---------------------------------------- */
+.wrapped-nodata,
+.wrapped-loading {
+  color: #fff;
+  text-align: center;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  font-size: 16px;
+}
+.wrapped-close-btn {
+  margin-top: 20px;
+  padding: 10px 28px;
+  border-radius: 99px;
+  border: 1.5px solid rgba(255,255,255,0.4);
+  background: transparent;
+  color: #fff;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+/* ── Weekly Leaderboard entry button ─────────────── */
+.wlb-entry-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  border-radius: 99px;
+  border: 1.5px solid var(--primary);
+  background: transparent;
+  color: var(--primary);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  margin-bottom: 14px;
+  transition: background 0.15s, color 0.15s;
+}
+.wlb-entry-btn:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+/* ── Overlay ─────────────────────────────────────── */
+.wlb-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 900;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+/* ── Wrap ────────────────────────────────────────── */
+.wlb-wrap {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 32px;
+}
+.wlb-loading {
+  text-align: center;
+  padding: 40px;
+  color: var(--muted);
+}
+
+/* ── Header ──────────────────────────────────────── */
+.wlb-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 16px;
+  background: var(--panel);
+  border-radius: 12px;
+}
+.wlb-title { font-size: 18px; font-weight: 850; color: var(--text); }
+.wlb-subtitle { font-size: 12px; color: var(--muted); margin-top: 2px; }
+.wlb-close {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  border-radius: 50%;
+  width: 28px; height: 28px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+/* ── Your standing ───────────────────────────────── */
+.wlb-your-standing {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 14px 16px;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 700;
+  background: var(--panel);
+  border: 1.5px solid var(--line);
+}
+.wlb-your-standing.wlb-gold {
+  border-color: #e0a92e;
+  background: linear-gradient(180deg, #fff3c4 0%, #ffe899 100%);
+}
+.wlb-your-standing.wlb-silver {
+  border-color: #94a0b3;
+  background: linear-gradient(180deg, #e8ebf2 0%, #d1d6e0 100%);
+}
+.wlb-your-standing.wlb-bronze {
+  border-color: #b8743f;
+  background: linear-gradient(180deg, #f5dec1 0%, #e9bd8e 100%);
+}
+.wlb-your-sp {
+  margin-left: auto;
+  font-weight: 850;
+  color: var(--green);
+}
+
+/* ── Section label ───────────────────────────────── */
+.wlb-section-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+  padding: 0 4px;
+}
+
+/* ── Category winner cards ───────────────────────── */
+.wlb-categories {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 10px;
+}
+.wlb-cat-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 10px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.wlb-cat-card.wlb-you {
+  border-color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 8%, var(--panel));
+}
+.wlb-cat-emoji { font-size: 24px; }
+.wlb-cat-label { font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--muted); }
+.wlb-cat-name { font-size: 13px; font-weight: 700;
+  color: var(--text); }
+.wlb-cat-sub { font-size: 11px; color: var(--muted); }
+
+/* ── League tabs ─────────────────────────────────── */
+.wlb-tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.wlb-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 99px;
+  border: 1.5px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.wlb-tab-active {
+  border-color: var(--primary);
+  color: var(--primary);
+  font-weight: 700;
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+}
+/* League tabs - bold solid backgrounds with white text for maximum legibility */
+.wlb-tab {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-shadow: none;
+}
+.wlb-tab.wlb-tab-gold.wlb-tab-active {
+  border-color: #7c5400;
+  color: #ffffff;
+  background: linear-gradient(180deg, #f0a800 0%, #b27600 100%);
+  box-shadow: 0 2px 6px rgba(178,118,0,0.45), inset 0 1px 0 rgba(255,255,255,0.25);
+  text-shadow: 0 1px 1px rgba(0,0,0,0.18);
+}
+.wlb-tab.wlb-tab-silver.wlb-tab-active {
+  border-color: #374151;
+  color: #ffffff;
+  background: linear-gradient(180deg, #6b7280 0%, #374151 100%);
+  box-shadow: 0 2px 6px rgba(55,65,81,0.45), inset 0 1px 0 rgba(255,255,255,0.2);
+  text-shadow: 0 1px 1px rgba(0,0,0,0.25);
+}
+.wlb-tab.wlb-tab-bronze.wlb-tab-active {
+  border-color: #7a3b0e;
+  color: #ffffff;
+  background: linear-gradient(180deg, #b8743f 0%, #7a3b0e 100%);
+  box-shadow: 0 2px 6px rgba(122,59,14,0.45), inset 0 1px 0 rgba(255,255,255,0.22);
+  text-shadow: 0 1px 1px rgba(0,0,0,0.25);
+}
+/* Inactive tab - color-themed but readable on white background */
+.wlb-tab.wlb-tab-gold {
+  border-color: #e0a92e;
+  color: #7c5400;
+  background: #fff7e0;
+}
+.wlb-tab.wlb-tab-silver {
+  border-color: #94a0b3;
+  color: #1f2937;
+  background: #f0f2f7;
+}
+.wlb-tab.wlb-tab-bronze {
+  border-color: #b8743f;
+  color: #5c2d0a;
+  background: #f6ecde;
+}
+.wlb-tab-count {
+  font-size: 11px;
+  background: var(--line);
+  border-radius: 99px;
+  padding: 1px 7px;
+}
+
+/* ── League section ──────────────────────────────── */
+.wlb-league-section {
+  background: var(--panel);
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+}
+/* League sections: strong color-coded panels so each league reads as its own thing */
+.wlb-league-section.wlb-gold {
+  border: 2px solid #e0a92e;
+  background: linear-gradient(180deg, #fff3c4 0%, #ffe899 50%, #fff8e1 100%);
+}
+.wlb-league-section.wlb-silver {
+  border: 2px solid #94a0b3;
+  background: linear-gradient(180deg, #e8ebf2 0%, #d1d6e0 50%, #f0f2f7 100%);
+}
+.wlb-league-section.wlb-bronze {
+  border: 2px solid #b8743f;
+  background: linear-gradient(180deg, #f5dec1 0%, #e9bd8e 50%, #faf0e0 100%);
+}
+.wlb-league-section .wlb-table thead th {
+  background: rgba(255,255,255,0.55);
+  font-weight: 800;
+}
+/* League badge chip on the section header */
+.wlb-league-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 99px;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #fff;
+}
+.wlb-league-section.wlb-gold .wlb-league-badge {
+  background: linear-gradient(180deg, #f7c948 0%, #b27600 100%);
+  box-shadow: 0 1px 3px rgba(178,118,0,0.45);
+}
+.wlb-league-section.wlb-silver .wlb-league-badge {
+  background: linear-gradient(180deg, #c9ced8 0%, #4b5563 100%);
+  box-shadow: 0 1px 3px rgba(75,85,99,0.45);
+}
+.wlb-league-section.wlb-bronze .wlb-league-badge {
+  background: linear-gradient(180deg, #d49a5e 0%, #7a3b0e 100%);
+  box-shadow: 0 1px 3px rgba(122,59,14,0.45);
+}
+
+.wlb-league-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--text);
+  border-bottom: 1px solid var(--line);
+}
+.wlb-league-count {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 400;
+}
+
+/* ── Table ───────────────────────────────────────── */
+.wlb-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.wlb-table th {
+  text-align: left;
+  padding: 8px 16px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  font-weight: 700;
+}
+.wlb-table td { padding: 10px 16px; }
+.wlb-table tr + tr { border-top: 1px solid var(--line); }
+.wlb-you-row { background:
+  color-mix(in srgb, var(--primary) 8%, transparent); }
+.wlb-rank { font-weight: 850; color: var(--primary);
+  font-size: 15px; width: 36px; }
+.wlb-name { font-weight: 600; color: var(--text); }
+.wlb-email { font-size: 11px; color: var(--muted); }
+.wlb-sp-week { font-weight: 850; color: var(--green);
+  text-align: right; }
+.wlb-sp-total { color: var(--muted); font-size: 12px;
+  text-align: right; }
+
+/* ── Explainer ───────────────────────────────────── */
+.wlb-explainer {
+  font-size: 12px;
+  color: var(--muted);
+  text-align: center;
+  padding: 8px;
+  line-height: 1.6;
+}
+
+/* -- Ghost Race entry button ----------------------- */
+.gr-entry-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  border-radius: 99px;
+  border: 1.5px solid var(--muted);
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  margin-bottom: 14px;
+  transition: border-color 0.15s, color 0.15s;
+}
+.gr-entry-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+/* -- Overlay --------------------------------------- */
+.gr-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  z-index: 900;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+/* -- Wrap ------------------------------------------ */
+.gr-wrap {
+  max-width: 580px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 32px;
+}
+.gr-loading {
+  text-align: center;
+  padding: 40px;
+  color: var(--muted);
+}
+
+/* -- Header ---------------------------------------- */
+.gr-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 16px;
+  background: var(--panel);
+  border-radius: 12px;
+}
+.gr-title    { font-size: 18px; font-weight: 850; color: var(--text); }
+.gr-subtitle { font-size: 12px; color: var(--muted); margin-top: 2px; }
+.gr-close {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  border-radius: 50%;
+  width: 28px; height: 28px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+/* -- Status banner --------------------------------- */
+.gr-status-banner {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--panel);
+  border-radius: 12px;
+  border-left: 4px solid var(--muted);
+}
+.gr-status-emoji { font-size: 28px; }
+.gr-status-label { font-size: 14px; font-weight: 850; }
+.gr-status-msg   { font-size: 13px; color: var(--muted);
+                   margin-top: 3px; line-height: 1.4; }
+
+/* -- Race track bars ------------------------------- */
+.gr-race-track {
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.gr-racer-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.gr-racer-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  width: 30px;
+  flex-shrink: 0;
+}
+.gr-ghost-label { color: var(--muted); }
+.gr-bar-wrap {
+  flex: 1;
+  height: 14px;
+  background: var(--line);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.gr-bar {
+  height: 100%;
+  border-radius: 99px;
+  transition: width 0.6s cubic-bezier(.4,0,.2,1);
+  min-width: 4px;
+}
+.gr-bar-you   { background: var(--primary); }
+.gr-bar-ghost { background: var(--muted); opacity: 0.5; }
+.gr-racer-sp  { font-size: 13px; font-weight: 700;
+                color: var(--text); width: 52px;
+                text-align: right; flex-shrink: 0; }
+.gr-muted     { color: var(--muted); }
+.gr-track-caption {
+  font-size: 11px;
+  color: var(--muted);
+  text-align: center;
+  margin-top: 4px;
+}
+
+/* -- Daily bars ------------------------------------ */
+.gr-daily-wrap { background: var(--panel); border-radius: 12px;
+                 padding: 14px 12px; }
+.gr-daily-label-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.gr-legend-dot  { width: 10px; height: 10px;
+                  border-radius: 50%; flex-shrink: 0; }
+.gr-you-dot     { background: var(--primary); }
+.gr-ghost-dot   { background: var(--muted); opacity: 0.5; }
+.gr-legend-text { margin-right: 8px; }
+
+.gr-daily-bars {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 4px;
+}
+.gr-day-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+.gr-today .gr-day-key {
+  color: var(--primary);
+  font-weight: 850;
+}
+.gr-future { opacity: 0.4; }
+.gr-bar-pair {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 64px;
+}
+.gr-mini-bar {
+  width: 10px;
+  border-radius: 3px 3px 0 0;
+  min-height: 3px;
+  transition: height 0.4s ease;
+}
+.gr-mini-you   { background: var(--primary); }
+.gr-mini-ghost { background: var(--muted); }
+.gr-day-key    { font-size: 9px; color: var(--muted);
+                 text-transform: uppercase; }
+.gr-day-diff   { font-size: 10px; font-weight: 700; }
+
+/* -- Stats row ------------------------------------- */
+.gr-stats-row {
+  display: flex;
+  gap: 10px;
+}
+.gr-stat {
+  flex: 1;
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 12px;
+  text-align: center;
+}
+.gr-stat-ghost { opacity: 0.65; }
+.gr-stat-val   { font-size: 22px; font-weight: 850;
+                 color: var(--primary); }
+.gr-stat-label { font-size: 10px; color: var(--muted);
+                 margin-top: 4px; line-height: 1.3; }
+
+/* -- Section --------------------------------------- */
+.gr-section { background: var(--panel); border-radius: 12px;
+              padding: 14px 16px; }
+.gr-section-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
+/* -- Session comparison ---------------------------- */
+.gr-sessions { display: flex; flex-direction: column; gap: 6px; }
+.gr-session-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.gr-session-cell {
+  flex: 1;
+  font-size: 12px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  text-align: center;
+  font-weight: 600;
+}
+.gr-qualified { background: color-mix(in srgb,
+  var(--green) 12%, var(--panel)); color: var(--green); }
+.gr-missed    { background: color-mix(in srgb,
+  var(--red) 12%, var(--panel)); color: var(--red); }
+.gr-empty     { background: var(--line); color: var(--muted); }
+.gr-ghost-cell { opacity: 0.7; }
+.gr-session-vs { font-size: 10px; color: var(--muted);
+                 font-weight: 700; flex-shrink: 0; }
+
+/* -- Personal bests -------------------------------- */
+.gr-bests-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 10px;
+}
+.gr-best-card {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.gr-best-emoji { font-size: 22px; }
+.gr-best-val   { font-size: 20px; font-weight: 850;
+                 color: var(--primary); }
+.gr-best-label { font-size: 11px; font-weight: 700;
+                 color: var(--text); }
+.gr-best-sub   { font-size: 10px; color: var(--muted);
+                 line-height: 1.3; }
+
+/* -- No ghost -------------------------------------- */
+.gr-no-ghost {
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 32px 20px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+.gr-no-ghost-title { font-size: 18px; font-weight: 850; color: var(--text); }
+.gr-no-ghost-sub {
+  font-size: 13px; color: var(--muted); line-height: 1.5;
+  max-width: 280px;
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,155 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* ── Progress band colour hooks ──────────────────── */
+.band-excellent strong { color: var(--green); }
+.band-active strong { color: var(--primary); }
+.band-slowing-down strong { color: var(--amber); }
+.band-recovery strong { color: var(--red); }
+
+/* ── XP progress bar ─────────────────────────────── */
+.xp-bar-wrap {
+ height: 6px;
+ background: var(--line);
+ border-radius: 99px;
+ overflow: hidden;
+ margin: 6px 0 4px;
+ width: 100%;
+}
+.xp-bar-fill {
+ height: 100%;
+ background: linear-gradient(90deg, var(--primary), var(--green));
+ border-radius: 99px;
+ transition: width 0.5s ease;
+ min-width: 0%;
+ max-width: 100%;
+}
+.xp-weekly {
+ font-size: 11px;
+ color: var(--muted);
+ display: block;
+ margin-top: 2px;
+}
+
+/* ── Streak timeline dots ────────────────────────── */
+.streak-dots {
+ display: flex;
+ gap: 4px;
+ flex-wrap: wrap;
+ margin-top: 8px;
+}
+.streak-dot {
+ display: inline-block;
+ width: 10px;
+ height: 10px;
+ border-radius: 50%;
+ flex-shrink: 0;
+}
+.dot-qualified { background: var(--green); }
+.dot-missed { background: var(--red); }
+
+
+/* ── Tile icons + labels (Level, Trophy, Legend, Group, Band) ── */
+.tile-icon {
+  display: inline-block;
+  width: 1.3em;
+  height: 1.3em;
+  margin-right: 4px;
+  vertical-align: -0.20em;
+  filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.15));
+}
+
+/* ── Legend Badge tier row (4 small medals, colored when unlocked) ── */
+.tier-badge-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
+  margin: 4px 0 6px 0;
+  flex-wrap: wrap;
+}
+.tier-badge {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  font-size: 0.78em;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 6px;
+}
+.tier-badge .tier-badge-icon {
+  width: 1.7em;
+  height: 1.7em;
+  display: block;
+}
+.tier-badge small {
+  font-size: 0.78em;
+  letter-spacing: 0.02em;
+}
+.tier-badge-on {
+  filter: drop-shadow(0 1px 0 rgba(0,0,0,0.10));
+}
+.tier-badge-off {
+  opacity: 0.45;
+  filter: saturate(0.4);
+}
+.tier-badge-off small {
+  color: var(--muted, #6b7280);
+}
+/* ── Streak flame icon (static, photo-realistic) ── */
+.streak-flame {
+  display: inline-block;
+  width: 1.3em;
+  height: 1.3em;
+  margin-right: 4px;
+  vertical-align: -0.15em;
+  filter: drop-shadow(0 1px 0 rgba(127, 29, 29, 0.25));
+}
+.streak-tile.streak-hot .streak-flame {
+  width: 1.5em;
+  height: 1.5em;
+  filter: drop-shadow(0 0 4px rgba(255, 120, 30, 0.55));
+}
+.streak-tile.streak-cold .streak-flame {
+  width: 1.3em;
+  height: 1.3em;
+  filter: drop-shadow(0 1px 0 rgba(127, 29, 29, 0.25)) saturate(0.85);
+}
+
+/* ── Progress Band icon (large, sits before the band word — mirrors streak flame pattern) ── */
+.level-tile.band .tile-icon,
+.level-tile.band svg.tile-icon {
+  width: 2.0em;
+  height: 2.0em;
+  margin-right: 6px;
+  vertical-align: -0.30em;
+}
+.level-tile.band > strong {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.1;
+}
+
+
+/* ── SP currency coin (top score card + wherever SP appears) ── */
+.sp-coin {
+  display: inline-block;
+  width: 1.2em;
+  height: 1.2em;
+  margin-right: 4px;
+  vertical-align: -0.18em;
+  filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.15));
+}
+.sp-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  line-height: 1;
+}
+.score-card .sp-coin {
+  width: 1.5em;
+  height: 1.5em;
+  vertical-align: -0.25em;
+}

--- a/list-students.mjs
+++ b/list-students.mjs
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+import Student from './server/models/Student.js';
+await mongoose.connect('mongodb://127.0.0.1:27017/analysis_summership');
+const dummyCount = await Student.countDocuments({ email: { $regex: /@spurti\.test$/i } });
+console.log('dummy count:', dummyCount);
+const total = await Student.countDocuments({});
+console.log('total students:', total);
+const aakarsh = await Student.findOne({ email: 'bahukhandiaakarsh@gmail.com' }).lean();
+console.log('aakarsh:', aakarsh ? { email: aakarsh.email, name: aakarsh.name, status: aakarsh.status } : 'NOT FOUND');
+process.exit(0);

--- a/remove-dummies.js
+++ b/remove-dummies.js
@@ -1,0 +1,74 @@
+/**
+ * remove-dummies.js
+ *
+ * Removes every record created by seed-dummies.js:
+ *   - 20 Student docs on @spurti.test
+ *   - all SPTransaction / AttendanceRecord / PollRecord tied to those emails
+ *
+ * SAFE — touches ONLY rows whose email is on @spurti.test (real students
+ * use @vitstudent.ac.in, @gmail.com, etc., so they are untouched).
+ *
+ * Run with:  node remove-dummies.js
+ */
+
+import mongoose from 'mongoose';
+import { MONGO_URI } from './server/config.js';
+
+import Student          from './server/models/Student.js';
+import SPTransaction    from './server/models/SPTransaction.js';
+import AttendanceRecord from './server/models/AttendanceRecord.js';
+import PollRecord       from './server/models/PollRecord.js';
+import ChatRecord       from './server/models/ChatRecord.js';
+
+const DUMMY_DOMAIN = '@spurti.test';
+// Match any email ending in @spurti.test (case-insensitive on the local-part side too)
+const filter = { email: { $regex: /@spurti\.test$/i } };
+
+async function run() {
+  await mongoose.connect(MONGO_URI);
+
+  const studentCount    = await Student.countDocuments(filter);
+  const txCount         = await SPTransaction.countDocuments(filter);
+  const attCount        = await AttendanceRecord.countDocuments(filter);
+  const pollCount       = await PollRecord.countDocuments(filter);
+  const chatCount       = await ChatRecord.countDocuments(filter);
+
+  console.log('─'.repeat(56));
+  console.log(`About to delete (scoped to ${DUMMY_DOMAIN}):`);
+  console.log(`  Students:           ${studentCount}`);
+  console.log(`  SP Transactions:    ${txCount}`);
+  console.log(`  Attendance Records: ${attCount}`);
+  console.log(`  Poll Records:       ${pollCount}`);
+  console.log(`  Chat Records:       ${chatCount}`);
+  if (studentCount + txCount + attCount + pollCount + chatCount === 0) {
+    console.log('Nothing to remove — DB is already clean.');
+    console.log('─'.repeat(56));
+    await mongoose.disconnect();
+    return;
+  }
+
+  const [sR, tR, aR, pR, cR] = await Promise.all([
+    Student.deleteMany(filter),
+    SPTransaction.deleteMany(filter),
+    AttendanceRecord.deleteMany(filter),
+    PollRecord.deleteMany(filter),
+    ChatRecord.deleteMany(filter),
+  ]);
+
+  console.log('Deleted:');
+  console.log(`  Students:           ${sR.deletedCount}`);
+  console.log(`  SP Transactions:    ${tR.deletedCount}`);
+  console.log(`  Attendance Records: ${aR.deletedCount}`);
+  console.log(`  Poll Records:       ${pR.deletedCount}`);
+  console.log(`  Chat Records:       ${cR.deletedCount}`);
+  console.log('─'.repeat(56));
+  console.log('All clear. Real students untouched.');
+
+  await mongoose.disconnect();
+}
+
+run().catch(async err => {
+  console.error(err);
+  await mongoose.disconnect();
+  process.exit(1);
+});

--- a/seed-dummies.js
+++ b/seed-dummies.js
@@ -1,0 +1,595 @@
+/**
+ * seed-dummies.js
+ *
+ * Seeds 20 dummy students (@spurti.test) plus enough supporting data
+ * (June 2026 sessions, SP transactions, attendance, polls) to populate
+ * the weekly leaderboard and the monthly Wrapped story with realistic,
+ * *distinct* content per dummy.
+ *
+ * IDs / emails are tagged with `dummy.` in their `name` field and the
+ * `dummy@spurti.test` domain so `remove-dummies.js` can find them later
+ * without touching real students.
+ *
+ * Run with:    node seed-dummies.js
+ * Tear down:   node remove-dummies.js   (when you're done testing)
+ *
+ * NOTE: ChatRecord model is seeded too, so the "Community Star"
+ * leaderboard category ("this week’s most positive chat reactions") has a
+ * real winner. All other leaderboard categories and every Wrapped card get
+ * distinct per-dummy data.
+ */
+
+import mongoose from 'mongoose';
+import { MONGO_URI } from './server/config.js';
+
+import Student          from './server/models/Student.js';
+import Session          from './server/models/Session.js';
+import SPTransaction    from './server/models/SPTransaction.js';
+import AttendanceRecord from './server/models/AttendanceRecord.js';
+import PollRecord       from './server/models/PollRecord.js';
+import ChatRecord       from './server/models/ChatRecord.js';
+import { leagueBand, levelFor } from './server/services/levels.js';
+
+const DOMAIN = 'spurti.test';
+
+/* ── dummy roster ────────────────────────────────── */
+// Each entry: { email, baseName, totalSp, personality }
+// `totalSp` is the LIFETIME balance the mock starts with.
+// `personality` drives the shape of their June transactions / attendance.
+const ROSTER = [
+  { email: `dummy1@${DOMAIN}`,  totalSp: 100,  p: 'bronze_starter'   },
+  { email: `dummy2@${DOMAIN}`,  totalSp: 250,  p: 'bronze_climber'  },
+  { email: `dummy3@${DOMAIN}`,  totalSp: 380,  p: 'silver_avg'      },
+  { email: `dummy4@${DOMAIN}`,  totalSp: 540,  p: 'silver_strong'   },
+  { email: `dummy5@${DOMAIN}`,  totalSp: 720,  p: 'gold_rising'     },
+  { email: `dummy6@${DOMAIN}`,  totalSp: 880,  p: 'gold_solid'      },
+  { email: `dummy7@${DOMAIN}`,  totalSp: 1010, p: 'gold_big_gain'   },
+  { email: `dummy8@${DOMAIN}`,  totalSp: 1150, p: 'platinum_steady' },
+  { email: `dummy9@${DOMAIN}`,  totalSp: 1380, p: 'platinum_quest'  },
+  { email: `dummy10@${DOMAIN}`, totalSp: 1620, p: 'legend_legend'   },
+  { email: `dummy11@${DOMAIN}`, totalSp: 100,  p: 'newbie'          },
+  { email: `dummy12@${DOMAIN}`, totalSp: 240,  p: 'comeback_kid'    },
+  { email: `dummy13@${DOMAIN}`, totalSp: 380,  p: 'attendee_perfect' },
+  { email: `dummy14@${DOMAIN}`, totalSp: 460,  p: 'poll_master'     },
+  { email: `dummy15@${DOMAIN}`, totalSp: 540,  p: 'mixed_balanced'  },
+  { email: `dummy16@${DOMAIN}`, totalSp: 720,  p: 'big_bonus_day'   },
+  { email: `dummy17@${DOMAIN}`, totalSp: 180,  p: 'slump_recover'   },
+  { email: `dummy18@${DOMAIN}`, totalSp: 320,  p: 'quiet_contrib'   },
+  { email: `dummy19@${DOMAIN}`, totalSp: 880,  p: 'last_week_champ' },
+  { email: `dummy20@${DOMAIN}`, totalSp: 200,  p: 'milestone_500'   },
+];
+
+/* ── personalities ───────────────────────────────── */
+// Each returns `{ weeklySp, lastWeeklySp, attendAttrs, pollAttrs }`:
+//   weeklySp:       SP earned in current week  (drives weekly leaderboard)
+//   lastWeeklySp:   SP earned in previous week (drives "Most Improved")
+//   attendAttrs:    [{ qualified: bool }] x 8   (June session attendance)
+//   pollAttrs:      [{ attemptedQuestions, totalQuestions }] x 8
+
+function attrsFromName(name) {
+  const n = String(name).match(/^DUMMY (\w+)/)?.[1] || 'One';
+  return n.charAt(0).toUpperCase() + n.slice(1).toLowerCase();
+}
+
+function profileFor(personality, totalSp) {
+  switch (personality) {
+    case 'bronze_starter':
+      return {
+        weeklySp: 35, lastWeeklySp: 18,
+        att: [0,1,1,0,1,1,0,0].map(q => ({ qualified: !!q })),
+        polls: lowPolls(),
+      };
+    case 'bronze_climber':
+      return {
+        weeklySp: 55, lastWeeklySp: 25,
+        att: [1,0,1,1,1,1,0,0].map(q => ({ qualified: !!q })),
+        polls: lowPolls(),
+      };
+    case 'silver_avg':
+      return {
+        weeklySp: 95, lastWeeklySp: 70,
+        att: [1,1,1,0,1,1,1,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'silver_strong':
+      return {
+        weeklySp: 130, lastWeeklySp: 90,
+        att: [1,1,1,1,1,0,1,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'gold_rising':
+      return {
+        weeklySp: 175, lastWeeklySp: 140,
+        att: [1,1,1,1,0,1,1,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'gold_solid':
+      return {
+        weeklySp: 220, lastWeeklySp: 180,
+        att: [1,1,1,1,1,1,0,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'gold_big_gain':
+      return {
+        weeklySp: 310, lastWeeklySp: 150,
+        att: [1,1,1,1,1,1,1,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'platinum_steady':
+      return {
+        weeklySp: 250, lastWeeklySp: 220,
+        att: [1,1,1,1,1,1,1,0].map(q => ({ qualified: !!q })),
+        polls: highPolls(),
+      };
+    case 'platinum_quest':
+      return {
+        weeklySp: 340, lastWeeklySp: 260,
+        att: [1,1,1,1,1,1,1,1].map(q => ({ qualified: !!q })),
+        polls: highPolls(),
+      };
+    case 'legend_legend':      // top dog — wins Weekly Champion by a lot
+      return {
+        weeklySp: 420, lastWeeklySp: 350,
+        att: [1,1,1,1,1,1,1,1].map(q => ({ qualified: !!q })),
+        polls: highPolls(),
+      };
+    case 'newbie':             // joined this week → very small numbers, joinedThisMonth true
+      return {
+        weeklySp: 10, lastWeeklySp: 0,
+        att: [0,0,0,0,0,0,0,0].map(q => ({ qualified: !!q })),
+        polls: lowPolls(),
+      };
+    case 'comeback_kid':       // last week < 40%, this week ≥ 60% → "Biggest Comeback"
+      return {
+        weeklySp: 200, lastWeeklySp: 80,
+        att: [0,0,0,0,1,1,1,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'attendee_perfect':   // 100% qualification → "Most Consistent"
+      return {
+        weeklySp: 105, lastWeeklySp: 100,
+        att: [1,1,1,1,1,1,1,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'poll_master':        // ~95% attempted → standout on Poll Card
+      return {
+        weeklySp: 165, lastWeeklySp: 110,
+        att: [1,1,0,1,1,1,1,0].map(q => ({ qualified: !!q })),
+        polls: highPolls(),
+      };
+    case 'mixed_balanced':
+      return {
+        weeklySp: 125, lastWeeklySp: 105,
+        att: [1,0,1,1,1,0,1,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'big_bonus_day':      // big manual award on a single best session
+      return {
+        weeklySp: 240, lastWeeklySp: 130,
+        att: [1,0,1,0,1,1,0,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'slump_recover':
+      return {
+        weeklySp: 45, lastWeeklySp: 5,
+        att: [1,0,1,0,1,0,1,0].map(q => ({ qualified: !!q })),
+        polls: lowPolls(),
+      };
+    case 'quiet_contrib':      // solid bronze, decent attendance
+      return {
+        weeklySp: 85, lastWeeklySp: 70,
+        att: [1,1,0,0,1,1,1,0].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'last_week_champ':    // won last week big, smaller this week
+      return {
+        weeklySp: 30, lastWeeklySp: 380,
+        att: [0,1,0,1,0,1,0,0].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    case 'milestone_500':      // crosses lifetime 500 this month (Lifetime Card delta)
+      return {
+        weeklySp: 110, lastWeeklySp: 90,
+        att: [1,1,0,1,1,1,0,1].map(q => ({ qualified: !!q })),
+        polls: midPolls(),
+      };
+    default:
+      return {
+        weeklySp: 0, lastWeeklySp: 0,
+        att: Array(8).fill({ qualified: false }),
+        polls: lowPolls(),
+      };
+  }
+}
+
+function lowPolls()  { return Array(8).fill({ attempted: 3, total: 5 }); }
+function midPolls()  { return Array(8).fill({ attempted: 4, total: 5 }); }
+function highPolls() { return Array(8).fill({ attempted: 5, total: 5 }); }
+
+/* ── date helpers ────────────────────────────────── */
+
+// First day (00:00 IST = 18:30Z the day before) of the given YYYY-MM
+function juneMonthRange() {
+  const start = new Date('2026-06-01T00:00:00+05:30');  // June 1, 2026 IST
+  const end   = new Date('2026-07-01T00:00:00+05:30');  // exclusive
+  return { start, end };
+}
+
+// 8 weekday sessions spaced through June 2026 (Mon/Wed/Fri evenings)
+function juneSessions() {
+  // hard-coded labels so SPTransaction.sessionLabel matches cleanly
+  const dates = [
+    '2026-06-01T18:00:00+05:30',  // Mon  week 1
+    '2026-06-03T18:00:00+05:30',
+    '2026-06-05T18:00:00+05:30',
+    '2026-06-08T18:00:00+05:30',  // Mon  week 2
+    '2026-06-10T18:00:00+05:30',
+    '2026-06-12T18:00:00+05:30',
+    '2026-06-15T18:00:00+05:30',  // Mon  week 3
+    '2026-06-17T18:00:00+05:30',
+  ];
+  return dates.map((iso, i) => {
+    const start = new Date(iso);
+    const end   = new Date(new Date(iso).getTime() + 60 * 60 * 1000);
+    return {
+      label:          `JUNE-2026-S${i + 1}`,
+      date:           start,
+      startDateTime:  start,
+      endDateTime:    end,
+      totalMinutes:   60,
+      type:           'mock',
+    };
+  });
+}
+
+// Current week (this Mon → next Mon) and last week boundaries, server-local TZ
+function weekRanges() {
+  const now = new Date();
+  const day = now.getDay(); // 0=Sun..6=Sat
+  const diffToMon = day === 0 ? -6 : 1 - day;
+  const thisMon = new Date(now);
+  thisMon.setHours(0, 0, 0, 0);
+  thisMon.setDate(now.getDate() + diffToMon);
+  const nextMon = new Date(thisMon);
+  nextMon.setDate(thisMon.getDate() + 7);
+  const lastMon = new Date(thisMon);
+  lastMon.setDate(thisMon.getDate() - 7);
+  return { thisStart: thisMon, thisEnd: nextMon, lastStart: lastMon, lastEnd: thisMon };
+}
+
+/* ── main ────────────────────────────────────────── */
+async function run() {
+  await mongoose.connect(MONGO_URI);
+
+  const { start: juneStart, end: juneEnd } = juneMonthRange();
+  const sessions = juneSessions();
+  const { thisStart, lastStart, lastEnd } = weekRanges();
+  const weekLabelsThis = ['WLW-CURR-1', 'WLW-CURR-2'];          // 2 sessions this week
+  const weekLabelsLast = ['WLW-PREV-1', 'WLW-PREV-2'];          // 2 sessions last week
+
+  /* wipe existing dummies (idempotent re-run) */
+  const emails = ROSTER.map(r => r.email);
+  await Student.deleteMany({ email: { $in: emails } });
+  await SPTransaction.deleteMany({ email: { $in: emails } });
+  await AttendanceRecord.deleteMany({ email: { $in: emails } });
+  await PollRecord.deleteMany({ email: { $in: emails } });
+  await ChatRecord.deleteMany({ email: { $in: emails } });
+
+  // Build student docs
+  const students = ROSTER.map(r => {
+    const realName = `DUMMY ${attrsFromName(r.email.split('@')[0])} (dummy)`;
+    return {
+      name:                realName,            // name flagged with "(dummy)"
+      email:               r.email,
+      alternateEmail:      '',
+      internshipStartDate: new Date('2026-05-20T09:00:00+05:30'),
+      internshipEndDate:   new Date('2026-07-31T09:00:00+05:30'),
+      status:              'active',
+      totalSp:             r.totalSp,
+      highestSpEver:       r.totalSp,
+      level:               levelFor(r.totalSp),
+      trophyLeague:        leagueBand(r.totalSp),
+      legendBadgeUnlocked: false,
+      leaderboardGroup:    '2026-05-16_to_2026-05-31',
+    };
+  });
+  const inserted = await Student.insertMany(students);
+  const idByEmail = Object.fromEntries(inserted.map(s => [s.email, s._id]));
+
+  // Insert June sessions (only if not already present)
+  for (const s of sessions) {
+    const exists = await Session.findOne({ label: s.label }).lean();
+    if (!exists) await Session.create(s);
+  }
+
+  // Insert the synthetic week-window Session docs so that
+  // weekly-leaderboard.js (which derives labels from the Session collection
+  // by endDateTime) actually picks up the WLW-CURR-* / WLW-PREV-* labels.
+  // Without these, "thisWeekLabels" is empty -> chatMap / attThis are empty
+  // -> mostConsistent / biggestComeback / communityStar all resolve to null.
+  //
+  // weeklyLeaderboard.js defines this week as [thisMon, thisMon+7d).
+  // Place each synthetic session near the middle of its target window so the
+  // endDateTime definitely lands in [Mon, +Mon).
+  const weekSessions = [
+    { label: 'WLW-PREV-1', when: new Date(lastStart.getTime() + 1 * 86400000) },  // Tue last week
+    { label: 'WLW-PREV-2', when: new Date(lastStart.getTime() + 3 * 86400000) },  // Thu last week
+    { label: 'WLW-CURR-1', when: new Date(thisStart.getTime() + 2 * 86400000) },  // Wed this week
+    { label: 'WLW-CURR-2', when: new Date(thisStart.getTime() + 4 * 86400000) },  // Fri this week
+  ].map(w => {
+    const start = w.when;
+    const end   = new Date(start.getTime() + 60 * 60 * 1000);
+    return {
+      label:         w.label,
+      date:          start,
+      startDateTime: start,
+      endDateTime:   end,
+      totalMinutes:  60,
+      type:          'mock-weekly',
+    };
+  });
+  for (const w of weekSessions) {
+    const exists = await Session.findOne({ label: w.label }).lean();
+    if (!exists) await Session.create(w);
+  }
+
+  /* ── June activity: attendance + polls + transactions per dummy ── */
+  const txDocs = [];
+  const attDocs = [];
+  const pollDocs = [];
+  const chatDocs = [];
+
+  for (const r of ROSTER) {
+    const studentId = idByEmail[r.email];
+    const prof = profileFor(r.p, r.totalSp);
+
+    // Attendance + polls for each of 8 June sessions
+    sessions.forEach((sess, idx) => {
+      const att = prof.att[idx];
+      attDocs.push({
+        email:               r.email,
+        studentId,
+        sessionLabel:        sess.label,
+        attendedMinutes:     att.qualified ? 60 : 30,
+        totalSessionMinutes: 60,
+        attendancePercentage: att.qualified ? 100 : 50,
+        qualified:           att.qualified,
+      });
+
+      const p = prof.polls[idx];
+      pollDocs.push({
+        email:                r.email,
+        studentId,
+        sessionLabel:         sess.label,
+        totalQuestions:       p.total,
+        attemptedQuestions:   p.attempted,
+        missedQuestions:      p.total - p.attempted,
+      });
+
+      // SP transaction for each June session
+      // Allocate the dummy's monthly SP delta across sessions weighted by attendance
+      const sessionSp = Math.round(prof.weeklySp * 0.25); // ~4 weeks worth per month
+      if (att.qualified) {
+        txDocs.push({
+          email:         r.email,
+          studentId,
+          category:      'attendance',
+          sessionLabel:  sess.label,
+          deltaMode:     'absolute',
+          deltaValue:    sessionSp,
+          appliedDelta:  sessionSp,
+          balanceAfter:  0,
+          reason:        'Session attendance (dummy)',
+          dateTime:      sess.endDateTime,
+        });
+      }
+      // Per-session poll SP (smaller)
+      if (p.attempted >= 3) {
+        const pollSp = Math.round(p.attempted * 2);
+        txDocs.push({
+          email:         r.email,
+          studentId,
+          category:      'poll',
+          sessionLabel:  sess.label,
+          deltaMode:     'absolute',
+          deltaValue:    pollSp,
+          appliedDelta:  pollSp,
+          balanceAfter:  0,
+          reason:        'Poll participation (dummy)',
+          dateTime:      sess.endDateTime,
+        });
+      }
+    });
+
+    // "Big bonus day" gets one juicy manual award on the middle June session
+    if (r.p === 'big_bonus_day') {
+      txDocs.push({
+        email:         r.email,
+        studentId,
+        category:      'manual',
+        sessionLabel:  sessions[4].label,
+        deltaMode:     'absolute',
+        deltaValue:    120,
+        appliedDelta:  120,
+        balanceAfter:  0,
+        reason:        'Outstanding project demo (dummy)',
+        dateTime:      sessions[4].endDateTime,
+      });
+    }
+
+    // "Manual award" appears for several personalities so the Wrapped
+    // category-breakdown card has variation.
+    if (['platinum_quest', 'gold_big_gain', 'poll_master', 'mixed_balanced'].includes(r.p)) {
+      txDocs.push({
+        email:         r.email,
+        studentId,
+        category:      'manual',
+        sessionLabel:  sessions[6].label,
+        deltaMode:     'absolute',
+        deltaValue:    40,
+        appliedDelta:  40,
+        balanceAfter:  0,
+        reason:        'Mentor recognition (dummy)',
+        dateTime:      sessions[6].endDateTime,
+      });
+    }
+
+    /* ── Weekly leaderboard window ───────────────── */
+    // 1 synthetic session this week + 1 last week, plus transactions
+    for (const label of weekLabelsThis) {
+      txDocs.push({
+        email:         r.email,
+        studentId,
+        category:      'attendance',
+        sessionLabel:  label,
+        deltaMode:     'absolute',
+        deltaValue:    prof.weeklySp,
+        appliedDelta:  prof.weeklySp,
+        balanceAfter:  0,
+        reason:        'Weekly session (dummy)',
+        dateTime:      new Date(thisStart.getTime() + 60 * 60 * 1000),
+      });
+    }
+    for (const label of weekLabelsLast) {
+      txDocs.push({
+        email:         r.email,
+        studentId,
+        category:      'attendance',
+        sessionLabel:  label,
+        deltaMode:     'absolute',
+        deltaValue:    prof.lastWeeklySp,
+        appliedDelta:  prof.lastWeeklySp,
+        balanceAfter:  0,
+        reason:        'Weekly session (dummy)',
+        dateTime:      new Date(lastStart.getTime() + 60 * 60 * 1000),
+      });
+    }
+
+    /* ── Chat activity this week (drives "Community Star" category) ── */
+    // 2 dummies are set up to win the category outright. Others get a small
+    // base of positive reactions so the leaderboard has variation (not just
+    // two zeros and two winners).
+    let chatPositive;
+    let chatMessages;
+    switch (r.p) {
+      case 'platinum_quest':   chatPositive = 18; chatMessages = 42; break;
+      case 'poll_master':       chatPositive = 14; chatMessages = 38; break;
+      case 'gold_big_gain':     chatPositive = 11; chatMessages = 30; break;
+      case 'mixed_balanced':    chatPositive =  9; chatMessages = 28; break;
+      case 'silver_strong':     chatPositive =  7; chatMessages = 22; break;
+      case 'last_week_champ':   chatPositive =  6; chatMessages = 20; break;
+      case 'attendee_perfect':  chatPositive =  5; chatMessages = 18; break;
+      case 'quiet_contrib':     chatPositive =  4; chatMessages = 14; break;
+      case 'gold_solid':        chatPositive =  3; chatMessages = 12; break;
+      case 'platinum_steady':   chatPositive =  3; chatMessages = 11; break;
+      case 'gold_rising':       chatPositive =  2; chatMessages = 10; break;
+      case 'comeback_kid':      chatPositive =  2; chatMessages =  9; break;
+      case 'bronze_climber':    chatPositive =  1; chatMessages =  7; break;
+      case 'silver_avg':        chatPositive =  1; chatMessages =  6; break;
+      default:                  chatPositive =  0; chatMessages =  4;
+    }
+    // Spread the positive counts across the two synthetic "this week" sessions.
+    const split1 = Math.ceil(chatPositive * 0.6);
+    const split2 = chatPositive - split1;
+    for (const [label, pos] of [[weekLabelsThis[0], split1], [weekLabelsThis[1], split2]]) {
+      if (pos > 0 || chatMessages > 0) {
+        chatDocs.push({
+          email:         r.email,
+          studentId,
+          sessionLabel:  label,
+          positiveCount: pos,
+          messageCount:  Math.max(pos, Math.ceil(chatMessages / 2)),
+        });
+      }
+    }
+  }
+
+  // balanceAfter isn't actively queried for display, but the model requires it.
+  // Recompute it cheaply: walk this dummy's sorted tx list and apply.
+  // (Belt-and-braces — won't break anything if user re-runs.)
+  const balances = {};
+  for (const t of txDocs) {
+    balances[t.email] = (balances[t.email] || 0) + t.appliedDelta;
+    t.balanceAfter = balances[t.email];
+  }
+
+  // Insert dummy-only AttendanceRecord rows for the synthetic weekly labels
+  // so "Most Consistent" / "Biggest Comeback" categories resolve correctly.
+  // Real students have no AttendanceRecord for these synthetic labels, so the
+  // per-dummy winners of these categories come purely from this dataset.
+  const weeklyAttDocs = [];
+  for (const r of ROSTER) {
+    const studentId = idByEmail[r.email];
+    const prof = profileFor(r.p, r.totalSp);
+    // Take last 2 att flags from the June profile (re-uses existing behavior).
+    const lastTwo = prof.att.slice(-2).map(a => !!a.qualified);
+    weeklyAttDocs.push({
+      email:                r.email,
+      studentId,
+      sessionLabel:         'WLW-CURR-1',
+      attendedMinutes:      lastTwo[0] ? 60 : 30,
+      totalSessionMinutes:  60,
+      attendancePercentage: lastTwo[0] ? 100 : 50,
+      qualified:            lastTwo[0],
+    });
+    weeklyAttDocs.push({
+      email:                r.email,
+      studentId,
+      sessionLabel:         'WLW-CURR-2',
+      attendedMinutes:      lastTwo[1] ? 60 : 30,
+      totalSessionMinutes:  60,
+      attendancePercentage: lastTwo[1] ? 100 : 50,
+      qualified:            lastTwo[1],
+    });
+    // Last-week attendance is derived so 'comeback_kid' (prior <40% / this >=60%)
+    // and 'attendee_perfect' (always 100%) categories resolve correctly.
+    // Heuristic: 80% of dummies got last-week attendance same as this-week
+    // (steady state); the 'comeback_kid' personality specifically had a low
+    // prior week (1/2 = 50% — close to <40%) — so push to 1/2 = 50% (still >40%).
+    // Use 0/2 for last week to guarantee <40%, and use the same this-week
+    // pattern for everyone else (steady).
+    const lastTwoPrev = (r.p === 'comeback_kid') ? [false, false] : lastTwo;
+    weeklyAttDocs.push({
+      email:                r.email,
+      studentId,
+      sessionLabel:         'WLW-PREV-1',
+      attendedMinutes:      lastTwoPrev[0] ? 60 : 30,
+      totalSessionMinutes:  60,
+      attendancePercentage: lastTwoPrev[0] ? 100 : 50,
+      qualified:            lastTwoPrev[0],
+    });
+    weeklyAttDocs.push({
+      email:                r.email,
+      studentId,
+      sessionLabel:         'WLW-PREV-2',
+      attendedMinutes:      lastTwoPrev[1] ? 60 : 30,
+      totalSessionMinutes:  60,
+      attendancePercentage: lastTwoPrev[1] ? 100 : 50,
+      qualified:            lastTwoPrev[1],
+    });
+  }
+  await AttendanceRecord.insertMany(weeklyAttDocs);
+
+  await AttendanceRecord.insertMany(attDocs);
+  await PollRecord.insertMany(pollDocs);
+  await SPTransaction.insertMany(txDocs);
+  if (chatDocs.length) await ChatRecord.insertMany(chatDocs);
+
+  console.log('─'.repeat(56));
+  console.log('Seeded 20 dummies at @spurti.test');
+  console.log('Sessions inserted:', sessions.length);
+  console.log('Attendance records:', attDocs.length);
+  console.log('Poll records:     ', pollDocs.length);
+  console.log('Chat records:     ', chatDocs.length);
+  console.log('SP transactions:  ', txDocs.length);
+  console.log('Tear down later with:  node remove-dummies.js');
+  console.log('─'.repeat(56));
+
+  await mongoose.disconnect();
+}
+
+run().catch(async err => {
+  console.error(err);
+  await mongoose.disconnect();
+  process.exit(1);
+});

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,92 @@
+/**
+ * server/auth.js
+ *
+ * Shared auth helpers for routes that need to identify the current student.
+ * Implemented identically to the version that used to live inline in
+ * server.js — extracted to a module so route files (e.g.
+ * routes/weeklyLeaderboard.js) can reuse the same auth pattern as /me,
+ * /wrapped, etc.
+ */
+import { SAMAGAMA_AUTH_URL } from './config.js';
+
+export function normalizeEmail(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function parseCookies(header = '') {
+  return Object.fromEntries(String(header).split(';').map(part => {
+    const index = part.indexOf('=');
+    if (index < 0) return null;
+    return [part.slice(0, index).trim(), decodeURIComponent(part.slice(index + 1).trim())];
+  }).filter(Boolean));
+}
+
+// Validate the student's Samagama session by forwarding their chatengine_token
+// cookie to Samagama's internal auth endpoint. Returns the user object on success.
+export async function getSamagamaUser(chatengineToken) {
+  if (!chatengineToken) return null;
+  try {
+    const res = await fetch(SAMAGAMA_AUTH_URL, {
+      headers: { cookie: `chatengine_token=${chatengineToken}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function studentEmailFromRequest(req) {
+  const cookies = parseCookies(req.headers.cookie || '');
+  const data = await getSamagamaUser(cookies.chatengine_token);
+  // Samagama's /api/auth/me nests the user as { user: { email, ... } };
+  // fall back to a top-level email in case the shape ever flattens.
+  const email = data?.user?.email || data?.email;
+  if (!email) return null;
+  return normalizeEmail(email);
+}
+
+// Dev helper: try ?asEmail= first, then a localhost-only dev cookie set by
+// the search/confirm login flow, then real auth. NO localhost default —
+// the user must explicitly request an impersonated student via ?asEmail=
+// or complete the search/confirm flow. Returns the email string, or null
+// if neither path produced one.
+export async function resolveStudentEmail(req) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (req.query.asEmail) return normalizeEmail(req.query.asEmail);
+    // Honor the devStudentEmail cookie set by /search (exact match) or
+    // /confirm in non-production. This lets the manual login UX drive
+    // student-specific endpoints without a Samagama session cookie.
+    const cookies = parseCookies(req.headers.cookie || '');
+    if (cookies.devStudentEmail) return normalizeEmail(cookies.devStudentEmail);
+  }
+  return await studentEmailFromRequest(req);
+}
+
+// Set the devStudentEmail cookie on the response (localhost/non-prod only).
+// httpOnly so the client JS can't tamper with it. By default this is a
+// session cookie (no Max-Age), so it dies when the browser tab closes and
+// a refresh re-prompts for credentials. Set DEV_COOKIE_MAX_AGE_SECONDS in
+// .env to a positive number if you want a longer-lived cookie for testing.
+export function setDevStudentCookie(res, email) {
+  if (process.env.NODE_ENV === 'production') return;
+  const value = encodeURIComponent(normalizeEmail(email));
+  const maxAgeSec = Number(process.env.DEV_COOKIE_MAX_AGE_SECONDS) || 0;
+  const attrs = [
+    `devStudentEmail=${value}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+  if (maxAgeSec > 0) attrs.push(`Max-Age=${maxAgeSec}`);
+  res.setHeader('Set-Cookie', attrs.join('; '));
+}
+
+// Clear the devStudentEmail cookie (e.g. on logout).
+export function clearDevStudentCookie(res) {
+  res.setHeader(
+    'Set-Cookie',
+    'devStudentEmail=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax'
+  );
+}

--- a/server/models/ChatRecord.js
+++ b/server/models/ChatRecord.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+
+/**
+ * ChatRecord
+ *
+ * Aggregated per-session chat-positive scores for a student.
+ * Populated by whatever pipeline scrapes / scores the chat transcript
+ * (e.g. a scheduled job that runs after the session ends). The weekly
+ * leaderboard uses `positiveCount` for the "Community Star" category.
+ *
+ * Schema matches what `server/routes/weeklyLeaderboard.js` reads:
+ *   - email + sessionLabel (join key, unique together)
+ *   - positiveCount       (sum of "👍" / helpful reactions)
+ *   - messageCount        (raw total — not currently displayed)
+ */
+const chatRecordSchema = new mongoose.Schema({
+  email:        { type: String, required: true, lowercase: true, trim: true, index: true },
+  studentId:    { type: mongoose.Schema.Types.ObjectId, ref: 'Student', index: true },
+  sessionLabel: { type: String, required: true, index: true },
+  positiveCount: { type: Number, default: 0 },
+  messageCount: { type: Number, default: 0 },
+}, { timestamps: true });
+
+chatRecordSchema.index({ email: 1, sessionLabel: 1 }, { unique: true });
+
+export default mongoose.model('ChatRecord', chatRecordSchema);

--- a/server/routes/ghostRace.js
+++ b/server/routes/ghostRace.js
@@ -1,0 +1,332 @@
+/**
+ * server/routes/ghostRace.js
+ *
+ * GET /api/ghost-race
+ *
+ * Returns this-week vs last-week SP comparison for the calling student.
+ * Powers the "Race Your Ghost" overlay in the client.
+ *
+ * Response shape (matches client/src/GhostRace.jsx expectations):
+ *   {
+ *     today,                // 'Mon'..'Sun'
+ *     weekOf,               // ISO date string, Monday of this week
+ *     thisWeek: { totalSp, dailyMap, sessions[], sessionCount, sessionsQualified },
+ *     ghost: {
+ *       hasGhost, weekOf, totalSp, dailyMap, sessions[],
+ *       status,             // 'ahead' | 'behind' | 'tied' | 'no-ghost'
+ *       spDiff,             // positive = you're ahead of ghost at this point
+ *       thisWindowSp,
+ *       lastWindowSp,
+ *       message,
+ *     },
+ *     personalBests: { bestWeeklySp, bestWeekOf, bestSession: {label, sp}, bestStreak },
+ *   }
+ *
+ * Auth: same resolveStudentEmail helper used by /me, /wrapped, and
+ * /weekly-leaderboard (chatengine_token passthrough -> SAMAGAMA_AUTH_URL
+ * in prod; ?asEmail= or devStudentEmail cookie in non-prod).
+ *
+ * Pure read-only — no writes.
+ */
+
+import express from 'express';
+
+import Student             from '../models/Student.js';
+import Session             from '../models/Session.js';
+import AttendanceRecord    from '../models/AttendanceRecord.js';
+import SPTransaction       from '../models/SPTransaction.js';
+import { resolveStudentEmail } from '../auth.js';
+
+const router = express.Router();
+
+/* ── Week boundary helpers (Mon 00:00 → Sun 23:59) ──── */
+function weekStart(date = new Date()) {
+  const d   = new Date(date);
+  const day = d.getDay(); // 0=Sun
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - (day === 0 ? 6 : day - 1));
+  return d;
+}
+
+function currentWeek() {
+  const start = weekStart();
+  const end   = new Date(start);
+  end.setDate(start.getDate() + 7);
+  return { start, end };
+}
+
+function lastWeek() {
+  const thisStart = weekStart();
+  const end   = new Date(thisStart);
+  const start = new Date(thisStart);
+  start.setDate(thisStart.getDate() - 7);
+  return { start, end };
+}
+
+/* ── Day-key helpers ────────────────────────────────── */
+const DAY_KEYS  = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+const DAY_INDEX = { Mon:0, Tue:1, Wed:2, Thu:3, Fri:4, Sat:5, Sun:6 };
+
+function dayKey(date) {
+  // JS getDay: 0=Sun,1=Mon,...,6=Sat. Map to our Mon-first order.
+  const keys = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+  return keys[new Date(date).getDay()];
+}
+
+function todayKey() {
+  return dayKey(new Date());
+}
+
+/* ── Daily SP map ───────────────────────────────────── */
+function buildDailyMap(transactions) {
+  const m = { Mon:0, Tue:0, Wed:0, Thu:0, Fri:0, Sat:0, Sun:0 };
+  for (const t of transactions) {
+    const k = dayKey(t.dateTime);
+    m[k] = (m[k] || 0) + (t.appliedDelta || 0);
+  }
+  return m;
+}
+
+/* ── Sum daily SP up to and including `targetDay` ──── */
+// Used to compare "this week so far" vs "last week at same point"
+function sumUpToDay(dailyMap, targetDay) {
+  const cutoff = DAY_INDEX[targetDay];
+  if (cutoff === undefined) return 0;
+  return DAY_KEYS.slice(0, cutoff + 1)
+    .reduce((s, d) => s + (dailyMap[d] || 0), 0);
+}
+
+/* ── Ghost motivational message ────────────────────── */
+function ghostMessage(status, spDiff, today) {
+  const late = ['Thu','Fri','Sat','Sun'].includes(today);
+  if (status === 'no-ghost')
+    return "No ghost yet \u2014 race begins after your first full week! \uD83D\uDC7B";
+  if (status === 'tied')
+    return "Perfectly tied with your ghost. One session tips the balance. \uD83D\uDC7B";
+  if (status === 'ahead') {
+    if (spDiff >= 20)
+      return `You're crushing your ghost by ${spDiff} SP. Unstoppable. \uD83D\uDC7B\uD83D\uDD25`;
+    if (spDiff >= 10)
+      return `${spDiff} SP ahead of your ghost. Keep the pressure on. \uD83D\uDC7B`;
+    return `${spDiff} SP ahead of your ghost. Don't let it catch up. \uD83D\uDC7B`;
+  }
+  // behind
+  if (late && Math.abs(spDiff) > 15)
+    return `Ghost is ${Math.abs(spDiff)} SP ahead. Still time to close the gap. \uD83D\uDC7B`;
+  if (Math.abs(spDiff) <= 5)
+    return `Ghost is only ${Math.abs(spDiff)} SP ahead. You can catch it today. \uD83D\uDC7B`;
+  return `Ghost earned ${Math.abs(spDiff)} more SP at this point last week. Chase it. \uD83D\uDC7B`;
+}
+
+/* ── Best weekly SP (all-time) ──────────────────────── */
+// Groups all transactions by ISO week (Mon-based epoch weeks).
+// EPOCH_MON: Jan 5 1970 was the first Monday-aligned week boundary.
+// Bucket = floor((dateTime - EPOCH_MON) / WEEK_MS).
+async function computeBestWeek(email) {
+  const WEEK_MS   = 7 * 24 * 60 * 60 * 1000;
+  const EPOCH_MON = 4 * 24 * 60 * 60 * 1000; // Jan 5 1970 in ms epoch
+
+  const agg = await SPTransaction.aggregate([
+    { $match: { email } },
+    { $addFields: {
+        weekBucket: {
+          $floor: {
+            $divide: [
+              { $subtract: [
+                  { $toLong: '$dateTime' },
+                  EPOCH_MON,
+              ]},
+              WEEK_MS,
+            ],
+          },
+        },
+    }},
+    { $group: {
+        _id: '$weekBucket',
+        totalSp:   { $sum: '$appliedDelta' },
+        firstDate: { $min: '$dateTime' },
+    }},
+    { $sort: { totalSp: -1 } },
+    { $limit: 1 },
+  ]);
+
+  if (!agg.length) return { bestWeeklySp: 0, bestWeekOf: null };
+  const monDate = weekStart(new Date(agg[0].firstDate));
+  return {
+    bestWeeklySp: agg[0].totalSp,
+    bestWeekOf:   monDate.toISOString().slice(0, 10),
+  };
+}
+
+/* ── Best session SP (all-time) ─────────────────────── */
+async function computeBestSession(email) {
+  const agg = await SPTransaction.aggregate([
+    { $match: {
+        email,
+        sessionLabel: { $exists: true, $ne: null, $ne: '' },
+    }},
+    { $group: {
+        _id: '$sessionLabel',
+        sp:  { $sum: '$appliedDelta' },
+    }},
+    { $sort: { sp: -1 } },
+    { $limit: 1 },
+  ]);
+  if (!agg.length) return { label: null, sp: 0 };
+  return { label: agg[0]._id, sp: agg[0].sp };
+}
+
+/* ── Main route ──────────────────────────────────────── */
+router.get('/', async (req, res) => {
+  try {
+    /* Auth — same pattern as /me, /wrapped, weekly-leaderboard. */
+    const email = await resolveStudentEmail(req);
+    if (!email) return res.status(401).json({ error: 'Unauthorized' });
+
+    const student = await Student.findOne({ email }).lean();
+    if (!student)  return res.status(404).json({ error: 'Not found' });
+    if (student.status === 'excused')
+      return res.status(403).json({ error: 'Excused' });
+
+    const { start: thisStart, end: thisEnd } = currentWeek();
+    const { start: lastStart, end: lastEnd } = lastWeek();
+    const today = todayKey();
+
+    /* Parallel fetch */
+    const [thisTx, lastTx, thisSessions, lastSessions] = await Promise.all([
+      SPTransaction.find({
+        email,
+        dateTime: { $gte: thisStart, $lt: thisEnd },
+      }).lean(),
+      SPTransaction.find({
+        email,
+        dateTime: { $gte: lastStart, $lt: lastEnd },
+      }).lean(),
+      Session.find({
+        endDateTime: { $gte: thisStart, $lt: thisEnd },
+      }).lean(),
+      Session.find({
+        endDateTime: { $gte: lastStart, $lt: lastEnd },
+      }).lean(),
+    ]);
+
+    /* Only fetch attendance records for THIS student's sessions in both
+       windows — keeps the record set small. */
+    const allLabels = [
+      ...thisSessions.map(s => s.label),
+      ...lastSessions.map(s => s.label),
+    ];
+    const attendance = allLabels.length
+      ? await AttendanceRecord.find({
+          email,
+          sessionLabel: { $in: allLabels },
+        }).lean()
+      : [];
+    const attByLabel = Object.fromEntries(
+      attendance.map(r => [r.sessionLabel, r])
+    );
+
+    /* Daily maps */
+    const thisDailyMap = buildDailyMap(thisTx);
+    const lastDailyMap = buildDailyMap(lastTx);
+
+    /* Total SP for each week */
+    const thisWeekTotal = thisTx
+      .reduce((s, t) => s + (t.appliedDelta || 0), 0);
+    const lastWeekTotal = lastTx
+      .reduce((s, t) => s + (t.appliedDelta || 0), 0);
+
+    /* Comparable window: this week so far vs last week at same day */
+    const thisWindowSp = sumUpToDay(thisDailyMap, today);
+    const lastWindowSp = sumUpToDay(lastDailyMap, today);
+
+    /* Ghost status */
+    const hasGhost = lastTx.length > 0;
+    let ghostStatus = 'no-ghost';
+    let spDiff = 0;
+    if (hasGhost) {
+      spDiff = thisWindowSp - lastWindowSp;
+      if (spDiff > 0)      ghostStatus = 'ahead';
+      else if (spDiff < 0) ghostStatus = 'behind';
+      else                 ghostStatus = 'tied';
+    }
+
+    /* Per-session rollups */
+    const buildSessionRows = (sessions, txSet, attSet) =>
+      sessions.map(s => ({
+        label:     s.label,
+        qualified: !!(attSet[s.label]?.qualified),
+        sp: txSet
+          .filter(t => t.sessionLabel === s.label)
+          .reduce((sum, t) => sum + (t.appliedDelta || 0), 0),
+      }));
+
+    const thisSessionData = buildSessionRows(thisSessions, thisTx, attByLabel);
+    const lastSessionData = buildSessionRows(lastSessions, lastTx, attByLabel);
+
+    /* Personal bests (parallel) */
+    const [bestWeek, bestSession] = await Promise.all([
+      computeBestWeek(email),
+      computeBestSession(email),
+    ]);
+
+    /* Streak — best effort; if progress.js disappears the field is null. */
+    let bestStreak = null;
+    try {
+      const { computeStreak } = await import('../services/progress.js');
+      const now = new Date();
+      const allSessions = await Session
+        .find().sort({ endDateTime: 1 }).lean();
+      const applicable = allSessions.filter(s =>
+        new Date(s.endDateTime) <= now &&
+        new Date(s.endDateTime) >= new Date(student.internshipStartDate)
+      );
+      const allAtt = await AttendanceRecord.find({ email }).lean();
+      const allAttMap = Object.fromEntries(
+        allAtt.map(r => [r.sessionLabel, r])
+      );
+      const flags = applicable.map(s =>
+        !!allAttMap[s.label]?.qualified
+      );
+      ({ longestStreak: bestStreak } = computeStreak(flags));
+    } catch (_) { /* progress.js absent — skip */ }
+
+    return res.json({
+      today,
+      weekOf: thisStart.toISOString().slice(0, 10),
+
+      thisWeek: {
+        totalSp:          thisWeekTotal,
+        dailyMap:         thisDailyMap,
+        sessions:         thisSessionData,
+        sessionCount:     thisSessions.length,
+        sessionsQualified: thisSessionData.filter(s => s.qualified).length,
+      },
+
+      ghost: {
+        hasGhost,
+        weekOf:        lastStart.toISOString().slice(0, 10),
+        totalSp:       lastWeekTotal,
+        dailyMap:      lastDailyMap,
+        sessions:      lastSessionData,
+        status:        ghostStatus,
+        spDiff,
+        thisWindowSp,
+        lastWindowSp,
+        message:       ghostMessage(ghostStatus, spDiff, today),
+      },
+
+      personalBests: {
+        bestWeeklySp:  bestWeek.bestWeeklySp,
+        bestWeekOf:    bestWeek.bestWeekOf,
+        bestSession,
+        bestStreak,
+      },
+    });
+  } catch (err) {
+    console.error('[ghostRace]', err);
+    return res.status(500).json({ error: 'Server error' });
+  }
+});
+
+export default router;

--- a/server/routes/weeklyLeaderboard.js
+++ b/server/routes/weeklyLeaderboard.js
@@ -1,0 +1,243 @@
+import express from 'express';
+
+import Student from '../models/Student.js';
+import Session from '../models/Session.js';
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import ChatRecord from '../models/ChatRecord.js';
+import SPTransaction from '../models/SPTransaction.js';
+import { studentEmailFromRequest, resolveStudentEmail } from '../auth.js';
+
+const router = express.Router();
+
+function maskEmail(email = '') {
+ const [local, domain] = email.split('@');
+ if (!local) return email;
+ return local.slice(0, 2) + '***@' + (domain || '');
+}
+
+/* ── week boundaries (Mon 00:00 → Sun 23:59) ────── */
+function currentWeekRange() {
+ const now = new Date();
+ const day = now.getDay(); // 0=Sun..6=Sat
+ const diff = day === 0 ? -6 : 1 - day; // offset to Monday
+ const mon = new Date(now);
+ mon.setHours(0, 0, 0, 0);
+ mon.setDate(now.getDate() + diff);
+ const nextMon = new Date(mon);
+ nextMon.setDate(mon.getDate() + 7);
+ return { weekStart: mon, weekEnd: nextMon };
+}
+
+function prevWeekRange() {
+ const { weekStart } = currentWeekRange();
+ const prevMon = new Date(weekStart);
+ prevMon.setDate(weekStart.getDate() - 7);
+ return { weekStart: prevMon, weekEnd: new Date(weekStart) };
+}
+
+/* ── league assignment ───────────────────────────── */
+function assignLeagues(rankedRows) {
+ const n = rankedRows.length;
+ const gold = Math.max(1, Math.floor(n * 0.25));
+ const silv = Math.max(gold + 1, Math.floor(n * 0.60));
+ return rankedRows.map((row, i) => ({
+ ...row,
+ league: i < gold ? 'gold' : i < silv ? 'silver' : 'bronze',
+ }));
+}
+
+/* ── main route ──────────────────────────────────── */
+router.get('/', async (req, res) => {
+ try {
+ /* auth — use the same Samagama-validated pattern as /me and /wrapped.
+ In dev (?asEmail=…) the impersonation must beat the real auth check so
+ the browser can preview the weekly leaderboard without a Samagama cookie.
+ On localhost with no real auth we fall back to dummy1. */
+ const email = await resolveStudentEmail(req);
+ if (!email) return res.status(401).json({ error: 'Unauthorized' });
+
+ const me = await Student.findOne({ email }).lean();
+ if (!me) return res.status(404).json({ error: 'Not found' });
+ if (me.status === 'excused')
+ return res.status(403).json({ error: 'Excused' });
+
+ const { weekStart, weekEnd } = currentWeekRange();
+ const { weekStart: prevStart, weekEnd: prevEnd } = prevWeekRange();
+
+ /* fetch all data in one round-trip */
+ const [
+ thisWeekTx, lastWeekTx,
+ thisWeekSessions, allStudents,
+ ] = await Promise.all([
+ SPTransaction.aggregate([
+ { $match: { dateTime: { $gte: weekStart, $lt: weekEnd } } },
+ { $group: { _id: '$email',
+ periodSp: { $sum: '$appliedDelta' } } },
+ ]),
+ SPTransaction.aggregate([
+ { $match: { dateTime: { $gte: prevStart, $lt: prevEnd } } },
+ { $group: { _id: '$email',
+ periodSp: { $sum: '$appliedDelta' } } },
+ ]),
+ Session.find({
+ endDateTime: { $gte: weekStart, $lt: weekEnd },
+ }).lean(),
+ Student.find({ status: 'active' }).lean(),
+ ]);
+
+ const studentMap = Object.fromEntries(
+ allStudents.map(s => [s.email, s])
+ );
+ const thisWeekSpMap = Object.fromEntries(
+ thisWeekTx.map(r => [r._id, r.periodSp])
+ );
+ const lastWeekSpMap = Object.fromEntries(
+ lastWeekTx.map(r => [r._id, r.periodSp])
+ );
+
+ /* attendance + chat for this week's sessions */
+ const weekLabels = thisWeekSessions.map(s => s.label);
+ const [thisWeekAtt, thisWeekChat,
+ lastWeekSessions] = await Promise.all([
+ weekLabels.length
+ ? AttendanceRecord.find({
+ sessionLabel: { $in: weekLabels },
+ }).lean()
+ : Promise.resolve([]),
+ weekLabels.length
+ ? ChatRecord.find({
+ sessionLabel: { $in: weekLabels },
+ }).lean()
+ : Promise.resolve([]),
+ Session.find({
+ endDateTime: { $gte: prevStart, $lt: prevEnd },
+ }).lean(),
+ ]);
+
+ const prevLabels = lastWeekSessions.map(s => s.label);
+ const lastWeekAtt = prevLabels.length
+ ? await AttendanceRecord.find({
+ sessionLabel: { $in: prevLabels },
+ }).lean()
+ : [];
+
+ /* attendance maps: email → { qualified, total } */
+ function buildAttMap(records) {
+ const m = {};
+ for (const r of records) {
+ if (!m[r.email]) m[r.email] = { q: 0, t: 0 };
+ m[r.email].t += 1;
+ if (r.qualified) m[r.email].q += 1;
+ }
+ return m;
+ }
+ const thisAttMap = buildAttMap(thisWeekAtt);
+ const prevAttMap = buildAttMap(lastWeekAtt);
+
+ /* chat map: email → sum positiveCount */
+ const chatMap = {};
+ for (const c of thisWeekChat) {
+ chatMap[c.email] = (chatMap[c.email] || 0) +
+ (c.positiveCount || 0);
+ }
+
+ /* ── Build ranked rows ─────────────────────── */
+ const rows = allStudents
+ .map(s => ({
+ email: s.email,
+ name: s.name,
+ maskedEmail: maskEmail(s.email),
+ periodSp: thisWeekSpMap[s.email] || 0,
+ lastPeriodSp: lastWeekSpMap[s.email] || 0,
+ totalSp: s.totalSp || 0,
+ level: s.level ?? null,
+ trophyLeague: s.trophyLeague ?? null,
+ attThis: thisAttMap[s.email] || { q: 0, t: 0 },
+ attPrev: prevAttMap[s.email] || { q: 0, t: 0 },
+ chatScore: chatMap[s.email] || 0,
+ isCurrentStudent: s.email === me.email,
+ }))
+ .sort((a, b) => b.periodSp - a.periodSp)
+ .map((row, i) => ({ ...row, rank: i + 1 }));
+
+ const withLeagues = assignLeagues(rows);
+
+ /* ── Category winners ──────────────────────── */
+ function winner(arr, scoreFn) {
+ if (!arr.length) return null;
+ const scored = arr
+ .map(r => ({ ...r, _score: scoreFn(r) }))
+ .filter(r => r._score > 0)
+ .sort((a, b) => b._score - a._score);
+ if (!scored.length) return null;
+ const w = scored[0];
+ return {
+ name: w.name,
+ maskedEmail: w.maskedEmail,
+ trophyLeague: w.trophyLeague,
+ score: w._score,
+ isCurrentStudent: w.isCurrentStudent,
+ };
+ }
+
+ const categoryWinners = {
+ weeklyChampion: winner(withLeagues,
+ r => r.periodSp),
+ mostConsistent: winner(
+ withLeagues.filter(r => r.attThis.t > 0),
+ r => r.attThis.q / r.attThis.t),
+ mostImproved: winner(
+ withLeagues.filter(r => r.lastPeriodSp > 0),
+ r => r.periodSp - r.lastPeriodSp),
+ biggestComeback: winner(
+ withLeagues.filter(r =>
+ r.attPrev.t > 0 && r.attThis.t > 0 &&
+ (r.attPrev.q / r.attPrev.t) < 0.40 &&
+ (r.attThis.q / r.attThis.t) >= 0.60
+ ),
+ r => (r.attThis.q / r.attThis.t) -
+ (r.attPrev.q / r.attPrev.t)),
+ communityStar: winner(withLeagues,
+ r => r.chatScore),
+ };
+
+ /* ── Split into leagues ────────────────────── */
+ const leagueRows = row => ({
+ rank: row.rank,
+ name: row.name,
+ maskedEmail: row.maskedEmail,
+ periodSp: row.periodSp,
+ totalSp: row.totalSp,
+ level: row.level,
+ trophyLeague: row.trophyLeague,
+ league: row.league,
+ isCurrentStudent: row.isCurrentStudent,
+ });
+
+ const leagues = {
+ gold: withLeagues.filter(r => r.league === 'gold')
+ .map(leagueRows),
+ silver: withLeagues.filter(r => r.league === 'silver')
+ .map(leagueRows),
+ bronze: withLeagues.filter(r => r.league === 'bronze')
+ .map(leagueRows),
+ };
+
+ const myRow = withLeagues.find(r => r.email === me.email);
+
+ return res.json({
+ weekOf: weekStart.toISOString().slice(0, 10),
+ totalActive: allStudents.length,
+ leagues,
+ categoryWinners,
+ yourLeague: myRow?.league ?? null,
+ yourRank: myRow?.rank ?? null,
+ yourPeriodSp: myRow?.periodSp ?? 0,
+ });
+ } catch (err) {
+ console.error('[weeklyLeaderboard]', err);
+ return res.status(500).json({ error: 'Server error' });
+ }
+});
+
+export default router;

--- a/server/scripts/seed-dummies.js
+++ b/server/scripts/seed-dummies.js
@@ -1,0 +1,223 @@
+// DUMMY data seeder for spurti
+// Idempotent: cleans up by tag regex first, then inserts.
+// Run: node server/scripts/seed-dummies.js
+// Drop: node server/scripts/seed-dummies.js --drop
+//
+// 20 dummy students total:
+//   dummy1-10: all 13 sessions qualified  → Excellent 100%, streak 13, freezes 2
+//              highestSpEver varied 100..1620 across the 10 to show levels 1..16
+//   dummy11-20: deliberately varied last-5 patterns to demo all 4 bands,
+//               various streaks (0..13), levels (1..5), and trends (up/down/steady).
+//
+// All real student data is left untouched.
+
+import mongoose from 'mongoose';
+import Student from '../models/Student.js';
+import Session from '../models/Session.js';
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import SPTransaction from '../models/SPTransaction.js';
+import { MONGO_URI } from '../config.js';
+
+const DROP = process.argv.includes('--drop');
+const NOW = new Date();
+const DAY = 24 * 60 * 60 * 1000;
+
+// ────────────────────────────────────────────────────────────────────
+// Dummy definitions
+// ────────────────────────────────────────────────────────────────────
+//
+// Each entry: [name, email, qualifiedPattern(13 booleans), highestSpEver]
+// highestSpEver sets totalSp/level/levelProgress. totalSp mirrors it (this
+// is fine for demo purposes).
+//
+// Pattern positions are OLDEST (1) → NEWEST (13). The progress band is
+// computed from the LAST 5 entries (positions 9..13), so that's where the
+// band variety comes from. The streak walks the entire array.
+//
+const DUMMY_DEFS = [
+  // ── Group A: all 13 qualified, varying levels ──────────────────────
+  // (Level = floor(highestSpEver/100), levelProgress = highestSpEver % 100)
+  ['DUMMY One',   'dummy1@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 100],   // L1  / 0
+  ['DUMMY Two',   'dummy2@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 250],   // L2  / 50
+  ['DUMMY Three', 'dummy3@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 380],   // L3  / 80
+  ['DUMMY Four',  'dummy4@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 540],   // L5  / 40
+  ['DUMMY Five',  'dummy5@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 720],   // L7  / 20
+  ['DUMMY Six',   'dummy6@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 880],   // L8  / 80
+  ['DUMMY Seven', 'dummy7@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 1010],  // L10 / 10
+  ['DUMMY Eight', 'dummy8@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 1150],  // L11 / 50
+  ['DUMMY Nine',  'dummy9@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1], 1380],  // L13 / 80
+  ['DUMMY Ten',   'dummy10@spurti.test', [1,1,1,1,1,1,1,1,1,1,1,1,1], 1620],  // L16 / 20 (Legend candidate)
+
+  // ── Group B: deliberately varied bands, streaks, trends, levels ─────
+  // Each pattern is hand-tuned so the last-5 + streak + trend produce
+  // a distinct, recognizable UI state covering all 4 bands.
+  //
+  // last5 = positions 9..13. band rates: 5/5=100%, 4/5=80% Excellent;
+  // 3/5=60% Active; 2/5=40% Slowing Down; 0..1/5=Recovery.
+  // trend compares recent(pos 11..13) vs prev(pos 7..9).
+  //
+  // Verify by running `node server/scripts/_design.js`.
+
+  ['DUMMY Eleven',  'dummy11@spurti.test',  [1,1,1,1,1,1,1,1,1,1,1,1,1],  100], // Excellent 100% steady,    streak 13, frz 2 — L1  / 0
+  ['DUMMY Twelve',  'dummy12@spurti.test',  [1,1,1,1,1,1,1,1,1,1,0,1,1],  240], // Excellent  80% down,      streak 12, frz 1 — L2  / 40
+  ['DUMMY Thirteen','dummy13@spurti.test',  [1,1,1,1,1,1,0,0,0,1,1,1,1],  380], // Excellent  80% up,        streak 4,  frz 1 — L3  / 80
+  ['DUMMY Fourteen', 'dummy14@spurti.test', [1,1,1,1,1,0,0,0,0,0,1,1,1],  460], // Active     60% up,        streak 3,  frz 0 — L4  / 60
+  ['DUMMY Fifteen',  'dummy15@spurti.test', [1,1,1,1,1,1,1,0,1,1,0,0,1],  540], // Active     60% down,      streak 1,  frz 1 — L5  / 40
+  ['DUMMY Sixteen',  'dummy16@spurti.test', [1,1,1,1,1,1,0,0,1,0,0,1,1],  720], // Active     60% up,        streak 2,  frz 0 — L7  / 20
+  ['DUMMY Seventeen','dummy17@spurti.test', [1,1,1,1,1,1,1,1,0,0,0,0,1],  180], // Recovery   20% steady,    streak 1,  frz 0 — L1  / 80
+  ['DUMMY Eighteen', 'dummy18@spurti.test', [1,1,1,1,1,1,1,1,0,0,0,0,0],  320], // Recovery    0% down,      streak 0,  frz 0 — L3  / 20
+  ['DUMMY Nineteen', 'dummy19@spurti.test', [1,1,1,1,1,0,0,0,0,0,1,0,1],  880], // Slowing Dn 40% up,        streak 1,  frz 0 — L8  / 80
+  ['DUMMY Twenty',   'dummy20@spurti.test', [1,1,1,1,1,1,0,1,1,0,0,1,1], 1200], // Active     60% up,        streak 2,  frz 1 — L12 / 0
+];
+
+const DUMMY_NAMES = DUMMY_DEFS.map(([n, e]) => [n, e]);
+const DUMMY_PATTERN = /^DUMMY /;
+const DUMMY_LABEL = /^DUMMY-/;
+const DUMMY_EMAIL = /^dummy\d+@spurti\.test$/i;
+
+// ────────────────────────────────────────────────────────────────────
+
+async function dropAll() {
+  const s = await Student.deleteMany({ name: DUMMY_PATTERN });
+  const se = await Session.deleteMany({ label: DUMMY_LABEL });
+  const a = await AttendanceRecord.deleteMany({ email: DUMMY_EMAIL });
+  const t = await SPTransaction.deleteMany({ email: DUMMY_EMAIL });
+  console.log(`Dropped dummy: students=${s.deletedCount}, sessions=${se.deletedCount}, attendance=${a.deletedCount}, sp_txns=${t.deletedCount}`);
+}
+
+async function seed() {
+  // 13 sessions: spaced 2 days apart, last one ending ~1h before now
+  const sessions = [];
+  for (let i = 1; i <= 13; i++) {
+    const offset = (13 - i) * 2 * DAY + 60 * 60 * 1000;
+    const start = new Date(NOW.getTime() - offset);
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    sessions.push({
+      label: `DUMMY-S${String(i).padStart(2, '0')}`,
+      date: start,
+      startDateTime: start,
+      endDateTime: end,
+      totalMinutes: 60,
+      type: 'lecture',
+      title: `Dummy Session ${i}`,
+    });
+  }
+  await Session.insertMany(sessions);
+  console.log(`Inserted sessions=${sessions.length}`);
+
+  for (const [name, email, qualified, highestSpEver] of DUMMY_DEFS) {
+    const internshipStartDate = new Date(NOW.getTime() - 30 * DAY);
+    const qualifiedCount = qualified.filter(Boolean).length;
+
+    const student = await Student.create({
+      name,
+      email,
+      alternateEmail: email,
+      internshipStartDate,
+      status: 'active',
+      totalSp: highestSpEver,
+      highestSpEver,
+      level: 1,            // sync-levels.cjs will recompute
+      trophyLeague: 'Bronze II',
+      legendBadgeUnlocked: false,
+      leaderboardGroup: 'I',
+    });
+
+    // 1 initial txn (100 SP, the default starting balance)
+    await SPTransaction.create({
+      email,
+      studentId: student._id,
+      category: 'initial',
+      sessionLabel: '',
+      deltaMode: 'absolute',
+      deltaValue: 100,
+      appliedDelta: 100,
+      balanceAfter: 100,
+      reason: 'Initial credit (DUMMY)',
+      dateTime: internshipStartDate,
+    });
+
+    // 13 attendance records + per-session SP txns (only when qualified)
+    let runningBalance = 100;
+    for (let i = 0; i < sessions.length; i++) {
+      const s = sessions[i];
+      const isQualified = qualified[i];
+
+      await AttendanceRecord.create({
+        email,
+        studentId: student._id,
+        sessionLabel: s.label,
+        attendedMinutes: isQualified ? 60 : 0,
+        totalSessionMinutes: 60,
+        attendancePercentage: isQualified ? 100 : 0,
+        qualified: isQualified,
+        transactionId: null,
+      });
+
+      if (isQualified) {
+        runningBalance += 20;
+        await SPTransaction.create({
+          email,
+          studentId: student._id,
+          category: 'attendance',
+          sessionLabel: s.label,
+          deltaMode: 'absolute',
+          deltaValue: 20,
+          appliedDelta: 20,
+          balanceAfter: runningBalance,
+          reason: `Session ${s.label} (DUMMY)`,
+          dateTime: s.endDateTime,
+        });
+      }
+    }
+
+    // If highestSpEver target exceeds 100 + qualifiedCount*20, top up with manual txn(s)
+    const earnedSoFar = runningBalance;
+    let topup = highestSpEver - earnedSoFar;
+    let topupTime = NOW;
+    let lastBalance = earnedSoFar;
+    let idx = 0;
+    while (topup > 0) {
+      const chunk = Math.min(topup, 50);
+      lastBalance += chunk;
+      await SPTransaction.create({
+        email,
+        studentId: student._id,
+        category: 'manual',
+        sessionLabel: '',
+        deltaMode: 'absolute',
+        deltaValue: chunk,
+        appliedDelta: chunk,
+        balanceAfter: lastBalance,
+        reason: `Level topup ${++idx} (DUMMY)`,
+        dateTime: new Date(topupTime.getTime() - idx * 1000),
+      });
+      topup -= chunk;
+    }
+  }
+
+  const totalTxn = await SPTransaction.countDocuments({ email: DUMMY_EMAIL });
+  console.log(`Inserted dummy students=${DUMMY_NAMES.length}, attendance=${DUMMY_NAMES.length * sessions.length}, sp_txns=${totalTxn}`);
+}
+
+async function run() {
+  await mongoose.connect(MONGO_URI);
+  await new Promise(r => setTimeout(r, 500));
+
+  if (DROP) {
+    await dropAll();
+  } else {
+    await dropAll();
+    await seed();
+  }
+
+  const sc = await Student.countDocuments({ name: DUMMY_PATTERN });
+  const sec = await Session.countDocuments({ label: DUMMY_LABEL });
+  const ac = await AttendanceRecord.countDocuments({ email: DUMMY_EMAIL });
+  const tc = await SPTransaction.countDocuments({ email: DUMMY_EMAIL });
+  console.log(`Post-run: dummy students=${sc}, dummy sessions=${sec}, dummy attendance=${ac}, dummy sp_txns=${tc}`);
+
+  await mongoose.disconnect();
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/server/server.js
+++ b/server/server.js
@@ -12,7 +12,13 @@ import AttendanceRecord from './models/AttendanceRecord.js';
 import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
-import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel, legendTiers } from './services/levels.js';
+import {
+  computeStreak,
+  computeProgressBand,
+  computeWeeklyXp,
+  buildTimelineDots,
+} from './services/progress.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -178,13 +184,14 @@ function excusedPayload(student) {
 async function studentPayload(student) {
   const email = student.email;
   const activeFilter = { status: { $ne: 'excused' } };
-  const [transactions, polls, attendance, rankInfo, leaderboard, allStudents] = await Promise.all([
+  const [transactions, polls, attendance, rankInfo, leaderboard, allStudents, sessions] = await Promise.all([
     SPTransaction.find({ email }).sort({ dateTime: 1, createdAt: 1 }).lean(),
     PollRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     AttendanceRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     rankFor(email),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
-    Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
+    Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean(),
+    Session.find().sort({ endDateTime: 1 }).lean()
   ]);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
@@ -204,6 +211,22 @@ async function studentPayload(student) {
     level: levelFor(Math.max(Number(row.highestSpEver) || 0, Number(row.totalSp) || 0)),
     isCurrentStudent: row.email === email
   });
+  const now = new Date();
+  const applicableSessions = sessions.filter(s =>
+    new Date(s.endDateTime) <= now &&
+    new Date(s.endDateTime) >=
+      new Date(student.internshipStartDate)
+  );
+  const attMap = Object.fromEntries(
+    attendance.map(r => [r.sessionLabel, r])
+  );
+  const qualifiedFlags = applicableSessions.map(s =>
+    !!(attMap[s.label]?.qualified)
+  );
+  const { currentStreak, longestStreak, freezesAvailable } = computeStreak(qualifiedFlags);
+  const { band, rate, trend } = computeProgressBand(qualifiedFlags);
+  const { weeklyXp } = computeWeeklyXp(transactions);
+  const streakTimeline = buildTimelineDots(qualifiedFlags);
   return {
     student: {
       _id: String(student._id),
@@ -220,12 +243,22 @@ async function studentPayload(student) {
       cohortSize: rankInfo?.cohortSize || null,
       highestSpEver,
       level: levelFor(highestSpEver),
+      levelProgress: highestSpEver % 100,
       trophyLeague: leagueBand(student.totalSp),
       legendBadgeUnlocked: legendBadge(highestSpEver),
+      legendTiers: legendTiers(highestSpEver),
       leaderboardGroup: myGroup,
       leaderboardGroupLabel: groupLabel(myGroup),
       surveyCompleted: Boolean(student.surveyCompleted),
-      poll2Completed: Boolean(student.poll2Completed)
+      poll2Completed: Boolean(student.poll2Completed),
+      currentStreak,
+      longestStreak,
+      streakFreezesAvailable: freezesAvailable,
+      progressBand: band,
+      progressRate: rate,
+      progressTrend: trend,
+      weeklyXp,
+      streakTimeline,
     },
     transactions,
     polls,
@@ -262,6 +295,15 @@ api.get('/config', (_req, res) => res.json({
 }));
 
 api.get('/me', async (req, res) => {
+  // Dev override: ?asEmail=... impersonates a student without Samagama auth.
+  // Gated on NODE_ENV !== 'production' so it's auto-disabled in prod.
+  if (process.env.NODE_ENV !== 'production' && req.query.asEmail) {
+    const asEmail = String(req.query.asEmail).toLowerCase().trim();
+    const student = await Student.findOne({ $or: [{ email: asEmail }, { alternateEmail: asEmail }] }).lean();
+    if (!student) return res.status(404).json({ authenticated: false, error: 'Student not found', email: asEmail });
+    if (student.status === 'excused') return res.json({ authenticated: true, ...excusedPayload(student) });
+    return res.json({ authenticated: true, profile: await studentPayload(student) });
+  }
   const email = await studentEmailFromRequest(req);
   if (!email) return res.status(401).json({ authenticated: false });
   const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
@@ -619,6 +661,18 @@ function last24Hours(now) {
 
 app.use('/api', api);
 app.use('/spurti/api', api);
+
+// Dev cache-busting: tell the browser to always revalidate HTML/JS/CSS so
+// new client builds show up on next refresh instead of getting served from cache.
+// Gated on NODE_ENV !== 'production' so production uses default caching.
+if (process.env.NODE_ENV !== 'production') {
+  app.use((_req, res, next) => {
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+    next();
+  });
+}
 
 if (fs.existsSync(clientDist)) {
   app.use('/spurti', express.static(clientDist));

--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,45 @@ import {
   computeWeeklyXp,
   buildTimelineDots,
 } from './services/progress.js';
+import { buildWrappedStory } from './services/wrapped.js';
+import weeklyLeaderboardRouter from './routes/weeklyLeaderboard.js';
+import ghostRaceRouter from './routes/ghostRace.js';
+import { normalizeEmail, studentEmailFromRequest, resolveStudentEmail, setDevStudentCookie, clearDevStudentCookie } from './auth.js';
+
+
+function maskEmail(email = '') {
+  const [local, domain] = String(email).split('@');
+  if (!local) return email;
+  return local.slice(0, 2) + '***@' + (domain || '');
+}
+
+function publicStudent(student) {
+  return {
+    _id: String(student._id),
+    name: student.name,
+    maskedEmail: maskEmail(student.email),
+    maskedAlternateEmail: student.alternateEmail ? maskEmail(student.alternateEmail) : '',
+    status: student.status || 'active',
+    totalSp: student.totalSp
+  };
+}
+
+function monthRange(yyyyMM) {
+  const [y, m] = yyyyMM.split('-').map(Number);
+  return {
+    start: new Date(y, m - 1, 1),
+    end: new Date(y, m, 1),
+  };
+}
+
+function prevCompletedMonth() {
+  const now = new Date();
+  const y = now.getMonth() === 0
+    ? now.getFullYear() - 1 : now.getFullYear();
+  const m = now.getMonth() === 0
+    ? 12 : now.getMonth();
+  return `${y}-${String(m).padStart(2, '0')}`;
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -40,7 +79,7 @@ function makeSurvey(prefix, completedField) {
     formUrl: process.env[`${prefix}_FORM_URL`] || '',          // .../viewform  (the published form)
     emailEntryId: process.env[`${prefix}_EMAIL_ENTRY`] || '',  // e.g. entry.1234567890  (pre-fills email)
     // Mandatory: 'hard' = blocking modal the student cannot dismiss until they
-    // submit. No SP reward — participation is required, not incentivised.
+    // submit. No SP reward â€” participation is required, not incentivised.
     enforcement: process.env[`${prefix}_ENFORCEMENT`] || 'hard',
     // Auto-expiry. After this instant the modal stops showing (normal Spurti
     // resumes) with no redeploy. ISO 8601 incl. offset, e.g. 2026-06-30T23:59:59+05:30.
@@ -102,62 +141,7 @@ const liveViewers = new Map();
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
 
-function normalizeEmail(value) {
-  return String(value || '').trim().toLowerCase();
-}
 
-function maskEmail(email) {
-  const [name, domain] = String(email || '').split('@');
-  if (!name || !domain) return 'hidden email';
-  const start = name.slice(0, Math.min(2, name.length));
-  const end = name.length > 4 ? name.slice(-2) : '';
-  return `${start}${'*'.repeat(Math.max(3, name.length - start.length - end.length))}${end}@${domain}`;
-}
-
-function publicStudent(student) {
-  return {
-    _id: String(student._id),
-    name: student.name,
-    maskedEmail: maskEmail(student.email),
-    maskedAlternateEmail: student.alternateEmail ? maskEmail(student.alternateEmail) : '',
-    status: student.status || 'active',
-    totalSp: student.totalSp
-  };
-}
-
-function parseCookies(header = '') {
-  return Object.fromEntries(String(header).split(';').map(part => {
-    const index = part.indexOf('=');
-    if (index < 0) return null;
-    return [part.slice(0, index).trim(), decodeURIComponent(part.slice(index + 1).trim())];
-  }).filter(Boolean));
-}
-
-// Validate the student's Samagama session by forwarding their chatengine_token
-// cookie to Samagama's internal auth endpoint. Returns the email on success.
-async function getSamagamaUser(chatengineToken) {
-  if (!chatengineToken) return null;
-  try {
-    const res = await fetch(SAMAGAMA_AUTH_URL, {
-      headers: { cookie: `chatengine_token=${chatengineToken}` },
-      signal: AbortSignal.timeout(5000)
-    });
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
-}
-
-async function studentEmailFromRequest(req) {
-  const cookies = parseCookies(req.headers.cookie || '');
-  const data = await getSamagamaUser(cookies.chatengine_token);
-  // Samagama's /api/auth/me nests the user as { user: { email, ... } };
-  // fall back to a top-level email in case the shape ever flattens.
-  const email = data?.user?.email || data?.email;
-  if (!email) return null;
-  return normalizeEmail(email);
-}
 
 async function rankFor(email) {
   const student = await Student.findOne({ email }).lean();
@@ -199,7 +183,7 @@ async function studentPayload(student) {
   const top50Cutoff = allStudents[49]?.totalSp || null;
   const currentIndex = allStudents.findIndex(s => s.email === email);
   const nextStudent = currentIndex > 0 ? allStudents[currentIndex - 1] : null;
-  // Spurti Levels & Trophy Leagues — derived from existing SP (lifetime highest + current).
+  // Spurti Levels & Trophy Leagues â€” derived from existing SP (lifetime highest + current).
   const highestSpEver = Math.max(Number(student.highestSpEver) || 0, Number(student.totalSp) || 0);
   const myGroup = leaderboardGroup(student.internshipStartDate);
   const groupStudents = allStudents.filter(s => leaderboardGroup(s.internshipStartDate) === myGroup);
@@ -295,21 +279,105 @@ api.get('/config', (_req, res) => res.json({
 }));
 
 api.get('/me', async (req, res) => {
-  // Dev override: ?asEmail=... impersonates a student without Samagama auth.
-  // Gated on NODE_ENV !== 'production' so it's auto-disabled in prod.
-  if (process.env.NODE_ENV !== 'production' && req.query.asEmail) {
-    const asEmail = String(req.query.asEmail).toLowerCase().trim();
-    const student = await Student.findOne({ $or: [{ email: asEmail }, { alternateEmail: asEmail }] }).lean();
-    if (!student) return res.status(404).json({ authenticated: false, error: 'Student not found', email: asEmail });
-    if (student.status === 'excused') return res.json({ authenticated: true, ...excusedPayload(student) });
-    return res.json({ authenticated: true, profile: await studentPayload(student) });
-  }
-  const email = await studentEmailFromRequest(req);
+  // Auth + dev impersonation: ?asEmail= wins, then real Samagama cookie,
+  // then a localhost-only fallback to dummy1 so the dev experience works
+  // out of the box without a Samagama cookie.
+  const email = await resolveStudentEmail(req);
   if (!email) return res.status(401).json({ authenticated: false });
   const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
-  if (!student) return res.status(404).json({ authenticated: false, error: 'Student not found' });
+  if (!student) return res.status(404).json({ authenticated: false, error: 'Student not found', email });
   if (student.status === 'excused') return res.json({ authenticated: true, ...excusedPayload(student) });
   res.json({ authenticated: true, profile: await studentPayload(student) });
+});
+
+api.get('/wrapped', async (req, res) => {
+  try {
+    // Auth + dev impersonation: ?asEmail= wins, then real Samagama cookie,
+    // then localhost default to dummy1.
+    const email = await resolveStudentEmail(req);
+    if (!email)
+      return res.status(401).json({ error: 'Unauthorized' });
+    const student = await Student.findOne({ email }).lean();
+    if (!student)
+      return res.status(404).json({ error: 'Not found' });
+    if (student.status === 'excused')
+      return res.status(403).json({ error: 'Account excused' });
+
+    const targetMonth = (
+      typeof req.query.month === 'string' &&
+      /^\d{4}-\d{2}$/.test(req.query.month)
+    ) ? req.query.month : prevCompletedMonth();
+
+    const { start, end } = monthRange(targetMonth);
+    const [y, m] = targetMonth.split('-').map(Number);
+    const monthLabel = new Date(y, m - 1, 1)
+      .toLocaleDateString('en-IN',
+        { month: 'long', year: 'numeric' });
+
+    if (new Date(student.internshipStartDate) >= end)
+      return res.json({ available: false, reason: 'no-data' });
+
+    const sessionsInMonth = await Session.find({
+      date: { $gte: start, $lt: end },
+    }).sort({ endDateTime: 1 }).lean();
+
+    const sessionLabels = sessionsInMonth.map(s => s.label);
+
+    const [attendanceInMonth, pollsInMonth, transactions] =
+      await Promise.all([
+        AttendanceRecord.find({
+          email,
+          sessionLabel: { $in: sessionLabels },
+        }).lean(),
+        PollRecord.find({
+          email,
+          sessionLabel: { $in: sessionLabels },
+        }).lean(),
+        SPTransaction.find({
+          email,
+          dateTime: { $gte: start, $lt: end },
+        }).lean(),
+      ]);
+
+    let streakInfo = null, progressInfo = null;
+    try {
+      const { computeStreak, computeProgressBand } =
+        await import('./services/progress.js');
+      const now = new Date();
+      const allSessions = await Session
+        .find().sort({ endDateTime: 1 }).lean();
+      const applicable = allSessions.filter(s =>
+        new Date(s.endDateTime) <= now &&
+        new Date(s.endDateTime) >=
+        new Date(student.internshipStartDate)
+      );
+      const allAtt = await AttendanceRecord
+        .find({ email }).lean();
+      const attMap = Object.fromEntries(
+        allAtt.map(r => [r.sessionLabel, r])
+      );
+      const flags = applicable.map(
+        s => !!(attMap[s.sessionLabel]?.qualified)
+      );
+      streakInfo = computeStreak(flags);
+      progressInfo = computeProgressBand(flags);
+    } catch (_) { /* progress.js absent â€” omit gracefully */ }
+
+    const joinedThisMonth =
+      new Date(student.internshipStartDate) >= start &&
+      new Date(student.internshipStartDate) < end;
+
+    const story = buildWrappedStory({
+      month: targetMonth, monthLabel, joinedThisMonth,
+      transactions, attendanceInMonth, sessionsInMonth,
+      pollsInMonth, student, streakInfo, progressInfo,
+    });
+
+    return res.json({ available: true, ...story });
+  } catch (err) {
+    console.error('[wrapped]', err);
+    return res.status(500).json({ error: 'Server error' });
+  }
 });
 
 api.get('/search', async (req, res) => {
@@ -321,7 +389,10 @@ api.get('/search', async (req, res) => {
     const email = normalizeEmail(q);
     const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
     if (student?.status === 'excused') return res.json(excusedPayload(student));
-    if (student) return res.json({ exact: true, profile: await studentPayload(student) });
+    if (student) {
+      setDevStudentCookie(res, student.email);
+      return res.json({ exact: true, profile: await studentPayload(student) });
+    }
   }
 
   const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -346,6 +417,7 @@ api.post('/confirm', async (req, res) => {
     return res.status(403).json({ error: 'Email did not match this record' });
   }
   if (student.status === 'excused') return res.json(excusedPayload(student));
+  setDevStudentCookie(res, student.email);
   res.json(await studentPayload(student));
 });
 
@@ -363,6 +435,9 @@ api.get('/leaderboard', async (req, res) => {
     trophyLeague: leagueBand(s.totalSp)
   })));
 });
+api.use('/weekly-leaderboard', weeklyLeaderboardRouter);
+api.use('/ghost-race', ghostRaceRouter);
+
 
 api.post('/ping', async (req, res) => {
   const { email, name, page } = req.body || {};
@@ -384,7 +459,7 @@ api.post('/ping', async (req, res) => {
 
 // --- Survey triangulation (mandatory perception follow-up) ---------------
 // Mark a student's survey as completed for the given survey config. Idempotent;
-// matches on primary or alternate email. No SP is awarded — mandatory, not rewarded.
+// matches on primary or alternate email. No SP is awarded â€” mandatory, not rewarded.
 async function markSurveyComplete(email, cfg) {
   const normalized = normalizeEmail(email);
   if (!normalized) return null;
@@ -675,6 +750,21 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 if (fs.existsSync(clientDist)) {
+  // SPA fallback — also clears the devStudentEmail cookie so refreshing
+  // the page (or closing the browser) returns the user to the login screen.
+  // Must run BEFORE express.static so it fires for the index.html served
+  // from the dist folder.
+  if (process.env.NODE_ENV !== 'production') {
+    app.use((req, res, next) => {
+      if (req.method === 'GET' && req.accepts('html') &&
+          !req.path.startsWith('/api') &&
+          !/\.[a-zA-Z0-9]+$/.test(req.path)) {
+        clearDevStudentCookie(res);
+        res.setHeader('Cache-Control', 'no-store');
+      }
+      next();
+    });
+  }
   app.use('/spurti', express.static(clientDist));
   app.use(express.static(clientDist));
   app.get('/spurti/*', (_req, res) => res.sendFile(path.join(clientDist, 'index.html')));

--- a/server/services/levels.js
+++ b/server/services/levels.js
@@ -62,3 +62,22 @@ export function leaderboardGroup(onboardingDate) {
 export function groupLabel(group) {
   return String(group || '').replace('_to_', ' to ');
 }
+
+// Legend tier badges — milestone collectibles keyed off lifetime SP.
+// Pure additive — does NOT change `legendBadge()` semantics (1500 threshold).
+// Tiers are derived views for the dashboard UI; the underlying schema keeps
+// the single `legendBadgeUnlocked` boolean untouched.
+const LEGEND_TIERS = [
+  { name: 'Bronze',   threshold: 100,  key: 'bronze' },
+  { name: 'Silver',   threshold: 500,  key: 'silver' },
+  { name: 'Gold',     threshold: 1000, key: 'gold' },
+  { name: 'Platinum', threshold: 1500, key: 'platinum' },
+];
+
+export function legendTiers(highestSpEver) {
+  const sp = Number(highestSpEver) || 0;
+  return LEGEND_TIERS.map(t => ({
+    ...t,
+    unlocked: sp >= t.threshold,
+  }));
+}

--- a/server/services/progress.js
+++ b/server/services/progress.js
@@ -1,0 +1,80 @@
+/**
+ * server/services/progress.js
+ * Derived-view utilities for streaks and progress bands.
+ * Pure functions only — no DB access, no side effects.
+ */
+
+export const PROGRESS_BANDS = [
+  { name: 'Excellent',    minRate: 0.80 },
+  { name: 'Active',       minRate: 0.60 },
+  { name: 'Slowing Down', minRate: 0.35 },
+  { name: 'Recovery',     minRate: 0.00 },
+];
+
+export function computeStreak(qualifiedFlags) {
+  if (!qualifiedFlags.length)
+    return { currentStreak: 0, longestStreak: 0, freezesAvailable: 0 };
+
+  let qualifiedSoFar  = 0;
+  let freezesEarned   = 0;
+  let freezesConsumed = 0;
+  let currentStreak   = 0;
+  let longestStreak   = 0;
+
+  for (const qualified of qualifiedFlags) {
+    if (qualified) {
+      qualifiedSoFar += 1;
+      currentStreak  += 1;
+      freezesEarned   = Math.floor(qualifiedSoFar / 5);
+      if (currentStreak > longestStreak) longestStreak = currentStreak;
+    } else {
+      const available = freezesEarned - freezesConsumed;
+      if (available > 0) {
+        freezesConsumed += 1;
+      } else {
+        currentStreak = 0;
+      }
+    }
+  }
+
+  return {
+    currentStreak,
+    longestStreak,
+    freezesAvailable: freezesEarned - freezesConsumed,
+  };
+}
+
+export function computeProgressBand(qualifiedFlags) {
+  const window = qualifiedFlags.slice(-5);
+  if (!window.length)
+    return { band: null, rate: null, trend: 'steady' };
+
+  const qualifiedCount = window.filter(Boolean).length;
+  const rate = qualifiedCount / window.length;
+  const band = PROGRESS_BANDS.find(b => rate >= b.minRate)?.name ?? 'Recovery';
+
+  const recent = qualifiedFlags.slice(-3);
+  const prev   = qualifiedFlags.slice(-6, -3);
+  let trend = 'steady';
+  if (prev.length > 0) {
+    const rr   = recent.filter(Boolean).length / recent.length;
+    const pr   = prev.filter(Boolean).length   / prev.length;
+    const diff = rr - pr;
+    if (diff >= 0.20)       trend = 'up';
+    else if (diff <= -0.20) trend = 'down';
+  }
+
+  return { band, rate: Math.round(rate * 100), trend };
+}
+
+export function computeWeeklyXp(transactions) {
+  const since    = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const weeklyXp = transactions
+    .filter(t => new Date(t.dateTime) >= since)
+    .reduce((sum, t) => sum + (t.appliedDelta || 0), 0);
+  return { weeklyXp };
+}
+
+export function buildTimelineDots(qualifiedFlags) {
+  return qualifiedFlags.slice(-13).map(q => (q ? 'qualified' : 'missed'));
+}

--- a/server/services/wrapped.js
+++ b/server/services/wrapped.js
@@ -1,0 +1,94 @@
+/**
+ * server/services/wrapped.js
+ * Pure assembly — no DB access, no side effects.
+ * Route does all DB queries and passes pre-fetched data in.
+ */
+
+export function buildWrappedStory({
+  month, monthLabel, joinedThisMonth,
+  transactions, attendanceInMonth,
+  sessionsInMonth, pollsInMonth,
+  student, streakInfo, progressInfo,
+}) {
+  // SP earned / deducted
+  const totalEarned = transactions
+    .filter(t => (t.appliedDelta || 0) > 0)
+    .reduce((s, t) => s + t.appliedDelta, 0);
+  const totalDeducted = transactions
+    .filter(t => (t.appliedDelta || 0) < 0)
+    .reduce((s, t) => s + t.appliedDelta, 0);
+  const netChange = totalEarned + totalDeducted;
+
+  // Category breakdown
+  const byCategory = cat =>
+    transactions
+      .filter(t => t.category === cat)
+      .reduce((s, t) => s + (t.appliedDelta || 0), 0);
+
+  // Attendance
+  const sessionsHeld = sessionsInMonth.length;
+  const sessionsAttended = attendanceInMonth
+    .filter(r => r.qualified).length;
+  const qualifiedRate = sessionsHeld > 0
+    ? Math.round((sessionsAttended / sessionsHeld) * 100) : null;
+
+  // Best session
+  const spBySession = {};
+  for (const t of transactions) {
+    if (!t.sessionLabel) continue;
+    spBySession[t.sessionLabel] =
+      (spBySession[t.sessionLabel] || 0) + (t.appliedDelta || 0);
+  }
+  const labels = sessionsInMonth.map(s => s.label);
+  let bestSession = null, bestSp = -Infinity;
+  for (const label of labels) {
+    const sp = spBySession[label] || 0;
+    if (sp > bestSp) { bestSp = sp; bestSession = label; }
+  }
+  if (bestSession !== null && bestSp <= 0) bestSession = null;
+
+  // Poll performance
+  const pollsWithData = pollsInMonth.filter(
+    p => typeof p.totalQuestions === 'number' &&
+    p.totalQuestions > 0
+  );
+  const pollsCount = pollsWithData.length;
+  const avgAttemptedRate = pollsCount > 0
+    ? Math.round(
+      pollsWithData.reduce(
+        (s, p) => s + p.attemptedQuestions / p.totalQuestions, 0
+      ) / pollsCount * 100
+    )
+    : null;
+
+  const cards = [
+    { type: 'intro', monthLabel, joinedThisMonth },
+    { type: 'sp-earned', totalEarned, totalDeducted, netChange },
+    { type: 'category-breakdown',
+      attendance: byCategory('attendance'),
+      poll: byCategory('poll'),
+      manual: byCategory('manual') },
+    { type: 'attendance', sessionsAttended,
+      sessionsHeld, qualifiedRate },
+    { type: 'best-session',
+      label: bestSession,
+      spEarned: bestSession !== null ? bestSp : null },
+    { type: 'poll-performance', avgAttemptedRate, pollsCount },
+    { type: 'current-standing',
+      level: student.level ?? null,
+      trophyLeague: student.trophyLeague ?? null,
+      legendBadgeUnlocked: student.legendBadgeUnlocked ?? false,
+      currentStreak: streakInfo?.currentStreak ?? null,
+      longestStreak: streakInfo?.longestStreak ?? null,
+      progressBand: progressInfo?.band ?? null },
+    { type: 'lifetime',
+      totalSp: student.totalSp || 0,
+      memberSinceLabel: student.internshipStartDate
+        ? new Date(student.internshipStartDate)
+          .toLocaleDateString('en-IN',
+            { month: 'long', year: 'numeric' })
+        : '—' },
+  ];
+
+  return { month, monthLabel, joinedThisMonth, cards };
+}


### PR DESCRIPTION
  • Monthly Wrapped  — Instagram-style stories that recap a student's
    SP, attendance, polls, best session, league standing for the previous
    full month. New route /api/wrapped + service/services/wrapped.js.
  • Weekly Leaderboard — Gold/Silver/Bronze leagues with 5 weekly
    category winners (Weekly Champion, Most Consistent, Most Improved,
    Biggest Comeback, Community Star). New route /api/weekly-leaderboard.
  • Ghost Race — race last week vs this week with daily bars, per-session
    rollup, personal bests, and motivational message. New route
    /api/ghost-race.