### PR TITLE
feat(admin): quick SP award from student profile modal

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -514,6 +514,12 @@ function AdminView({ admin, auth, onBack }) {
   const [analytics, setAnalytics] = useState(null);
   const [stats, setStats] = useState(null);
   const [studentProfile, setStudentProfile] = useState(null);
+  const [awardOpen, setAwardOpen] = useState(false);
+  const [awardMode, setAwardMode] = useState('absolute'); // 'absolute' | 'percentage'
+  const [awardAmount, setAwardAmount] = useState('');
+  const [awardReason, setAwardReason] = useState('');
+  const [awarding, setAwarding] = useState(false);
+  const [awardError, setAwardError] = useState('');
 
   const headers = adminHeaders(auth);
 
@@ -548,6 +554,54 @@ function AdminView({ admin, auth, onBack }) {
   const loadAnalytics = async () => {
     const res = await fetch(`${API}/admin/analytics`, { headers });
     setAnalytics(await res.json());
+  };
+
+  const submitAward = async () => {
+    if (!studentProfile) return;
+    setAwarding(true);
+    setAwardError('');
+    try {
+      const amount = Number(awardAmount);
+      if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error('amount must be a positive integer');
+      }
+      if (!awardReason.trim()) {
+        throw new Error('reason is required');
+      }
+      const body = { delta: amount, reason: awardReason.trim() };
+      if (awardMode === 'percentage') body.deltaMode = 'percentage';
+      const res = await fetch(`${API}/admin/student/${studentProfile.student._id}/award`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      // Update the local profile in place so the new balance reflects immediately.
+      setStudentProfile(prev => prev && {
+        ...prev,
+        student: { ...prev.student, totalSp: data.transaction.balanceAfter },
+        transactions: [
+          {
+            _id: data.transaction._id,
+            category: 'manual',
+            appliedDelta: data.transaction.appliedDelta,
+            balanceAfter: data.transaction.balanceAfter,
+            reason: data.transaction.reason,
+            dateTime: data.transaction.dateTime,
+            sessionLabel: ''
+          },
+          ...(prev.transactions || [])
+        ]
+      });
+      setAwardOpen(false);
+      setAwardAmount('');
+      setAwardReason('');
+    } catch (err) {
+      setAwardError(err.message);
+    } finally {
+      setAwarding(false);
+    }
   };
 
   useEffect(() => { loadLeaderboard(50); fetchStats(); }, []);
@@ -593,7 +647,94 @@ function AdminView({ admin, auth, onBack }) {
       {tab === 'live' && <LiveAnalytics active={active} />}
       {tab === 'analytics' && <Analytics data={analytics} />}
       {tab === 'students' && <AllStudentsPanel stats={stats} onStudent={loadStudent} auth={auth} />}
-      {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} /></section></div>}
+      {studentProfile && (
+        <div className="overlay">
+          <section className="modal wide">
+            <div className="modal-head">
+              <h2>{studentProfile.student.name} — {studentProfile.student.totalSp} SP</h2>
+              <button className="icon" onClick={() => setStudentProfile(null)}>x</button>
+            </div>
+            <div className="admin-actions-row">
+              <button className="primary" onClick={() => { setAwardOpen(true); setAwardError(''); }}>
+                Award SP
+              </button>
+              <span className="muted">Private admin action — student sees no notification</span>
+            </div>
+            <SpBank transactions={studentProfile.transactions} />
+          </section>
+        </div>
+      )}
+      {awardOpen && studentProfile && (
+        <div className="overlay">
+          <section className="modal">
+            <div className="modal-head">
+              <h2>Award SP to {studentProfile.student.name}</h2>
+              <button className="icon" onClick={() => setAwardOpen(false)}>x</button>
+            </div>
+            <div className="award-form">
+              <label className="award-field">
+                <span>Mode</span>
+                <div className="award-mode-toggle">
+                  <button
+                    className={awardMode === 'absolute' ? 'primary' : 'secondary'}
+                    onClick={() => setAwardMode('absolute')}
+                    type="button"
+                  >Fixed SP (+)</button>
+                  <button
+                    className={awardMode === 'percentage' ? 'primary' : 'secondary'}
+                    onClick={() => setAwardMode('percentage')}
+                    type="button"
+                  >% of current balance</button>
+                </div>
+              </label>
+              <label className="award-field">
+                <span>
+                  {awardMode === 'percentage'
+                    ? `Percentage (1-${100})`
+                    : 'Amount (SP, positive integer)'}
+                </span>
+                <input
+                  type="number"
+                  min={awardMode === 'percentage' ? 1 : 1}
+                  max={awardMode === 'percentage' ? 100 : 1_000_000}
+                  value={awardAmount}
+                  onChange={e => setAwardAmount(e.target.value)}
+                  placeholder={awardMode === 'percentage' ? 'e.g. 10 (= 10%)' : 'e.g. 5'}
+                  autoFocus
+                />
+                {awardMode === 'percentage' && studentProfile && (
+                  <span className="muted award-preview">
+                    Preview: +{Math.floor((studentProfile.student.totalSp * Number(awardAmount || 0)) / 100)} SP
+                  </span>
+                )}
+              </label>
+              <label className="award-field">
+                <span>Reason (visible in student's ledger)</span>
+                <textarea
+                  value={awardReason}
+                  onChange={e => setAwardReason(e.target.value)}
+                  placeholder="e.g. Outstanding presentation on Day 12"
+                  rows={3}
+                  maxLength={500}
+                />
+              </label>
+              {awardMode === 'percentage' && studentProfile && (
+                <p className="award-note">
+                  <strong>Note:</strong> percentage is rounded down to the nearest integer so admins never accidentally over-credit.
+                  e.g. 10% of 145 = 14 SP (not 14.5).
+                </p>
+              )}
+              <div className="award-actions">
+                <button className="primary" onClick={submitAward} disabled={awarding}>
+                  {awarding ? 'Awarding…' : `Award ${awardMode === 'percentage' ? `${awardAmount || 0}%` : `+${awardAmount || 0} SP`}`}
+                </button>
+                <button className="secondary" onClick={() => setAwardOpen(false)} disabled={awarding}>Cancel</button>
+                {awardError && <span className="error">{awardError}</span>}
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
     </main>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,81 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* Admin Award SP (feature/admin-quick-sp-award) */
+.admin-actions-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  background: #fbfdff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.admin-actions-row .muted { font-size: 12px; }
+
+.award-form {
+  display: grid;
+  gap: 14px;
+}
+.award-field {
+  display: grid;
+  gap: 6px;
+}
+.award-field > span:first-child {
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+.award-mode-toggle {
+  display: flex;
+  gap: 8px;
+}
+.award-mode-toggle button {
+  flex: 1;
+  font-size: 13px;
+  padding: 8px 12px;
+}
+.award-field input[type="number"],
+.award-field textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 10px 12px;
+  color: var(--text);
+  background: #fff;
+  font-family: inherit;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.award-preview {
+  font-size: 12px;
+  color: var(--primary);
+  font-weight: 800;
+  background: #f1f5f9;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-family: ui-monospace, monospace;
+}
+.award-note {
+  font-size: 12px;
+  color: var(--muted);
+  background: #fef9ec;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 0;
+}
+.award-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+.award-actions .error {
+  font-size: 12px;
+  color: var(--red);
+}

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { validateAwardPayload, computeAppliedDelta, buildAwardReason } from './services/adminAward.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -466,6 +467,50 @@ api.get('/admin/student/:id', adminGuard, async (req, res) => {
   const student = await Student.findById(req.params.id).lean();
   if (!student) return res.status(404).json({ error: 'Student not found' });
   res.json(await studentPayload(student));
+});
+
+// Award SP to a student. Admin-only. Two modes:
+//   - absolute:  { delta: 10, reason: "..." }  -> +10 SP
+//   - percentage:{ delta: 10, reason: "...", deltaMode: "percentage" } -> 10% of current balance
+// Creates an SPTransaction with category='manual' and atomically increments
+// Student.totalSp via $inc. Returns the new balance + transaction.
+api.post('/admin/student/:id/award', adminGuard, async (req, res) => {
+  const student = await Student.findById(req.params.id);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  if (student.status === 'excused') {
+    return res.status(400).json({ error: 'Cannot award SP to an excused student' });
+  }
+  const v = validateAwardPayload(req.body);
+  if (!v.ok) return res.status(400).json({ error: v.error });
+  const appliedDelta = computeAppliedDelta(v, student.totalSp);
+  if (appliedDelta <= 0) {
+    return res.status(400).json({ error: 'Computed award is 0 (balance is 0 or percentage rounds to 0)' });
+  }
+  const reason = buildAwardReason(v.deltaMode, v.delta, v.reason);
+  const now = new Date();
+  const [txn] = await SPTransaction.create([{
+    email: student.email,
+    studentId: student._id,
+    category: 'manual',
+    sessionLabel: '',
+    deltaMode: v.deltaMode,
+    deltaValue: v.delta,
+    appliedDelta,
+    balanceAfter: student.totalSp + appliedDelta,
+    reason,
+    dateTime: now
+  }]);
+  await Student.updateOne({ _id: student._id }, { $inc: { totalSp: appliedDelta } });
+  res.json({
+    ok: true,
+    transaction: {
+      _id: txn._id,
+      appliedDelta,
+      balanceAfter: student.totalSp + appliedDelta,
+      reason,
+      dateTime: now
+    }
+  });
 });
 
 api.get('/admin/active', adminGuard, (_req, res) => {

--- a/server/services/adminAward.js
+++ b/server/services/adminAward.js
@@ -1,0 +1,107 @@
+/**
+ * server/services/adminAward.js
+ *
+ * Pure helpers for the admin quick SP award feature. Validates and
+ * normalizes the award payload before it touches the database.
+ *
+ * Zero side effects, zero DB. Trivially unit-testable. Mirrors the
+ * style of services/adminNote.js.
+ */
+
+/** Hard cap on award reason text length. */
+export const AWARD_REASON_MAX_LENGTH = 500;
+
+/** Hard cap on award percentage when deltaMode is 'percentage'. */
+export const AWARD_PERCENTAGE_MAX = 100;
+
+/**
+ * @typedef {'absolute' | 'percentage'} DeltaMode
+ *  - absolute: the delta is a fixed SP amount (e.g. +5 SP)
+ *  - percentage: the delta is a % of the student's current balance
+ *    (e.g. +10% of current balance)
+ */
+
+/**
+ * Validate an admin award payload.
+ *
+ * Rules:
+ *  - body must be an object
+ *  - delta must be present and a positive integer (1..1_000_000 SP, or 1..100%)
+ *  - reason must be a non-empty string within AWARD_REASON_MAX_LENGTH
+ *  - deltaMode, if present, must be 'absolute' (default) or 'percentage'
+ *
+ * Returns: { ok: true, delta, reason, deltaMode } | { ok: false, error }
+ */
+export function validateAwardPayload(body) {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'body must be a JSON object' };
+  }
+  if (!('delta' in body)) {
+    return { ok: false, error: 'delta field is required' };
+  }
+  if (typeof body.delta !== 'number') {
+    return { ok: false, error: 'delta must be a number' };
+  }
+  const delta = body.delta;
+  if (!Number.isFinite(delta) || !Number.isInteger(delta)) {
+    return { ok: false, error: 'delta must be an integer' };
+  }
+  if (delta <= 0) {
+    return { ok: false, error: 'delta must be a positive integer (use deduction flow for negative)' };
+  }
+  if (delta > 1_000_000) {
+    return { ok: false, error: 'delta exceeds maximum award of 1,000,000 SP' };
+  }
+  if (!('reason' in body)) {
+    return { ok: false, error: 'reason field is required' };
+  }
+  if (typeof body.reason !== 'string') {
+    return { ok: false, error: 'reason must be a string' };
+  }
+  const trimmedReason = body.reason.trim();
+  if (trimmedReason.length === 0) {
+    return { ok: false, error: 'reason must not be empty' };
+  }
+  if (trimmedReason.length > AWARD_REASON_MAX_LENGTH) {
+    return { ok: false, error: `reason exceeds max length of ${AWARD_REASON_MAX_LENGTH} characters` };
+  }
+  const deltaMode = body.deltaMode === 'percentage' ? 'percentage' : 'absolute';
+  if (deltaMode === 'percentage' && delta > AWARD_PERCENTAGE_MAX) {
+    return { ok: false, error: `percentage delta must be between 1 and ${AWARD_PERCENTAGE_MAX}` };
+  }
+  return { ok: true, delta, reason: trimmedReason, deltaMode };
+}
+
+/**
+ * Compute the actual SP amount to apply given the validated payload and the
+ * student's current balance. For 'percentage' mode, appliedDelta is the
+ * percentage of currentBalance, rounded to the nearest integer (floor so
+ * admins never accidentally over-credit).
+ *
+ * Returns the integer appliedDelta (always > 0; negative deductions are
+ * not supported in this award flow — separate deduction endpoint should
+ * be added if needed).
+ */
+export function computeAppliedDelta({ delta, deltaMode }, currentBalance) {
+  const bal = Math.max(0, Number(currentBalance || 0));
+  if (deltaMode === 'percentage') {
+    // Floor so admins never over-credit. 10% of 145 = 14 SP, not 14.5.
+    return Math.floor((bal * delta) / 100);
+  }
+  return delta;
+}
+
+/**
+ * Build the reason text stored on the SPTransaction. Prefixes the mode
+ * for audit clarity so future readers know whether +10 was fixed or 10%.
+ *
+ * Examples:
+ *   - "Admin award (absolute): Great question on binary trees"
+ *   - "Admin award (10% of balance): Outstanding presentation"
+ */
+export function buildAwardReason(deltaMode, delta, adminReason) {
+  const prefix = deltaMode === 'percentage'
+    ? `Admin award (${delta}% of balance)`
+    : `Admin award (absolute)`;
+  return `${prefix}: ${adminReason}`;
+}

--- a/server/tests/admin-award.test.js
+++ b/server/tests/admin-award.test.js
@@ -1,0 +1,153 @@
+/**
+ * server/tests/admin-award.test.js
+ *
+ * Tests for server/services/adminAward.js
+ *
+ * Coverage: validateAwardPayload (15), computeAppliedDelta (6),
+ * buildAwardReason (4). 25 tests, ~150ms.
+ *
+ * Run: node --test server/tests/admin-award.test.js
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateAwardPayload,
+  computeAppliedDelta,
+  buildAwardReason,
+  AWARD_REASON_MAX_LENGTH,
+  AWARD_PERCENTAGE_MAX
+} from '../services/adminAward.js';
+
+// ── validateAwardPayload ────────────────────────────────────────────────
+
+test('validateAwardPayload: missing body', () => {
+  const r = validateAwardPayload(null);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /object/i);
+});
+test('validateAwardPayload: non-object body', () => {
+  assert.equal(validateAwardPayload('foo').ok, false);
+});
+test('validateAwardPayload: missing delta', () => {
+  const r = validateAwardPayload({ reason: 'good' });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /delta/);
+});
+test('validateAwardPayload: non-numeric delta', () => {
+  assert.equal(validateAwardPayload({ delta: '5', reason: 'good' }).ok, false);
+});
+test('validateAwardPayload: float delta is rejected (must be integer)', () => {
+  assert.equal(validateAwardPayload({ delta: 5.5, reason: 'good' }).ok, false);
+});
+test('validateAwardPayload: NaN delta is rejected', () => {
+  assert.equal(validateAwardPayload({ delta: NaN, reason: 'good' }).ok, false);
+});
+test('validateAwardPayload: zero delta is rejected', () => {
+  const r = validateAwardPayload({ delta: 0, reason: 'good' });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /positive/i);
+});
+test('validateAwardPayload: negative delta is rejected (use deduction)', () => {
+  const r = validateAwardPayload({ delta: -5, reason: 'good' });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /positive/i);
+});
+test('validateAwardPayload: delta above 1M is rejected', () => {
+  const r = validateAwardPayload({ delta: 1_000_001, reason: 'good' });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /maximum/);
+});
+test('validateAwardPayload: missing reason', () => {
+  const r = validateAwardPayload({ delta: 5 });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /reason/);
+});
+test('validateAwardPayload: non-string reason', () => {
+  assert.equal(validateAwardPayload({ delta: 5, reason: 42 }).ok, false);
+});
+test('validateAwardPayload: empty reason is rejected', () => {
+  assert.equal(validateAwardPayload({ delta: 5, reason: '' }).ok, false);
+});
+test('validateAwardPayload: whitespace-only reason is rejected', () => {
+  assert.equal(validateAwardPayload({ delta: 5, reason: '     ' }).ok, false);
+});
+test('validateAwardPayload: reason over 500 chars is rejected', () => {
+  const r = validateAwardPayload({ delta: 5, reason: 'x'.repeat(501) });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /max length/);
+});
+test('validateAwardPayload: valid absolute payload', () => {
+  const r = validateAwardPayload({ delta: 10, reason: '  Great question  ' });
+  assert.equal(r.ok, true);
+  assert.equal(r.delta, 10);
+  assert.equal(r.reason, 'Great question', 'reason should be trimmed');
+  assert.equal(r.deltaMode, 'absolute');
+});
+test('validateAwardPayload: valid percentage payload (50%)', () => {
+  const r = validateAwardPayload({ delta: 50, reason: 'Outstanding', deltaMode: 'percentage' });
+  assert.equal(r.ok, true);
+  assert.equal(r.delta, 50);
+  assert.equal(r.deltaMode, 'percentage');
+});
+test('validateAwardPayload: percentage over 100 is rejected', () => {
+  const r = validateAwardPayload({ delta: 101, reason: 'x', deltaMode: 'percentage' });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /between 1 and 100/);
+});
+test('validateAwardPayload: percentage at exactly 100 is allowed', () => {
+  const r = validateAwardPayload({ delta: 100, reason: 'x', deltaMode: 'percentage' });
+  assert.equal(r.ok, true);
+});
+test('validateAwardPayload: unknown deltaMode falls back to absolute', () => {
+  const r = validateAwardPayload({ delta: 5, reason: 'x', deltaMode: 'totally-bogus' });
+  assert.equal(r.ok, true);
+  assert.equal(r.deltaMode, 'absolute');
+});
+
+// ── computeAppliedDelta ─────────────────────────────────────────────────
+
+test('computeAppliedDelta: absolute mode returns delta unchanged', () => {
+  const out = computeAppliedDelta({ delta: 10, deltaMode: 'absolute' }, 145);
+  assert.equal(out, 10);
+});
+test('computeAppliedDelta: percentage of 145 with 10% = 14 (rounded down)', () => {
+  const out = computeAppliedDelta({ delta: 10, deltaMode: 'percentage' }, 145);
+  assert.equal(out, 14);
+});
+test('computeAppliedDelta: percentage of 100 with 25% = 25', () => {
+  const out = computeAppliedDelta({ delta: 25, deltaMode: 'percentage' }, 100);
+  assert.equal(out, 25);
+});
+test('computeAppliedDelta: percentage of 99 with 33% = 32 (floored)', () => {
+  const out = computeAppliedDelta({ delta: 33, deltaMode: 'percentage' }, 99);
+  assert.equal(out, 32);
+});
+test('computeAppliedDelta: percentage of 0 balance = 0', () => {
+  const out = computeAppliedDelta({ delta: 50, deltaMode: 'percentage' }, 0);
+  assert.equal(out, 0);
+});
+test('computeAppliedDelta: negative currentBalance normalized to 0', () => {
+  const out = computeAppliedDelta({ delta: 10, deltaMode: 'percentage' }, -50);
+  assert.equal(out, 0);
+});
+
+// ── buildAwardReason ────────────────────────────────────────────────────
+
+test('buildAwardReason: absolute mode', () => {
+  const out = buildAwardReason('absolute', 10, 'Great question');
+  assert.equal(out, 'Admin award (absolute): Great question');
+});
+test('buildAwardReason: percentage mode shows the % value', () => {
+  const out = buildAwardReason('percentage', 10, 'Outstanding');
+  assert.equal(out, 'Admin award (10% of balance): Outstanding');
+});
+test('buildAwardReason: percentage with large % value', () => {
+  const out = buildAwardReason('percentage', 100, 'Incredible');
+  assert.equal(out, 'Admin award (100% of balance): Incredible');
+});
+test('buildAwardReason: empty reason still included', () => {
+  const out = buildAwardReason('absolute', 5, '');
+  assert.equal(out, 'Admin award (absolute): ');
+});


### PR DESCRIPTION
Adds the missing admin-side SP adjustment. Today admins can write notes about a student (PR #19) but cannot issue a one-off SP award for outstanding contributions. This PR closes that gap with a single "Reward" button in the student profile modal.

## What

Two ways to award:

  - Fixed SP:     { delta: 10, reason: "Great question on binary trees" }     -> +10 SP
  - % of balance: { delta: 10, reason: "Outstanding presentation",             -> 10% of current
                   deltaMode: "percentage" }                                      (floored to int)

## Server side

New endpoint  POST /api/admin/student/:id/award (adminGuard)

Pipeline:
  1. validateAwardPayload(body)     -- 19 input rules
  2. computeAppliedDelta(v, balance) -- resolves percentage to absolute
                                       (floored so admins never
                                        over-credit, e.g. 10% of 145
                                        = 14 SP, not 14.5)
  3. Block if student.status === 'excused' (defensive)
  4. Insert SPTransaction(category='manual', deltaMode, deltaValue,
                           appliedDelta, balanceAfter, reason,
                           dateTime)
  5. Student.updateOne($inc totalSp) -- atomic balance update
  6. Return { ok, transaction } with the new balance

Rejects bad inputs with 400 + specific error message:
  - missing body / wrong type / missing fields
  - non-numeric delta, float delta, NaN, zero, negative, over 1M
  - non-string reason, empty, whitespace-only, over 500 chars
  - percentage over 100%
  - unknown deltaMode -> falls back to absolute (lenient)

Pure helpers in server/services/adminAward.js (107 lines, no DB):
  - validateAwardPayload
  - computeAppliedDelta
  - buildAwardReason  (prefixes "Admin award (absolute):" or "(10% of balance):" for audit clarity)

## Client side

  + "Reward SP" button in the student profile modal header
  + Modal with mode toggle (fixed / %), live preview ("+14 SP" for percentage), 500-char reason textarea, Confirm/Cancel
  + The student's totalSp in the modal header updates immediately after a successful award (state stored in studentProfile)
  + The new transaction appears at the top of the SpBank below

## Tests  29 tests, all pass in ~150ms

server/tests/admin-award.test.js:

  validateAwardPayload  -- 19 tests:
    - missing body / non-object body / missing delta
    - non-numeric / float / NaN / zero / negative / over 1M
    - missing reason / non-string / empty / whitespace-only / over 500
    - valid absolute payload (with reason trim)
    - valid percentage payload
    - percentage over 100 rejected, exactly 100 allowed
    - unknown deltaMode falls back to absolute

  computeAppliedDelta  -- 6 tests:
    - absolute returns delta unchanged
    - percentage of 145 with 10% = 14 (rounded down)
    - percentage of 99 with 33% = 32 (floored)
    - percentage of 0 balance = 0
    - negative currentBalance normalized to 0

  buildAwardReason  -- 4 tests:
    - absolute mode
    - percentage mode shows the % value
    - large percentage value
    - empty reason still included

## Verification

  node --check server/server.js                       passes
  node --check server/services/adminAward.js           passes
  node --test server/tests/admin-award.test.js         29/29 in ~150ms
  npm --prefix client run build                        passes (174.67 kB JS)

End-to-end flow:
  admin opens student profile modal
  admin clicks "Reward SP"
  admin picks mode "10% of current balance", types 10, reason "Day 12 MVP"
  admin sees "Preview: +14 SP" (assuming balance 145)
  admin clicks "Award 10%"
  POST /api/admin/student/{id}/award runs the pipeline above
  modal closes, totalSp shown as 159, new "manual" transaction at top

## Tech

  new endpoint:     POST /api/admin/student/:id/award
  new component:    Award SP modal (in AdminView)
  schema changes:   none -- uses existing 'manual' category in SPTransaction
  new deps:         none
  lines:            +525 / -1 across 5 files
                    107 service, 153 tests, 143 client, 78 CSS, 45 server

## Notes for reviewer

  - validateAwardPayload returns ok=false / error string (never throws) so the endpoint can map cleanly to 400 responses.

  - percentage is floored to int so admins never accidentally over-credit. 10% of 145 = 14 SP, not 14.5. Documented inline.

  - For percentage mode the rejection window is 1..100 inclusive; exactly 100% is allowed (= +full balance, rare but valid for "you aced every session").

  - Atomic update via $inc means even concurrent admin actions cannot drop the balance to a wrong value -- the increment is atomic server-side.

  - Excused students are blocked at the endpoint with 400 to avoid awarding SP to someone who isn't participating.

  - The new SPTransaction entry is inserted BEFORE the $inc, so the ledger always has the record even if the update fails (and the endpoint returns the tx regardless).