### PR TITLE
Feat:Add Back to Top button for long pages

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -264,12 +264,37 @@ function SearchModal({ onClose, onStudent }) {
 
 function StudentView({ profile, onBack }) {
   const [tab, setTab] = useState('bank');
+  const [showBackToTop, setShowBackToTop] = useState(false);
+  const topbarRef = useRef(null);
   const { student } = profile;
   const badges = useMemo(() => buildBadges(profile), [profile]);
   const nextActions = useMemo(() => buildNextActions(profile), [profile]);
+
+  useEffect(() => {
+    const target = topbarRef.current;
+    if (!target) return;
+
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(([entry]) => {
+        setShowBackToTop(!entry.isIntersecting);
+      }, { threshold: 0 });
+      observer.observe(target);
+      return () => observer.disconnect();
+    }
+
+    const onScroll = () => setShowBackToTop(window.scrollY > 240);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
   return (
     <main className="page compact">
-      <header className="topbar">
+      <header className="topbar" ref={topbarRef}>
         {onBack ? <button className="secondary" onClick={onBack}>Back</button> : <span />}
         <div>
           <p className="eyebrow">Student Spurti Bank</p>
@@ -283,6 +308,15 @@ function StudentView({ profile, onBack }) {
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
+      <button
+        className={`back-to-top ${showBackToTop ? 'visible' : ''}`}
+        onClick={scrollToTop}
+        aria-label="Back to top"
+        title="Back to top"
+        type="button"
+      >
+        ↑
+      </button>
     </main>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -296,6 +296,41 @@ input {
 .credit { color: var(--green); }
 .debit { color: var(--red); }
 
+.back-to-top {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--primary-dark);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(12px) scale(0.96);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+  z-index: 15;
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.back-to-top:hover {
+  background: #f3f8fb;
+  color: var(--primary);
+}
+
 .cards { display: grid; gap: 12px; }
 .card {
   border: 1px solid var(--line);


### PR DESCRIPTION
## Summary

This PR adds a floating Back to Top button to improve navigation on pages with long student histories. When page gets long with records, instead of manual scrolling back to top, we can just click this button.

## Changes

- Added a floating Back to Top button.
- Button appears after scrolling beyond the page header.
- Smoothly scrolls back to the top when clicked.
- Styled to match the existing application theme.
- Lightweight implementation with no additional dependencies.

## Testing

- Verified the button is hidden initially.
- Verified it appears after scrolling.
- Verified smooth scrolling back to the top.

Note the button will appear as such on RHS bottom of the page.
<img width="1899" height="95" alt="image" src="https://github.com/user-attachments/assets/a74594a8-30c6-4846-be1a-fb707fdaa65c" />
