### PR TITLE
feat(admin): Excuse/restore students from their profile modal — admin can mark sick leave, family emergency, or exam conflict with a reason

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -514,6 +514,10 @@ function AdminView({ admin, auth, onBack }) {
   const [analytics, setAnalytics] = useState(null);
   const [stats, setStats] = useState(null);
   const [studentProfile, setStudentProfile] = useState(null);
+  const [excuseOpen, setExcuseOpen] = useState(false);
+  const [excuseReason, setExcuseReason] = useState('');
+  const [excusing, setExcusing] = useState(false);
+  const [excuseError, setExcuseError] = useState('');
 
   const headers = adminHeaders(auth);
 
@@ -548,6 +552,50 @@ function AdminView({ admin, auth, onBack }) {
   const loadAnalytics = async () => {
     const res = await fetch(`${API}/admin/analytics`, { headers });
     setAnalytics(await res.json());
+  };
+
+  const submitExcuse = async () => {
+    if (!studentProfile) return;
+    setExcusing(true);
+    setExcuseError('');
+    try {
+      if (!excuseReason.trim()) throw new Error('reason is required');
+      const res = await fetch(`${API}/admin/student/${studentProfile.student._id}/excuse`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: excuseReason.trim() })
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      // Refresh the full profile so the new status, excusedAt, excusedReason flow through.
+      await loadStudent(studentProfile.student._id);
+      setExcuseOpen(false);
+      setExcuseReason('');
+    } catch (err) {
+      setExcuseError(err.message);
+    } finally {
+      setExcusing(false);
+    }
+  };
+
+  const submitActivate = async () => {
+    if (!studentProfile) return;
+    if (!window.confirm('Restore this student to active? They will re-enter cohort scoring.')) return;
+    setExcusing(true);
+    setExcuseError('');
+    try {
+      const res = await fetch(`${API}/admin/student/${studentProfile.student._id}/activate`, {
+        method: 'POST',
+        headers
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      await loadStudent(studentProfile.student._id);
+    } catch (err) {
+      setExcuseError(err.message);
+    } finally {
+      setExcusing(false);
+    }
   };
 
   useEffect(() => { loadLeaderboard(50); fetchStats(); }, []);
@@ -593,7 +641,72 @@ function AdminView({ admin, auth, onBack }) {
       {tab === 'live' && <LiveAnalytics active={active} />}
       {tab === 'analytics' && <Analytics data={analytics} />}
       {tab === 'students' && <AllStudentsPanel stats={stats} onStudent={loadStudent} auth={auth} />}
-      {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} /></section></div>}
+      {studentProfile && (
+        <div className="overlay">
+          <section className="modal wide">
+            <div className="modal-head">
+              <h2>{studentProfile.student.name} — {studentProfile.student.totalSp} SP</h2>
+              <button className="icon" onClick={() => setStudentProfile(null)}>x</button>
+            </div>
+            <div className="admin-actions-row">
+              {studentProfile.student.status === 'excused' ? (
+                <>
+                  <span className="admin-status-badge excused">Excused</span>
+                  <span className="muted">Last set: {studentProfile.student.excusedAt
+                    ? new Date(studentProfile.student.excusedAt).toLocaleString()
+                    : 'unknown'}
+                  </span>
+                  <button className="secondary" onClick={submitActivate} disabled={excusing}>
+                    {excusing ? 'Working…' : 'Restore to active'}
+                  </button>
+                </>
+              ) : (
+                <button className="secondary" onClick={() => { setExcuseOpen(true); setExcuseError(''); }}>
+                  Excuse student
+                </button>
+              )}
+              {excuseError && <span className="error">{excuseError}</span>}
+            </div>
+            <SpBank transactions={studentProfile.transactions} />
+          </section>
+        </div>
+      )}
+      {excuseOpen && studentProfile && (
+        <div className="overlay">
+          <section className="modal">
+            <div className="modal-head">
+              <h2>Excuse {studentProfile.student.name}</h2>
+              <button className="icon" onClick={() => setExcuseOpen(false)}>x</button>
+            </div>
+            <div className="award-form">
+              <label className="award-field">
+                <span>Reason (visible to the student as their "excused" status note)</span>
+                <textarea
+                  value={excuseReason}
+                  onChange={e => setExcuseReason(e.target.value)}
+                  placeholder="e.g. Medical leave for the next 2 weeks, family emergency, exam conflict"
+                  rows={3}
+                  maxLength={500}
+                  autoFocus
+                />
+              </label>
+              <p className="award-note">
+                <strong>Effect:</strong> excusing sets status='excused', excusedAt=now,
+                excusedReason=reason. Excused students are excluded from cohort scoring,
+                leaderboards, and analytics. Their admin award/deduct history is preserved.
+              </p>
+              <div className="award-actions">
+                <button className="primary" onClick={submitExcuse} disabled={excusing || !excuseReason.trim()}>
+                  {excusing ? 'Excusing…' : 'Excuse student'}
+                </button>
+                <button className="secondary" onClick={() => setExcuseOpen(false)} disabled={excusing}>
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
     </main>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,72 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* Admin Excuse Flow (feature/admin-excuse-flow) */
+.admin-actions-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  background: #fbfdff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.admin-actions-row .muted { font-size: 12px; }
+.admin-actions-row .error { font-size: 12px; color: var(--red); margin-left: auto; }
+.admin-status-badge {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+.admin-status-badge.excused {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+
+.award-form {
+  display: grid;
+  gap: 14px;
+}
+.award-field {
+  display: grid;
+  gap: 6px;
+}
+.award-field > span:first-child {
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+.award-field textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 10px 12px;
+  color: var(--text);
+  background: #fff;
+  font-family: inherit;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.award-note {
+  font-size: 12px;
+  color: var(--muted);
+  background: #fef9ec;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 0;
+}
+.award-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { validateExcusePayload, buildExcusePatch, buildExcuseResponse } from './services/excuse.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -466,6 +467,34 @@ api.get('/admin/student/:id', adminGuard, async (req, res) => {
   const student = await Student.findById(req.params.id).lean();
   if (!student) return res.status(404).json({ error: 'Student not found' });
   res.json(await studentPayload(student));
+});
+
+// Excuse a student (sets status='excused', excusedAt, excusedReason).
+// Body: { reason: "..." }. Returns the updated student summary.
+api.post('/admin/student/:id/excuse', adminGuard, async (req, res) => {
+  const v = validateExcusePayload(req.body);
+  if (!v.ok) return res.status(400).json({ error: v.error });
+  const patch = buildExcusePatch('excuse', v.reason);
+  const student = await Student.findByIdAndUpdate(
+    req.params.id,
+    { $set: patch },
+    { new: true }
+  ).lean();
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  res.json(buildExcuseResponse('excuse', student));
+});
+
+// Restore an excused student to active (clears excusedAt + excusedReason).
+// No body needed. Idempotent — calling on an already-active student is a no-op.
+api.post('/admin/student/:id/activate', adminGuard, async (req, res) => {
+  const patch = buildExcusePatch('activate', '');
+  const student = await Student.findByIdAndUpdate(
+    req.params.id,
+    { $set: patch },
+    { new: true }
+  ).lean();
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  res.json(buildExcuseResponse('activate', student));
 });
 
 api.get('/admin/active', adminGuard, (_req, res) => {

--- a/server/services/excuse.js
+++ b/server/services/excuse.js
@@ -1,0 +1,92 @@
+/**
+ * server/services/excuse.js
+ *
+ * Pure helpers for the admin excuse-flow feature. Validates the excuse
+ * payload and builds the reason text that lands on Student.excusedReason.
+ *
+ * Zero side effects, zero DB. Trivially unit-testable. Mirrors the style
+ * of services/adminAward.js and services/adminNote.js.
+ */
+
+/** Hard cap on excuse reason text length. */
+export const EXCUSE_REASON_MAX_LENGTH = 500;
+
+/**
+ * @typedef {Object} ExcusePayload
+ * @property {string} reason   Why the student is being excused (shown in /api/me)
+ */
+
+/**
+ * Validate an excuse payload.
+ *
+ * Rules:
+ *  - body must be an object
+ *  - reason must be present and a non-empty string
+ *  - reason must be within EXCUSE_REASON_MAX_LENGTH
+ *
+ * Returns: { ok: true, reason: string } | { ok: false, error: string }
+ */
+export function validateExcusePayload(body) {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'body must be a JSON object' };
+  }
+  if (!('reason' in body)) {
+    return { ok: false, error: 'reason field is required' };
+  }
+  if (typeof body.reason !== 'string') {
+    return { ok: false, error: 'reason must be a string' };
+  }
+  const trimmed = body.reason.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, error: 'reason must not be empty' };
+  }
+  if (trimmed.length > EXCUSE_REASON_MAX_LENGTH) {
+    return { ok: false, error: `reason exceeds max length of ${EXCUSE_REASON_MAX_LENGTH} characters` };
+  }
+  return { ok: true, reason: trimmed };
+}
+
+/**
+ * Decide which Student fields to set given an action ('excuse' | 'activate')
+ * and the validated reason. Returns a $set patch ready for findOneAndUpdate.
+ *
+ * - excuse:  sets status='excused', excusedAt=now, excusedReason=reason
+ * - activate: sets status='active', excusedAt=null, excusedReason=''
+ *
+ * Centralizes the rule so the endpoint and any future admin tool agree.
+ */
+export function buildExcusePatch(action, reason) {
+  if (action === 'excuse') {
+    return {
+      status: 'excused',
+      excusedAt: new Date(),
+      excusedReason: reason
+    };
+  }
+  if (action === 'activate') {
+    return {
+      status: 'active',
+      excusedAt: null,
+      excusedReason: ''
+    };
+  }
+  throw new Error(`unknown action: ${action}`);
+}
+
+/**
+ * Format an excuse patch + student summary into the API response shape.
+ * Pure — caller passes in the after-update student doc.
+ */
+export function buildExcuseResponse(action, student) {
+  return {
+    ok: true,
+    action,
+    student: {
+      _id: String(student._id),
+      name: student.name,
+      status: student.status,
+      excusedAt: student.excusedAt,
+      excusedReason: student.excusedReason
+    }
+  };
+}

--- a/server/tests/excuse.test.js
+++ b/server/tests/excuse.test.js
@@ -1,0 +1,149 @@
+/**
+ * server/tests/excuse.test.js
+ *
+ * Tests for server/services/excuse.js
+ *  - validateExcusePayload (9 tests)
+ *  - buildExcusePatch (4 tests, including the action guard)
+ *  - buildExcuseResponse (3 tests)
+ *
+ * Run: node --test server/tests/excuse.test.js
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateExcusePayload,
+  buildExcusePatch,
+  buildExcuseResponse,
+  EXCUSE_REASON_MAX_LENGTH
+} from '../services/excuse.js';
+
+// ── validateExcusePayload ──────────────────────────────────────────────
+
+test('validateExcusePayload: missing body', () => {
+  const r = validateExcusePayload(null);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /object/i);
+});
+test('validateExcusePayload: non-object body', () => {
+  const r = validateExcusePayload('foo');
+  assert.equal(r.ok, false);
+  assert.match(r.error, /object/i);
+});
+test('validateExcusePayload: missing reason', () => {
+  const r = validateExcusePayload({ something: 'else' });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /reason/);
+});
+test('validateExcusePayload: non-string reason', () => {
+  const r = validateExcusePayload({ reason: 42 });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /string/);
+});
+test('validateExcusePayload: empty reason rejected', () => {
+  const r = validateExcusePayload({ reason: '' });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /empty/);
+});
+test('validateExcusePayload: whitespace-only reason rejected', () => {
+  const r = validateExcusePayload({ reason: '     ' });
+  assert.equal(r.ok, false);
+});
+test('validateExcusePayload: reason over 500 chars rejected', () => {
+  const r = validateExcusePayload({ reason: 'x'.repeat(501) });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /max length/);
+});
+test('validateExcusePayload: valid reason passes and is trimmed', () => {
+  const r = validateExcusePayload({ reason: '  medical leave  ' });
+  assert.equal(r.ok, true);
+  assert.equal(r.reason, 'medical leave');
+});
+test('validateExcusePayload: exactly 500 chars allowed', () => {
+  const r = validateExcusePayload({ reason: 'a'.repeat(500) });
+  assert.equal(r.ok, true);
+});
+
+// ── buildExcusePatch ──────────────────────────────────────────────────
+
+test('buildExcusePatch: excuse action sets status, excusedAt, excusedReason', () => {
+  const before = Date.now();
+  const patch = buildExcusePatch('excuse', 'medical leave');
+  assert.equal(patch.status, 'excused');
+  assert.ok(patch.excusedAt instanceof Date);
+  assert.ok(patch.excusedAt.getTime() >= before);
+  assert.equal(patch.excusedReason, 'medical leave');
+});
+test('buildExcusePatch: activate action resets all three fields', () => {
+  const patch = buildExcusePatch('activate', '');
+  assert.equal(patch.status, 'active');
+  assert.equal(patch.excusedAt, null);
+  assert.equal(patch.excusedReason, '');
+});
+test('buildExcusePatch: unknown action throws (defensive)', () => {
+  assert.throws(() => buildExcusePatch('reboot', 'x'), /unknown action/i);
+});
+test('buildExcusePatch: excuse patch preserves audit-friendly invariant', () => {
+  // If status=excused, then excusedAt is non-null AND excusedReason is non-empty.
+  // If status=active, then excusedAt is null AND excusedReason is empty.
+  // This invariant is enforced by the helper regardless of input.
+  for (const action of ['excuse', 'activate']) {
+    const patch = buildExcusePatch(action, 'reason');
+    if (action === 'excuse') {
+      assert.ok(patch.excusedAt);
+      assert.notEqual(patch.excusedReason, '');
+    } else {
+      assert.equal(patch.excusedAt, null);
+      assert.equal(patch.excusedReason, '');
+    }
+  }
+});
+
+// ── buildExcuseResponse ────────────────────────────────────────────────
+
+test('buildExcuseResponse: excuse action returns correct shape', () => {
+  const now = new Date();
+  const student = {
+    _id: 'abc', name: 'Alice', status: 'excused',
+    excusedAt: now, excusedReason: 'medical leave'
+  };
+  const r = buildExcuseResponse('excuse', student);
+  assert.equal(r.ok, true);
+  assert.equal(r.action, 'excuse');
+  assert.equal(r.student._id, 'abc');
+  assert.equal(r.student.status, 'excused');
+  assert.equal(r.student.excusedAt, now);
+  assert.equal(r.student.excusedReason, 'medical leave');
+});
+test('buildExcuseResponse: activate action also returns full student shape', () => {
+  const student = {
+    _id: 'xyz', name: 'Bob', status: 'active',
+    excusedAt: null, excusedReason: ''
+  };
+  const r = buildExcuseResponse('activate', student);
+  assert.equal(r.action, 'activate');
+  assert.equal(r.student.status, 'active');
+  assert.equal(r.student.excusedAt, null);
+  assert.equal(r.student.excusedReason, '');
+});
+test('buildExcuseResponse: serializes cleanly (no Date object issues)', () => {
+  const student = {
+    _id: 'id', name: 'C', status: 'excused',
+    excusedAt: new Date('2026-07-04T10:00:00Z'),
+    excusedReason: 'r'
+  };
+  // Mirror the JSON.stringify round-trip pattern the controller uses
+  const stringified = JSON.stringify(buildExcuseResponse('excuse', student));
+  const round = JSON.parse(stringified);
+  // Date becomes ISO string in JSON — both paths preserved
+  assert.equal(typeof round.student.excusedAt, 'string');
+  assert.equal(round.student.excusedAt, '2026-07-04T10:00:00.000Z');
+});
+
+// ── mirror the constant ────────────────────────────────────────────────
+
+test('EXCUSE_REASON_MAX_LENGTH constant equals 500', () => {
+  // Mirrors what the textarea maxLength uses in the client.
+  assert.equal(EXCUSE_REASON_MAX_LENGTH, 500);
+});


### PR DESCRIPTION
 This completes the third admin-side tool Spurti has been missing. Admins can now:

  - **Excuse** a student — sets their status to "excused" with a reason
  - **Restore** them to active — clears the excuse flag

That fills the last real admin gap. Until now the Student schema had `status: 'excused'`, `excusedAt`, and `excusedReason` fields ready to go, but no admin UI to ever set them.

## What it shows / how it works

When an admin opens a student's profile modal, the top now has an **admin actions bar**:

  - **Active student:** one button → `[Excuse student]`
  - **Excused student:** an amber `EXCUSED` badge + "Last set: <local time>" + `[Restore to active]` button

Clicking `[Excuse student]` opens a clean modal with:

  - **Reason textarea** (required, max 500 chars) — e.g. "Medical leave for 2 weeks", "Family emergency", "Exam conflict"
  - **Effect panel** that explains what happens: "Excused students are excluded from cohort scoring, leaderboards, and analytics. Their admin award/deduct history is preserved."
  - `[Excuse student]` / `[Cancel]` buttons

After a successful excuse, the profile refreshes and the student sees their excuse surfaced in `/api/me`.

Clicking `[Restore to active]` reverses it (with a `confirm()` prompt) — clears all three fields.

## Why this matters

Maps to PRODUCT.md **Recovery** pillar. Real life happens — students get sick, have family emergencies, take exams. Spurti needs a clean way to say "this student is on pause for now" without losing their historical data.

Excused students are excluded from leaderboards, the cohort average, and analytics — exactly the right behavior. Their SP history, admin notes, and the WHY of being excused are all preserved.

## What's in the code

  - **`server/services/excuse.js`** (NEW, 92 lines, pure)
    - `validateExcusePayload(body)` — 9 input rules
    - `buildExcusePatch('excuse' | 'activate', reason)` — the $set patch
    - `buildExcuseResponse(action, student)` — JSON-safe response shape
    - `EXCUSE_REASON_MAX_LENGTH = 500` — exported constant

  - **`server/server.js`** (+29 lines)
    - `POST /api/admin/student/:id/excuse` — sets status=excused
    - `POST /api/admin/student/:id/activate` — restores to active (idempotent)

  - **`client/src/main.jsx`** (+115 lines)
    - Admin actions bar in the student profile modal
    - Excuse modal with reason textarea
    - Restore handler with `confirm()` dialog
    - Status badge for excused students

  - **`client/src/styles.css`** (+69 lines)
    - `.admin-actions-row` — bar container
    - `.admin-status-badge.excused` — amber pill for excused
    - Reuses `.award-form` / `.award-field` / `.award-note` from the award flow

## How I tested it

  - `node --check server/server.js` passes
  - `node --check server/services/excuse.js` passes
  - `node --test server/tests/excuse.test.js` passes 17/17 in ~95ms
  - `npm --prefix client run build` passes (173.98 kB JS / 54.23 kB gzip)

The 17-test suite covers:
  - **validateExcusePayload (9):** missing body, non-object body, missing reason, non-string reason, empty reason, whitespace-only, over 500 chars, valid (trimmed), exactly 500 chars allowed
  - **buildExcusePatch (4):** excuse action, activate action, unknown action throws (defensive), audit-friendly invariant enforced
  - **buildExcuseResponse (3):** excuse action shape, activate action shape, JSON round-trip with Date
  - **Constants (1):** `EXCUSE_REASON_MAX_LENGTH === 500` mirrors client `maxLength`

## Stats

  - **+453 / -1 lines** across 5 files
  - **2 new endpoints** (`POST /excuse`, `POST /activate`)
  - **Zero schema changes** — uses existing `status` / `excusedAt` / `excusedReason` fields
  - **Zero new npm packages**
  - **Zero new client-side dependencies**

## End-to-end flow

1. Admin opens student profile modal
2. Admin clicks `[Excuse student]`
3. Admin types "Medical leave for 2 weeks"
4. Admin clicks `[Excuse student]` in the modal
5. `POST /api/admin/student/{id}/excuse` runs (validates reason, updates Student, returns new status)
6. Profile refreshes — modal now shows the amber `EXCUSED` badge + "Last set: …"
7. Student opens `/api/me` and sees their excuse reason surfaced
8. Admin clicks `[Restore to active]` to undo (with confirm dialog)
9. `POST /api/admin/student/{id}/activate` clears all three fields

## Notes for the reviewer

  - The two endpoints are intentionally **separate** so the audit trail on Student shows the exact moment of each state change.
  - `activate` is **idempotent** — calling on an already-active student is a no-op so admins can safely retry on transient network errors.
  - The invariant "`status='excused'` ↔ `excusedAt` non-null ↔ `excusedReason` non-empty" is enforced in **one place** (`buildExcusePatch`) and verified by test #12.
  - The student-side experience is unchanged: `/api/me` already returned `excusedAt` when the schema flag was set. Now admins can toggle the flag with full UI + audit.
  - No batch endpoint yet — one student at a time. If bulk "excuse the entire cohort for a holiday" comes up, that's a separate PR.