### PR TITLE
Evening cutover (2026-07-16): attendance window + Spandan poll SP

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -107,9 +107,15 @@ which hold the retired CSV/±5 logic). See `pipeline/README.md` for detail.
 
 - **Initial:** +100 to every *started intern* on their official start date.
   Future-start interns are zeroed; non-intern roster entries are set aside.
-- **Attendance (A):** presence clipped to the official window
-  `[09:05 IST, min(first-instance-end, 11:00 IST)]`; `pct = clipped / window`,
-  then banded: **≥90% → +10, 75–89% → +5, 50–74% → +3, <50% → 0**.
+- **Attendance (A):** presence clipped to the official window, `pct = clipped /
+  window`, then banded: **≥90% → +10, 75–89% → +5, 50–74% → +3, <50% → 0**.
+  - **Before 2026-07-16 (morning standup):** window `[09:05 IST, min(first-instance-end, 11:00 IST)]`.
+  - **From 2026-07-16 (standup moved to evening):** window `[20:05 IST, min(picked-mtg-end, 21:00 IST)]`
+    and the scored meeting is the mandatory meeting with the **largest overlap**
+    of that evening window (not just the earliest-starting one — the all-day
+    persistent room must not steal the slot). Cutover + times are constants at
+    the top of `sp-rubric-build-mirror.cjs`: `EVENING_CUTOVER`,
+    `EVENING_WSTART_IST`, `EVENING_WEND_IST`. Change these if the timing shifts again.
 - **Poll (B):** `pct = answered / totalQuestions`, same band ladder (10/5/3/0).
 - **Grace day 2026-06-06:** 1-min join = full attendance + full poll.
 - **Chat / discretionary:** admin-reviewed via ChatSPReview in the web app
@@ -168,6 +174,19 @@ Code: `getSamagamaUser` / `studentEmailFromRequest` in `server/server.js`.
 - **To verify new ingestion:** After running `ingestSession`, check that: (a) new session appears in `sessions` collection, (b) transaction count increases, (c) for a sample student, balance in `sptransactions` matches their `totalSp` in `students` table, (d) leaderboard API reflects updated SP
 
 ## Known Bugs / Notes
+- **2026-07-16 standup moved morning → evening (attendance window fix).** Students
+  flagged that the 16 Jul evening standup (~60 min) credited "115 min". Cause was
+  NOT double-counting: the scorer clipped presence to the fixed **09:05–11:00 IST
+  (=115 min) morning window**, which no longer matched the standup. The persistent
+  Zoom room `95674128668` ("Evening Standup") stays open all day, so it satisfied
+  the old morning window. Fix: added an evening-window cutover (see SP Calculation
+  section) → from 16 Jul the window is **20:05–21:00 IST (55 min)** and the scorer
+  picks the max-overlap meeting. Re-scored + APPLIED 2026-07-17 09:17Z
+  (backup `sp-runs/sp_backup_mirror_2026-07-17T0917Z`; script backup
+  `pipeline/sp-rubric-build-mirror.cjs.bak.20260717T091026Z`). Impact on 16 Jul:
+  493 students ↑ (mostly 0→+10, real evening attendees who'd been under-credited),
+  35 ↓ (incl. ~20 who only idled in the morning room, 10→0), 204 unchanged.
+  Dates before the cutover use the identical old code path (no historical change).
 - `deltaMode` validator error: schema expects `'absolute' | 'percentage'`. Using `'percent'` (singular) causes validation failure. Fixed in code — only affects legacy transactions created before the fix (May 26 restart).
 - **Percentage SP support:** When a chat SP review is accepted with `% SP` (e.g. +10% SP), `deltaMode` is set to `'percentage'`, `deltaValue` holds the percent (e.g. 10), and `appliedDelta` is computed at accept time as `round(currentBalance * deltaValue / 100)`. This works correctly.
 

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -74,6 +74,12 @@ const EVENING_CUTOVER = '2026-07-16';
 const EVENING_WSTART_IST = '20:05';
 const EVENING_WEND_IST = '21:00';
 const GRACE_DATE = '2026-06-06'; // exceptional: 1 min join = full att + full poll
+// Polls also moved off Zoom to the Spandan evening classroom at the evening
+// cutover. On/after this date the poll (B) score comes from `spandan_polls`
+// (correctness, percentiled to the day's top scorer); strictly before it, from
+// the frozen `zoom_polls` mirror (participation) exactly as history has it — so
+// old poll SP is never disturbed. Same date as the evening attendance cutover.
+const SPANDAN_CUTOFF = process.env.SPANDAN_CUTOFF || EVENING_CUTOVER;
 const STAFF = new Set([
   'dled@iitrpr.ac.in', 'prakash.hegade@gmail.com',
   'sudarshansudarshan@gmail.com', 'sudarshan@iitrpr.ac.in', 'rajankrsna@gmail.com',
@@ -150,6 +156,27 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   // 3. per-student per-session attendance (A) + poll (B), all from the mirror
   const students = new Map(); // email -> { name, firstAtt, rows:[{date,order,cat,delta,reason}] }
   const touch = (email, name) => { const e = email.toLowerCase().trim(); if (!students.has(e)) students.set(e, { name: name || e, firstAtt: null, rows: [] }); const o = students.get(e); if (name && !name.includes('@')) o.name = name; return o; };
+
+  // Spandan evening-poll mirror (Day-N sessions >= SPANDAN_CUTOFF), keyed by date.
+  // Poll (B) here is correctness-based, percentiled to the day's TOP scorer:
+  // pct = pointsEarned / dayTopPoints * 100, then the same 10/5/3/0 band ladder.
+  const spandanByDate = new Map();
+  for (const sp of await sak.collection('spandan_polls').find({ date: { $gte: SPANDAN_CUTOFF } }).toArray()) {
+    const prev = spandanByDate.get(sp.date);
+    if (!prev || (sp.studentCount || 0) > (prev.studentCount || 0)) spandanByDate.set(sp.date, sp); // one Day-N/day; keep the fullest
+  }
+  const scoreSpandanPoll = (sp, label) => {
+    const top = sp.topPoints || (sp.students || []).reduce((mx, x) => Math.max(mx, x.pointsEarned || 0), 0);
+    for (const x of sp.students || []) {
+      const e = String(x.email || '').toLowerCase().trim(); if (!e) continue;
+      const pct = top ? Math.round((x.pointsEarned || 0) / top * 1000) / 10 : 0;
+      const d = tier(pct);
+      // Short bank message: conveys correctness-based + relative-to-day-top in one line.
+      touch(e).rows.push({ date: sp.date, order: 2, cat: 'poll', delta: d,
+        reason: `${label} (${ddmon(sp.date)}): ${pct}% of day's top poll score -> ${d > 0 ? '+' : ''}${d} SP (correctness-based).` });
+    }
+  };
+
   for (const s of sessions) {
     const winMin = Math.round((s.wEnd - s.wStart) / 60000);
     // attendance via zoom_attendance mirror (firstJoin/lastLeave), clipped to window
@@ -170,18 +197,27 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
       touch(e, v.name).rows.push({ date: s.date, order: 1, cat: 'attendance', delta: d, reason: `${s.label} (${ddmon(s.date)}): present ${mins} of ${winMin} min (${pct}%) within official ${istHHMM(s.wStart)}-${istHHMM(s.wEnd)} IST window -> ${d > 0 ? '+' : ''}${d} SP.` });
       const o = students.get(e); if (!o.firstAtt || s.date < o.firstAtt) o.firstAtt = s.date;
     }
-    // poll participation via zoom_polls for the same instance
-    const polls = await sak.collection('zoom_polls').find({ meetingUuid: s.uuid }).toArray();
-    const totalQ = new Set(polls.map((p) => p.question)).size;
-    if (totalQ > 0) {
-      const ans = new Map(); for (const p of polls) { const e = String(p.email || '').toLowerCase().trim(); if (!e) continue; if (!ans.has(e)) ans.set(e, new Set()); if (p.answer && String(p.answer).trim()) ans.get(e).add(p.question); }
-      const present = new Set([...segByEmail.keys(), ...ans.keys()]);
-      for (const e of present) {
-        const a = (s.date === GRACE_DATE && segByEmail.has(e)) ? totalQ : (ans.get(e) || new Set()).size; const pct = Math.round(a / totalQ * 1000) / 10; const d = tier(pct);
-        touch(e).rows.push({ date: s.date, order: 2, cat: 'poll', delta: d, reason: `${s.label} (${ddmon(s.date)}): answered ${a} of ${totalQ} poll questions (${pct}%) -> ${d > 0 ? '+' : ''}${d} SP.` });
+    // poll (B): Spandan evening performance on/after the cutoff; Zoom participation before it.
+    if (s.date >= SPANDAN_CUTOFF) {
+      const sp = spandanByDate.get(s.date);
+      if (sp) { scoreSpandanPoll(sp, s.label); spandanByDate.delete(s.date); } // consumed: covered by an evening session
+    } else {
+      // poll participation via zoom_polls for the same instance
+      const polls = await sak.collection('zoom_polls').find({ meetingUuid: s.uuid }).toArray();
+      const totalQ = new Set(polls.map((p) => p.question)).size;
+      if (totalQ > 0) {
+        const ans = new Map(); for (const p of polls) { const e = String(p.email || '').toLowerCase().trim(); if (!e) continue; if (!ans.has(e)) ans.set(e, new Set()); if (p.answer && String(p.answer).trim()) ans.get(e).add(p.question); }
+        const present = new Set([...segByEmail.keys(), ...ans.keys()]);
+        for (const e of present) {
+          const a = (s.date === GRACE_DATE && segByEmail.has(e)) ? totalQ : (ans.get(e) || new Set()).size; const pct = Math.round(a / totalQ * 1000) / 10; const d = tier(pct);
+          touch(e).rows.push({ date: s.date, order: 2, cat: 'poll', delta: d, reason: `${s.label} (${ddmon(s.date)}): answered ${a} of ${totalQ} poll questions (${pct}%) -> ${d > 0 ? '+' : ''}${d} SP.` });
+        }
       }
     }
   }
+
+  // Spandan poll days with no mandatory evening session still earn poll SP (label from the Day number).
+  for (const [, sp] of spandanByDate) scoreSpandanPoll(sp, 'Day ' + sp.dayNumber);
 
   // 4. assemble ledger, ROSTER-DRIVEN union: base 100 to every started intern.
   const ledger = []; const setAside = []; const finalBal = new Map(); const zeroOut = []; const nameByCanon = new Map();

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -65,6 +65,14 @@ const APPLY = process.env.APPLY === '1';
 
 // 09:05 IST = 03:35 UTC. wEnd = min(first-instance-end, 11:00 IST). Per-day end overrides (IST) take precedence.
 const WINDOW_END_OVERRIDE_IST = { '2026-05-22': '11:00' };
+// From EVENING_CUTOVER the daily standup moved from the morning (09:05-11:00 IST)
+// to the evening. On/after this date, score presence in [EVENING_WSTART_IST,
+// EVENING_WEND_IST] IST (5-min join grace, mirroring the old morning window) and
+// pick the mandatory meeting that overlaps THAT window (an all-day/leftover
+// morning room must not steal the slot). Dates before the cutover are unchanged.
+const EVENING_CUTOVER = '2026-07-16';
+const EVENING_WSTART_IST = '20:05';
+const EVENING_WEND_IST = '21:00';
 const GRACE_DATE = '2026-06-06'; // exceptional: 1 min join = full att + full poll
 const STAFF = new Set([
   'dled@iitrpr.ac.in', 'prakash.hegade@gmail.com',
@@ -116,10 +124,26 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   const byDate = {}; for (const m of meetings) (byDate[m.date] = byDate[m.date] || []).push(m);
   const sessions = [];
   for (const date of Object.keys(byDate).sort()) {
-    const first = byDate[date].filter((m) => isMandatory(m.topic) && (m.participantsCount || 0) >= 10).sort((a, b) => new Date(a.startTime) - new Date(b.startTime))[0];
-    if (!first) continue;
-    const wStart = utcFromISTDate(date, '09:05');
-    const wEnd = WINDOW_END_OVERRIDE_IST[date] ? utcFromISTDate(date, WINDOW_END_OVERRIDE_IST[date]) : Math.min(new Date(first.endTime).getTime(), utcFromISTDate(date, '11:00'));
+    const mandatory = byDate[date].filter((m) => isMandatory(m.topic) && (m.participantsCount || 0) >= 10);
+    if (!mandatory.length) continue;
+    let first, wStart, wEnd;
+    if (date >= EVENING_CUTOVER) {
+      // evening standup: fixed [20:05, 21:00] IST window; pick the mandatory meeting
+      // that overlaps it most so a leftover all-day/morning room can't steal the slot.
+      wStart = utcFromISTDate(date, EVENING_WSTART_IST);
+      const wCap = utcFromISTDate(date, EVENING_WEND_IST);
+      const scored = mandatory.map((m) => {
+        const ms = new Date(m.startTime).getTime(), me = new Date(m.endTime).getTime();
+        return { m, ov: Math.max(0, Math.min(me, wCap) - Math.max(ms, wStart)) };
+      }).sort((a, b) => b.ov - a.ov)[0];
+      if (!scored || scored.ov <= 0) continue; // no mandatory meeting overlaps the evening window
+      first = scored.m;
+      wEnd = Math.min(new Date(first.endTime).getTime(), wCap);
+    } else {
+      first = mandatory.sort((a, b) => new Date(a.startTime) - new Date(b.startTime))[0];
+      wStart = utcFromISTDate(date, '09:05');
+      wEnd = WINDOW_END_OVERRIDE_IST[date] ? utcFromISTDate(date, WINDOW_END_OVERRIDE_IST[date]) : Math.min(new Date(first.endTime).getTime(), utcFromISTDate(date, '11:00'));
+    }
     sessions.push({ date, uuid: first._id, topic: first.topic, wStart, wEnd, label: dayLabel(first.topic) });
   }
 

--- a/pipeline/spandan-poll-fetch.cjs
+++ b/pipeline/spandan-poll-fetch.cjs
@@ -1,0 +1,110 @@
+'use strict';
+/**
+ * spandan-poll-fetch.cjs
+ *
+ * Pulls ended poll sessions from the Spandan Research Session Export API and
+ * mirrors the qualifying ones into `spandan_polls` (one doc per session, keyed
+ * by roomId). This REPLACES the retired Zoom poll source for SP dates on/after
+ * the cutoff. It is purely additive/non-destructive: it never touches
+ * sptransactions, students, or any existing collection.
+ *
+ * Qualifying session = name matches /^Day N/ (the numbered classroom evening
+ * sessions) AND date >= CUTOFF. Non-Day sessions (FDP events, "19th July
+ * Evening Session" Sunday makeup) and pre-cutoff days are skipped.
+ *
+ * Incremental: stores the API's nextCursor in `spandan_sync` and passes it as
+ * ?since= on the next run, so a scheduled job never misses or double-counts.
+ *
+ * Env (from .env): MONGO_URI, SPANDAN_RESEARCH_KEY
+ * Flags:
+ *   FULL=1  ignore the stored cursor and re-pull from the beginning (backfill)
+ *   DRY=1   print what would be written; touch nothing
+ *
+ * Scoring itself lives in the rubric (sp-rubric-build-mirror.cjs), not here:
+ * per day, top scorer = 100%, others = pointsEarned / dayTop * 100, banded
+ * 10/5/3/0. This script just stores the raw session results + a convenience
+ * `topPoints` for that computation.
+ */
+const { MongoClient } = require('mongodb');
+require('dotenv').config();
+
+const BASE = 'https://spandan.fun/spandan/api/research/sessions';
+const CUTOFF = '2026-07-16';            // first full-cohort evening session (Day 53)
+const DAY_RE = /^Day\s+(\d+)\b/i;       // only numbered "Day N ..." sessions count
+const PAGE = 1000;
+
+const { MONGO_URI, SPANDAN_RESEARCH_KEY } = process.env;
+const FULL = process.env.FULL === '1';
+const DRY = process.env.DRY === '1';
+
+const lc = (s) => String(s || '').toLowerCase().trim();
+
+async function fetchPage(since) {
+  const url = new URL(BASE);
+  url.searchParams.set('preset', 'evening');
+  url.searchParams.set('limit', String(PAGE));
+  if (since) url.searchParams.set('since', since);
+  const r = await fetch(url, { headers: { 'X-Research-Key': SPANDAN_RESEARCH_KEY } });
+  if (!r.ok) throw new Error(`Spandan API ${r.status}: ${await r.text().catch(() => '')}`);
+  return r.json();
+}
+
+(async () => {
+  if (!MONGO_URI) { console.error('missing MONGO_URI'); process.exit(1); }
+  if (!SPANDAN_RESEARCH_KEY) { console.error('missing SPANDAN_RESEARCH_KEY'); process.exit(1); }
+
+  const client = await MongoClient.connect(MONGO_URI);
+  const db = client.db();                // db name comes from the URI
+  const sync = db.collection('spandan_sync');
+  const polls = db.collection('spandan_polls');
+
+  let since = null;
+  if (!FULL) {
+    const cur = await sync.findOne({ _id: 'cursor' });
+    since = cur ? cur.value : null;
+  }
+  console.log(`spandan-poll-fetch: ${FULL ? 'FULL backfill' : since ? `since ${since}` : 'first run (all)'}${DRY ? ' [DRY]' : ''}`);
+
+  let kept = 0, seen = 0, lastCursor = since;
+  while (true) {
+    const data = await fetchPage(since);
+    seen += data.count;
+    for (const s of data.sessions) {
+      const m = DAY_RE.exec(s.name || '');
+      if (!m) continue;                  // not a numbered Day session
+      if (s.date < CUTOFF) continue;     // pre-switchover
+      const students = (s.students || []).map((x) => ({
+        email: lc(x.studentEmail),
+        pointsEarned: x.pointsEarned || 0,
+        questionsAnswered: x.questionsAnswered || 0,
+      })).filter((x) => x.email);
+      const topPoints = students.reduce((mx, x) => Math.max(mx, x.pointsEarned), 0);
+      const doc = {
+        roomId: s.roomId,
+        name: s.name,
+        dayNumber: Number(m[1]),
+        date: s.date,
+        endedAt: new Date(s.endedAt),
+        totalQuestions: s.totalQuestions || 0,
+        maxPoints: s.maxPoints || 0,
+        topPoints,
+        studentCount: students.length,
+        students,
+        updatedAt: new Date(),
+      };
+      if (DRY) {
+        console.log(`  KEEP ${doc.date} Day ${doc.dayNumber} | Q${doc.totalQuestions} max${doc.maxPoints} top${topPoints} | ${doc.studentCount} students`);
+      } else {
+        await polls.updateOne({ roomId: doc.roomId }, { $set: doc, $setOnInsert: { createdAt: new Date() } }, { upsert: true });
+      }
+      kept++;
+    }
+    lastCursor = data.nextCursor || lastCursor;
+    if (!DRY && lastCursor) await sync.updateOne({ _id: 'cursor' }, { $set: { value: lastCursor, updatedAt: new Date() } }, { upsert: true });
+    if (data.count < PAGE) break;        // last page
+    since = data.nextCursor;
+  }
+
+  console.log(`Done. scanned ${seen} evening session(s), kept ${kept} Day-N session(s) >= ${CUTOFF}. cursor=${lastCursor}${DRY ? ' (not saved)' : ''}`);
+  await client.close();
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/pipeline/sync-poll-records.js
+++ b/pipeline/sync-poll-records.js
@@ -21,6 +21,18 @@ const POLL_RE = /answered (\d+) of (\d+) poll questions/;
   const students = await db.collection('students').find({}, { projection: { _id: 1, email: 1 } }).toArray();
   const studentById = new Map(students.map(s => [s.email.toLowerCase().trim(), s._id]));
 
+  // Spandan-era poll counts (>= cutoff): the reason is short and correctness-based,
+  // so it doesn't carry "answered X of Y". Take participation straight from the
+  // spandan_polls mirror, joined to each poll txn by (email, date).
+  const CUTOFF = process.env.SPANDAN_CUTOFF || '2026-07-16';
+  const spByEmailDate = new Map();
+  for (const sp of await db.collection('spandan_polls').find({ date: { $gte: CUTOFF } }).toArray()) {
+    for (const x of sp.students || []) {
+      const e = String(x.email || '').toLowerCase().trim(); if (!e) continue;
+      spByEmailDate.set(e + '|' + sp.date, { attempted: x.questionsAnswered || 0, total: sp.totalQuestions || 0 });
+    }
+  }
+
   const txns = await db.collection('sptransactions')
     .find({ category: 'poll' })
     .toArray();
@@ -32,9 +44,16 @@ const POLL_RE = /answered (\d+) of (\d+) poll questions/;
     const sessionLabel = tx.sessionLabel || '';
     if (!sessionLabel) { skipped++; continue; }
 
-    const m = POLL_RE.exec(tx.reason || '');
-    const attemptedQuestions = m ? Number(m[1]) : 0;
-    const totalQuestions = m ? Number(m[2]) : 0;
+    const date = tx.dateTime ? new Date(tx.dateTime).toISOString().slice(0, 10) : '';
+    const spd = spByEmailDate.get(email + '|' + date);
+    let attemptedQuestions, totalQuestions;
+    if (spd) {
+      attemptedQuestions = spd.attempted; totalQuestions = spd.total;   // Spandan participation
+    } else {
+      const m = POLL_RE.exec(tx.reason || '');                          // legacy Zoom reason
+      attemptedQuestions = m ? Number(m[1]) : 0;
+      totalQuestions = m ? Number(m[2]) : 0;
+    }
     const missedQuestions = Math.max(0, totalQuestions - attemptedQuestions);
     const studentId = studentById.get(email) || null;
 


### PR DESCRIPTION
Brings `main` up to what is deployed on the production server (checked out on this branch, at 9042ecc).

**Two changes, both from the 2026-07-16 evening cutover:**

1. **Evening attendance window** — the daily standup moved from morning (09:05–11:00 IST) to evening (20:05–21:00 IST). On/after the cutover, attendance is scored against that window, picking the mandatory meeting that overlaps it.

2. **Spandan poll SP** — Zoom polls are retired. On/after the cutover, poll (B) SP comes from the Spandan Research Session Export API instead of `zoom_polls`:
   - `spandan-poll-fetch.cjs` incrementally mirrors ended `Day N` evening sessions into `spandan_polls`.
   - The rubric branches on `SPANDAN_CUTOFF` (= `EVENING_CUTOVER`): Spandan **correctness** score (pointsEarned percentiled to the day top scorer, same 10/5/3/0 bands) after the cutover; frozen `zoom_polls` before it, so historical poll SP is provably unchanged.
   - `sync-poll-records.js` joins Polls-view counts from `spandan_polls` by (email, date).

Deployed + dry-run-verified on production (0 leaked Zoom poll rows ≥16 Jul). Fetch runs as step 0 of `sp-refresh.sh` on the existing 6h cron. `SPANDAN_RESEARCH_KEY` lives only in the server `.env`, git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)