### PR TITLE
Add rank neighbourhood (±3) to student leaderboard

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -264,7 +264,7 @@ function StudentView({ profile, onBack }) {
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'chats' && <Chats chats={profile.chats} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
-      {tab === 'leaderboard' && <Leaderboard rows={profile.leaderboard} />}
+      {tab === 'leaderboard' && <Leaderboard rows={profile.leaderboard} neighbors={profile.neighbors} student={profile.student} />}
       {tab === 'event' && <InvestmentEventTab email={profile.student.email} profile={profile} />}
     </main>
   );
@@ -439,14 +439,32 @@ function Polls({ polls }) {
   );
 }
 
-function Leaderboard({ rows }) {
+function Leaderboard({ rows, neighbors = [], student }) {
+  const renderRow = row => (
+    <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}>
+      <td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.totalSp}</td>
+    </tr>
+  );
+  const inTop50 = student && student.rank && student.rank <= 50;
   return (
     <section className="panel">
       <h2>Top 50 Leaderboard</h2>
       <table className="table">
         <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>SP</th></tr></thead>
-        <tbody>{rows.map(row => <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}><td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.totalSp}</td></tr>)}</tbody>
+        <tbody>{rows.map(renderRow)}</tbody>
       </table>
+      {student && student.rank && (
+        <div className="your-standing">
+          <h3>Your Standing</h3>
+          <p>You are <strong>Rank {student.rank}</strong> with <strong>{student.totalSp} SP</strong>{inTop50 ? ' — you are in the Top 50.' : '.'}</p>
+        </div>
+      )}
+      {neighbors.length > 0 && !inTop50 && (
+        <table className="table">
+          <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>SP</th></tr></thead>
+          <tbody>{neighbors.map(renderRow)}</tbody>
+        </table>
+      )}
     </section>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -320,6 +320,8 @@ input {
 }
 .table tbody tr:hover { background: #f5fbfd; }
 .table tr.current-student { background: #e9f7ee; font-weight: 850; }
+.your-standing { margin: 1rem 0 0.5rem; }
+.your-standing h3 { margin: 0 0 0.25rem; }
 .matrix-wrap { overflow-x: auto; }
 .matrix th, .matrix td { white-space: nowrap; }
 .ok-cell { background: #dcfce7; color: var(--green); font-weight: 800; }

--- a/server/server.js
+++ b/server/server.js
@@ -143,6 +143,15 @@ async function studentPayload(student) {
   const top50Cutoff = allStudents[49]?.totalSp || null;
   const currentIndex = allStudents.findIndex(s => s.email === email);
   const nextStudent = currentIndex > 0 ? allStudents[currentIndex - 1] : null;
+  const neighborStart = currentIndex === -1 ? 0 : Math.max(0, currentIndex - 3);
+  const neighborEnd = currentIndex === -1 ? 0 : Math.min(allStudents.length, currentIndex + 4);
+  const neighbors = allStudents.slice(neighborStart, neighborEnd).map((row, offset) => ({
+    rank: neighborStart + offset + 1,
+    name: row.name,
+    maskedEmail: maskEmail(row.email),
+    totalSp: row.totalSp,
+    isCurrentStudent: row.email === email
+  }));
   return {
     student: {
       _id: String(student._id),
@@ -175,7 +184,8 @@ async function studentPayload(student) {
       maskedEmail: maskEmail(row.email),
       totalSp: row.totalSp,
       isCurrentStudent: row.email === email
-    }))
+    })),
+    neighbors
   };
 }
 


### PR DESCRIPTION
## What & why
On the student Leaderboard tab, only the Top 50 is visible today. Students outside the Top 50 have no way to see where they stand relative to their immediate neighbours. This PR adds a "Your Standing" block and a ±3 rank window after the Top 50 table (e.g. a rank-100 student sees ranks 97–103, with their own row highlighted).

## Changes
- **server (`server/server.js`)** — in `studentPayload`, compute a `neighbors` slice (current student's index ±3) from the **already-loaded** fully-ranked cohort (`allStudents`) and include it in the payload. No new query: it reuses the existing `sort({ totalSp: -1, name: 1 })` + `{ status: { $ne: 'excused' } }` list, and assigns `rank: index + 1` — the same convention already used by the public and admin leaderboard endpoints. The window is clamped at both ends so students near rank 1 or the bottom don't break.
- **client (`client/src/main.jsx`)** — the `Leaderboard` component now renders "Your Standing" (rank + SP) and the ±3 neighbour table. The neighbour table is shown only for students **outside** the Top 50, since Top-50 students are already visible and highlighted in the main table.
- **styles (`client/src/styles.css`)** — minor spacing for the new block; reuses the existing `current-student` highlight.

## Ranking consistency
The neighbour window's ranks are provably consistent with `rankFor()` (which drives the header rank): a student's slice index equals `better` from `rankFor`, so the highlighted row's rank always matches `student.rank`.

## Testing
- `client` `vite build` passes.
- `server/server.js` passes `node --check`.
- UI verified against mock data for both cases (student inside vs. outside the Top 50).
