### PR TITLE
feat: add first-time onboarding flow with 5-step guided tour

### DIFF
--- a/client/src/components/OnboardingModal.jsx
+++ b/client/src/components/OnboardingModal.jsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useState } from 'react';
+
+const APP_BASE = window.location.pathname.startsWith('/spurti') ? '/spurti' : '';
+const API = `${APP_BASE}/api`;
+
+const STEPS = [
+  {
+    icon: 'SP',
+    title: 'Welcome to Spurti',
+    description: 'Spurti Points (SP) track how consistently you show up and participate throughout the program. Every session is a fresh opportunity to earn points and climb the leaderboard.',
+    Visual: SpCounterVisual,
+  },
+  {
+    icon: '%',
+    title: 'How you earn SP',
+    description: 'SP is earned based on how much of each session you attend and how many polls you answer. Stay for 90%+ of a session and earn +10 SP. Answer 90%+ of polls and earn another +10 SP. Partial effort still earns partial SP. No penalties for missing a session.',
+    Visual: RulesTableVisual,
+  },
+  {
+    icon: '#',
+    title: 'Your rank matters',
+    description: 'You are ranked against all students in your cohort. Your rank updates after every session. Consistent effort beats everything — SP compounds over time and small gains every day add up to a big rank difference by the end of the program.',
+    Visual: LeaderboardVisual,
+  },
+  {
+    icon: '!',
+    title: 'We have got your back',
+    description: 'If you start falling behind, you will get a personal nudge — in-app and by email — with exactly what to do next. The system watches your attendance and poll patterns so no one falls behind silently.',
+    Visual: NudgeVisual,
+  },
+  {
+    icon: 'Go',
+    title: 'Ready to earn your first SP?',
+    description: 'Stay for the full session and answer every poll — that is +20 SP in a single day. Even partial attendance earns you points. Show up consistently and your SP compounds fast.',
+    Visual: SpSimulatorVisual,
+  },
+];
+
+export default function OnboardingModal({ studentEmail, onComplete }) {
+  const [step, setStep] = useState(0);
+  const [phase, setPhase] = useState('in');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setPhase('out');
+    const id = requestAnimationFrame(() => setPhase('in'));
+    return () => cancelAnimationFrame(id);
+  }, [step]);
+
+  const isLast = step === STEPS.length - 1;
+  const current = STEPS[step];
+  const Visual = current.Visual;
+
+  async function markComplete() {
+    setSubmitting(true);
+    try {
+      await fetch(`${API}/onboarding/${encodeURIComponent(studentEmail)}/complete`, { method: 'POST' });
+    } catch {
+      // best-effort — the tour still closes even if the request fails
+    } finally {
+      setSubmitting(false);
+      onComplete();
+    }
+  }
+
+  function handleNext() {
+    if (isLast) {
+      markComplete();
+    } else {
+      setStep((s) => s + 1);
+    }
+  }
+
+  function handlePrevious() {
+    setStep((s) => Math.max(0, s - 1));
+  }
+
+  return (
+    <div className="onboarding-overlay">
+      <div className="onboarding-wrapper">
+        <div className="onboarding-card" role="dialog" aria-modal="true" aria-labelledby="onboarding-title">
+          <div className="onboarding-header">
+            <span className="onboarding-step-label">Step {step + 1} of {STEPS.length}</span>
+            <h2 id="onboarding-title" className="onboarding-title">{current.title}</h2>
+            <button type="button" className="onboarding-skip" onClick={markComplete} disabled={submitting}>
+              Skip
+            </button>
+          </div>
+          <div className="onboarding-progress-bar">
+            <div className="onboarding-progress-bar-fill" style={{ width: `${((step + 1) / STEPS.length) * 100}%` }} />
+          </div>
+          <div className="onboarding-body">
+            <div key={step} className={`onboarding-step-content phase-${phase}`}>
+              <div className="onboarding-icon-row">
+                <div className="onboarding-icon-circle">{current.icon}</div>
+              </div>
+              <h3 className="onboarding-step-title">{current.title}</h3>
+              <p className="onboarding-step-description">{current.description}</p>
+              <Visual />
+            </div>
+          </div>
+          <div className="onboarding-footer">
+            <div className="onboarding-dots">
+              {STEPS.map((_, i) => (
+                <span key={i} className={`onboarding-dot ${i === step ? 'active' : ''}`} />
+              ))}
+            </div>
+            <div className="onboarding-nav">
+              {step > 0 && (
+                <button type="button" className="onboarding-btn-secondary" onClick={handlePrevious}>
+                  Previous
+                </button>
+              )}
+              <button type="button" className="onboarding-btn-primary" onClick={handleNext} disabled={submitting}>
+                {isLast ? "Let's go!" : 'Next'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SpCounterVisual() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const duration = 1500;
+    const start = performance.now();
+    let raf;
+    function tick(now) {
+      const progress = Math.min(1, (now - start) / duration);
+      setCount(Math.round(progress * 100));
+      if (progress < 1) raf = requestAnimationFrame(tick);
+    }
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div className="onboarding-visual-card onboarding-sp-counter">
+      <div className="onboarding-sp-counter-value">{count}</div>
+      <div className="onboarding-sp-counter-caption">SP &middot; Your starting balance</div>
+    </div>
+  );
+}
+
+const RULE_ROWS = [
+  { label: '90%+', sp: '+10 SP', bg: '#dcfce7', color: '#166534' },
+  { label: '75–89%', sp: '+5 SP', bg: '#fef9c3', color: '#854d0e' },
+  { label: '50–74%', sp: '+3 SP', bg: '#f1f5f9', color: '#475569' },
+];
+
+function RulesTableVisual() {
+  return (
+    <div className="onboarding-visual-card onboarding-rules-table">
+      {['Attendance', 'Polls'].map((col) => (
+        <div key={col} className="onboarding-rules-col">
+          <div className="onboarding-rules-col-header">{col}</div>
+          {RULE_ROWS.map((row) => (
+            <div key={row.label} className="onboarding-rules-row">
+              <span>{row.label}</span>
+              <span className="onboarding-rules-badge" style={{ background: row.bg, color: row.color }}>{row.sp}</span>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const LEADERBOARD_ROWS = [
+  { rank: 1, name: 'Aisha Verma', sp: 420, cls: 'rank-1' },
+  { rank: 2, name: 'Rohan Mehta', sp: 385, cls: 'rank-2' },
+  { rank: 3, name: 'You', sp: 310, cls: 'rank-you' },
+];
+
+function LeaderboardVisual() {
+  return (
+    <div className="onboarding-visual-card">
+      {LEADERBOARD_ROWS.map((row) => (
+        <div key={row.rank} className={`onboarding-lb-row ${row.cls}`}>
+          <span className="onboarding-lb-rank">{row.rank}</span>
+          <span className="onboarding-lb-name">{row.name}</span>
+          <span className="onboarding-lb-sp">{row.sp} SP</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function NudgeVisual() {
+  return (
+    <div className="onboarding-visual-card onboarding-nudge-visual">
+      <div className="onboarding-nudge-banner">
+        <span className="onboarding-nudge-icon">!</span>
+        <span className="onboarding-nudge-text">
+          Hey Priya, you missed 2 sessions this week. Showing up tomorrow puts you back on track.
+        </span>
+        <button type="button" className="onboarding-nudge-dismiss">Dismiss</button>
+      </div>
+    </div>
+  );
+}
+
+function SpSimulatorVisual() {
+  const [attendance, setAttendance] = useState(true);
+  const [polls, setPolls] = useState(true);
+  const total = (attendance ? 10 : 0) + (polls ? 10 : 0);
+
+  return (
+    <div className="onboarding-visual-card onboarding-simulator">
+      <label className="onboarding-sim-row">
+        <span>Attendance</span>
+        <input type="checkbox" checked={attendance} onChange={() => setAttendance((v) => !v)} />
+      </label>
+      <label className="onboarding-sim-row">
+        <span>Polls</span>
+        <input type="checkbox" checked={polls} onChange={() => setPolls((v) => !v)} />
+      </label>
+      <div className="onboarding-sim-total">
+        <strong>{total} SP</strong>
+        <span>potential SP from this session</span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/OnboardingTrigger.jsx
+++ b/client/src/components/OnboardingTrigger.jsx
@@ -1,0 +1,37 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import OnboardingModal from './OnboardingModal.jsx';
+
+const APP_BASE = window.location.pathname.startsWith('/spurti') ? '/spurti' : '';
+const API = `${APP_BASE}/api`;
+
+const OnboardingTrigger = forwardRef(function OnboardingTrigger({ studentEmail, studentName }, ref) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!studentEmail) return;
+    let active = true;
+    fetch(`${API}/onboarding/${encodeURIComponent(studentEmail)}`)
+      .then((res) => (res.ok ? res.json() : { completed: false }))
+      .then((data) => {
+        if (active && !data.completed) setOpen(true);
+      })
+      .catch(() => {});
+    return () => { active = false; };
+  }, [studentEmail]);
+
+  useImperativeHandle(ref, () => ({
+    open: () => setOpen(true),
+  }), []);
+
+  if (!open) return null;
+
+  return (
+    <OnboardingModal
+      studentEmail={studentEmail}
+      studentName={studentName}
+      onComplete={() => setOpen(false)}
+    />
+  );
+});
+
+export default OnboardingTrigger;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles.css';
+import OnboardingTrigger from './components/OnboardingTrigger.jsx';
 
 const APP_BASE = window.location.pathname.startsWith('/spurti') ? '/spurti' : '';
 const API = `${APP_BASE}/api`;
@@ -267,6 +268,7 @@ function StudentView({ profile, onBack }) {
   const { student } = profile;
   const badges = useMemo(() => buildBadges(profile), [profile]);
   const nextActions = useMemo(() => buildNextActions(profile), [profile]);
+  const onboardingRef = useRef(null);
   return (
     <main className="page compact">
       <header className="topbar">
@@ -275,8 +277,14 @@ function StudentView({ profile, onBack }) {
           <p className="eyebrow">Student Spurti Bank</p>
           <h1>{student.name}</h1>
         </div>
-        <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
+        <div className="topbar-right">
+          <button type="button" className="onboarding-tour-pill" onClick={() => onboardingRef.current?.open()}>
+            Tour
+          </button>
+          <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
+        </div>
       </header>
+      <OnboardingTrigger ref={onboardingRef} studentEmail={student.email} studentName={student.name} />
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
       <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -513,4 +513,273 @@ input {
 .survey-primary { background: #4f46e5; color: #fff; }
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
+
+/* Wraps the Tour button + the existing score-card in the student topbar.
+   Layout-only — no color/background changes, so the topbar keeps its
+   original look. */
+.topbar-right { display: flex; align-items: center; gap: 14px; }
+
+.onboarding-tour-pill {
+  background: #e9f2f5;
+  border: 1px solid var(--line);
+  color: var(--primary-dark);
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: 12px;
+  font-weight: 850;
+  cursor: pointer;
+  min-height: auto;
+  white-space: nowrap;
+}
+.onboarding-tour-pill:hover { background: #dcebf0; }
+
+/* Onboarding tour modal */
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.onboarding-wrapper {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.onboarding-card {
+  width: 100%;
+  max-width: 540px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+}
+.onboarding-header {
+  background: #1a3a3a;
+  padding: 20px 28px;
+  border-radius: 12px 12px 0 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+}
+.onboarding-step-label {
+  justify-self: start;
+  color: #9fdfcb;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.onboarding-title {
+  justify-self: center;
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 500;
+  margin: 0;
+  text-align: center;
+}
+.onboarding-skip {
+  justify-self: end;
+  background: transparent;
+  border: 0;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 12px;
+  font-weight: 700;
+  min-height: auto;
+  padding: 4px 6px;
+}
+.onboarding-progress-bar {
+  width: 100%;
+  height: 3px;
+  background: #e2e8f0;
+}
+.onboarding-progress-bar-fill {
+  height: 100%;
+  background: #2d6a6a;
+  transition: width 300ms ease;
+}
+.onboarding-body {
+  background: #ffffff;
+  padding: 28px 32px;
+  min-height: 280px;
+  overflow: hidden;
+}
+.onboarding-step-content {
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+.onboarding-step-content.phase-out { opacity: 0; transform: translateX(-10px); }
+.onboarding-step-content.phase-in { opacity: 1; transform: translateX(0); }
+.onboarding-icon-row { display: flex; justify-content: center; }
+.onboarding-icon-circle {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #e1f5ee;
+  color: #1a3a3a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+}
+.onboarding-step-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #1a3a3a;
+  text-align: center;
+  margin: 16px 0 0;
+}
+.onboarding-step-description {
+  font-size: 14px;
+  color: #64748b;
+  line-height: 1.7;
+  text-align: center;
+  max-width: 400px;
+  margin: 12px auto 0;
+}
+.onboarding-visual-card {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 20px;
+  margin-top: 20px;
+}
+.onboarding-footer {
+  padding: 16px 32px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.onboarding-dots { display: flex; align-items: center; gap: 6px; }
+.onboarding-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #e2e8f0;
+}
+.onboarding-dot.active { width: 10px; height: 10px; background: #2d6a6a; }
+.onboarding-nav { display: flex; gap: 10px; }
+.onboarding-btn-primary {
+  background: #1a3a3a;
+  color: #ffffff;
+  border: 0;
+  border-radius: 8px;
+  padding: 8px 20px;
+  font-weight: 700;
+}
+.onboarding-btn-primary:disabled { opacity: 0.6; cursor: default; }
+.onboarding-btn-secondary {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  color: #64748b;
+  border-radius: 8px;
+  padding: 8px 18px;
+  font-weight: 700;
+}
+
+/* Step 1 — animated SP counter */
+.onboarding-sp-counter { text-align: center; }
+.onboarding-sp-counter-value { font-size: 48px; font-weight: 700; color: #1a3a3a; }
+.onboarding-sp-counter-caption { font-size: 13px; color: #64748b; margin-top: 4px; }
+
+/* Step 2 — SP rules table */
+.onboarding-rules-table { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.onboarding-rules-col-header {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+  margin-bottom: 10px;
+}
+.onboarding-rules-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: #1a3a3a;
+}
+.onboarding-rules-row:last-child { margin-bottom: 0; }
+.onboarding-rules-badge {
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+/* Step 3 — mini leaderboard */
+.onboarding-lb-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 0 8px 8px 0;
+  margin-bottom: 6px;
+  font-size: 13px;
+  color: #1a3a3a;
+}
+.onboarding-lb-row:last-child { margin-bottom: 0; }
+.onboarding-lb-row.rank-1 { border-left: 3px solid #f59e0b; background: #fffbeb; }
+.onboarding-lb-row.rank-2 { border-left: 3px solid #94a3b8; background: #f8fafc; }
+.onboarding-lb-row.rank-you { border-left: 3px solid #2d6a6a; background: #e1f5ee; font-weight: 600; }
+.onboarding-lb-rank { width: 16px; font-weight: 700; color: #64748b; }
+.onboarding-lb-name { flex: 1; }
+.onboarding-lb-sp { font-weight: 700; }
+
+/* Step 4 — nudge banner (mirrors NudgeBanner styling) */
+.onboarding-nudge-visual { background: transparent; border: 0; padding: 0; }
+.onboarding-nudge-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff8e1;
+  border-left: 4px solid #f59e0b;
+  border-radius: 0 8px 8px 0;
+  padding: 14px 16px;
+}
+.onboarding-nudge-icon { font-size: 16px; color: #f59e0b; font-weight: 700; }
+.onboarding-nudge-text { flex: 1; color: #78350f; font-size: 13px; line-height: 1.5; }
+.onboarding-nudge-dismiss {
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(120, 53, 15, 0.25);
+  color: #78350f;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 700;
+  min-height: auto;
+}
+
+/* Step 5 — SP earning simulator */
+.onboarding-simulator { padding-top: 16px; padding-bottom: 4px; }
+.onboarding-sim-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a3a3a;
+}
+.onboarding-sim-row input[type="checkbox"] { width: 18px; height: 18px; accent-color: #2d6a6a; }
+.onboarding-sim-total {
+  text-align: center;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px dashed #e2e8f0;
+}
+.onboarding-sim-total strong { display: block; font-size: 32px; color: #1a3a3a; }
+.onboarding-sim-total span { display: block; margin-top: 4px; font-size: 12px; color: #64748b; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }

--- a/server/models/OnboardingStatus.js
+++ b/server/models/OnboardingStatus.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const onboardingStatusSchema = new mongoose.Schema({
+  studentEmail: { type: String, required: true, unique: true },
+  completed: { type: Boolean, default: false },
+  completedAt: { type: Date },
+  createdAt: { type: Date, default: Date.now },
+});
+
+export default mongoose.model('OnboardingStatus', onboardingStatusSchema, 'onboardingstatuses');

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ import AttendanceRecord from './models/AttendanceRecord.js';
 import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
+import OnboardingStatus from './models/OnboardingStatus.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -305,6 +306,28 @@ api.post('/confirm', async (req, res) => {
   }
   if (student.status === 'excused') return res.json(excusedPayload(student));
   res.json(await studentPayload(student));
+});
+
+api.get('/onboarding/:email', async (req, res) => {
+  const sessionEmail = await studentEmailFromRequest(req);
+  if (!sessionEmail) return res.status(401).json({ error: 'Not authenticated' });
+  const email = normalizeEmail(req.params.email);
+  if (sessionEmail !== email) return res.status(403).json({ error: 'Forbidden' });
+  const record = await OnboardingStatus.findOne({ studentEmail: email }).lean();
+  res.json({ completed: Boolean(record?.completed) });
+});
+
+api.post('/onboarding/:email/complete', async (req, res) => {
+  const sessionEmail = await studentEmailFromRequest(req);
+  if (!sessionEmail) return res.status(401).json({ error: 'Not authenticated' });
+  const email = normalizeEmail(req.params.email);
+  if (sessionEmail !== email) return res.status(403).json({ error: 'Forbidden' });
+  await OnboardingStatus.findOneAndUpdate(
+    { studentEmail: email },
+    { studentEmail: email, completed: true, completedAt: new Date() },
+    { upsert: true, setDefaultsOnInsert: true }
+  );
+  res.json({ success: true });
 });
 
 api.get('/leaderboard', async (req, res) => {


### PR DESCRIPTION
Adds a 5-step guided onboarding flow for first-time students.

The modal appears automatically on first login and can be 
re-accessed anytime via the Tour button in the dashboard 
topbar. Completion is tracked per student in MongoDB so it 
only shows once.

Steps:
1. Welcome to Spurti — SP explained with animated counter
2. How you earn SP — attendance and poll rules table with 
   color-coded SP badges
3. Your rank matters — mini leaderboard preview with 
   gold/silver/teal accents
4. We have got your back — nudge system preview with real 
   amber banner
5. Ready to earn your first SP — interactive simulator with 
   toggleable attendance and poll checkboxes updating SP total

Security:
Both onboarding API endpoints resolve caller identity via 
studentEmailFromRequest() before touching any data — 401 if 
no valid session, 403 if session email does not match the 
URL parameter. This matches the ownership check pattern used 
throughout the rest of the file and prevents unauthenticated 
arbitrary reads or writes to the onboardingstatuses collection.

Files changed:
- server/models/OnboardingStatus.js — Mongoose schema
- server/server.js — two new routes, no existing routes touched
- client/src/components/OnboardingModal.jsx — 5-step modal
- client/src/components/OnboardingTrigger.jsx — auto-show 
  on first login and Tour button in topbar
- client/src/styles.css — onboarding styles appended at end

How to test:
1. Open any student dashboard — modal appears automatically
2. To re-test first-time flow:
   db.onboardingstatuses.deleteMany({}) in mongosh
3. Tour button in topbar reopens modal anytime after completion

<img width="1349" height="697" alt="Screenshot 2026-07-13 at 2 02 57 PM" src="https://github.com/user-attachments/assets/ab5cb2c2-2343-4329-a47d-92566cae4c2d" />
