### PR TITLE
feat: SP Redemption Marketplace — trade SP for real-world perks

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -782,9 +782,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,9 +794,6 @@
       "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -814,9 +808,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -829,9 +820,6 @@
       "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -846,9 +834,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -861,9 +846,6 @@
       "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -878,9 +860,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -893,9 +872,6 @@
       "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -910,9 +886,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -925,9 +898,6 @@
       "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -942,9 +912,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,9 +925,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -973,9 +937,6 @@
       "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -279,7 +279,8 @@ function StudentView({ profile, onBack }) {
       </header>
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard'], ['marketplace','Redeem SP']]} />
+      {tab === 'marketplace' && <Marketplace student={profile.student} />}
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
@@ -501,6 +502,65 @@ function Leaderboard({ rows }) {
         <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>SP</th></tr></thead>
         <tbody>{rows.map(row => <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}><td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.totalSp}</td></tr>)}</tbody>
       </table>
+    </section>
+  );
+}
+
+const REWARD_CATALOG = [
+  { id: 'resume-review', title: 'Resume Review', description: 'One-on-one resume review with a mentor.', cost: 150 },
+  { id: 'swag-kit', title: 'Spurti Swag Kit', description: 'T-shirt, sticker pack, and notebook.', cost: 100 },
+  { id: 'course-discount', title: 'Course Discount Code', description: '20% off a partner course of your choice.', cost: 200 },
+  { id: 'priority-mentor', title: 'Priority Mentor Session', description: '30-minute 1:1 session with a senior mentor.', cost: 250 },
+];
+
+function Marketplace({ student }) {
+  const [status, setStatus] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const redeem = async (reward) => {
+    if (student.totalSp < reward.cost) {
+      setStatus(`You need ${reward.cost - student.totalSp} more SP to redeem this.`);
+      return;
+    }
+    setSubmitting(true);
+    setStatus('');
+    try {
+      const res = await fetch(`${API}/redeem`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: student.email, rewardId: reward.id, cost: reward.cost })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Redemption failed');
+      setStatus(`Redeemed "${reward.title}"! Our team will reach out via email with next steps.`);
+    } catch (err) {
+      setStatus(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="panel">
+      <h2>Redeem Your SP</h2>
+      <p className="muted">You have <strong>{student.totalSp} SP</strong> available to redeem.</p>
+      <div className="cards">
+        {REWARD_CATALOG.map(reward => (
+          <article className="card" key={reward.id}>
+            <strong>{reward.title}</strong>
+            <p>{reward.description}</p>
+            <span>{reward.cost} SP</span>
+            <button
+              className="primary"
+              disabled={submitting || student.totalSp < reward.cost}
+              onClick={() => redeem(reward)}
+            >
+              {student.totalSp < reward.cost ? 'Not enough SP' : 'Redeem'}
+            </button>
+          </article>
+        ))}
+      </div>
+      {status && <p className="muted">{status}</p>}
     </section>
   );
 }


### PR DESCRIPTION
Adds a "Redeem SP" tab to the student dashboard where students can trade their earned Spurti Points for tangible rewards instead of virtual/cosmetic items.

Current catalog:
- Resume Review (150 SP)
- Spurti Swag Kit (100 SP)
- Course Discount Code (200 SP)
- Priority Mentor Session (250 SP)

Notes:
- Frontend calls a new `/api/redeem` endpoint (POST) with { email, rewardId, cost }
- This backend route does not exist yet — this PR covers the UI/UX; a follow-up would add server-side redemption logic (recording the request, deducting SP, and notifying the team)
- Redeem button disables automatically if the student doesn't have enough SP