### PR TITLE
feat: add Spurti Recognition & Growth Hub - achievement gallery, cert…

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -266,6 +266,7 @@ function StudentView({ profile, onBack }) {
   const [tab, setTab] = useState('bank');
   const { student } = profile;
   const badges = useMemo(() => buildBadges(profile), [profile]);
+  const achievementGallery = useMemo(() => buildAchievementGallery(profile), [profile]);
   const nextActions = useMemo(() => buildNextActions(profile), [profile]);
   return (
     <main className="page compact">
@@ -278,11 +279,14 @@ function StudentView({ profile, onBack }) {
         <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
       <LevelStatus student={student} />
+      <MilestoneCertificate student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard'], ['achievements','Achievements'], ['redeem','Redeem SP']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
+      {tab === 'achievements' && <AchievementGallery gallery={achievementGallery} />}
+      {tab === 'redeem' && <RedemptionMarketplace student={student} />}
     </main>
   );
 }
@@ -385,11 +389,151 @@ function StudentPulse({ profile, badges, nextActions }) {
         <span>SP trend</span>
         <Sparkline points={trend} />
       </div>
+      <WeeklyGoalWidget
+        student={profile.student}
+        weeklyGoal={profile.student.weeklyGoal}
+        onGoalUpdated={(updatedGoal) => {
+          profile.student.weeklyGoal = updatedGoal;
+          window.location.reload();
+        }}
+      />
+      <ForecastWidget forecast={profile.student.forecast} currentSp={student.totalSp} />
       <div className="pulse-card wide-pulse">
         <span>What to do next</span>
         <ul className="next-list">{nextActions.map(action => <li key={action}>{action}</li>)}</ul>
       </div>
     </section>
+  );
+}
+
+function WeeklyGoalWidget({ student, weeklyGoal, onGoalUpdated }) {
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(weeklyGoal?.targetSp || '');
+  const [saving, setSaving] = useState(false);
+
+  const target = weeklyGoal?.targetSp || 0;
+  const earned = weeklyGoal?.spEarnedThisWeek || 0;
+  const pct = weeklyGoal?.progressPct || 0;
+
+  const saveGoal = async () => {
+    const value = Number(inputValue);
+    if (!Number.isFinite(value) || value < 0) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`${API}/goal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: student.email, targetSp: value })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        onGoalUpdated(data.student.weeklyGoal);
+        setEditing(false);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="pulse-card wide-pulse">
+      <span>Weekly Goal</span>
+      {target === 0 && !editing ? (
+        <div className="goal-setup">
+          <p className="muted">Set a weekly SP target to track your pace.</p>
+          <button className="secondary" onClick={() => setEditing(true)}>Set a goal</button>
+        </div>
+      ) : editing ? (
+        <div className="goal-setup">
+          <input
+            type="number"
+            min="0"
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            placeholder="Target SP for this week"
+          />
+          <button className="primary" disabled={saving} onClick={saveGoal}>
+            {saving ? 'Saving...' : 'Save goal'}
+          </button>
+          <button className="secondary" onClick={() => setEditing(false)}>Cancel</button>
+        </div>
+      ) : (
+        <div className="goal-progress">
+          <p>{earned} / {target} SP this week</p>
+          <div className="progress-bar">
+            <div className="progress-fill" style={{ width: `${pct}%` }} />
+          </div>
+          <p className="muted">
+            {pct >= 100 ? 'Goal achieved! Great work.' : `${pct}% of the way there.`}
+          </p>
+          <button className="secondary" onClick={() => { setInputValue(target); setEditing(true); }}>Edit goal</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ForecastWidget({ forecast, currentSp }) {
+  const [goalInput, setGoalInput] = useState('');
+  const [requiredPace, setRequiredPace] = useState(null);
+
+  const { completedSessions, remainingSessions, avgSpPerSession, projectedFinalSp } = forecast;
+
+  const calculateRequiredPace = () => {
+    const goal = Number(goalInput);
+    if (!Number.isFinite(goal) || goal <= currentSp) {
+      setRequiredPace(null);
+      return;
+    }
+    if (remainingSessions === 0) {
+      setRequiredPace('no-sessions-left');
+      return;
+    }
+    const needed = (goal - currentSp) / remainingSessions;
+    setRequiredPace(Math.round(needed * 10) / 10);
+  };
+
+  return (
+    <div className="pulse-card wide-pulse">
+      <span>SP Forecast</span>
+      <div className="forecast-stats">
+        <div className="forecast-stat">
+          <b>{avgSpPerSession}</b>
+          <em>avg SP / session so far</em>
+        </div>
+        <div className="forecast-stat">
+          <b>{remainingSessions}</b>
+          <em>sessions remaining</em>
+        </div>
+        <div className="forecast-stat">
+          <b>{projectedFinalSp}</b>
+          <em>projected final SP</em>
+        </div>
+      </div>
+      <p className="muted">
+        Based on your pace across {completedSessions} completed sessions, you're on track to finish around
+        {' '}<strong>{projectedFinalSp} SP</strong>.
+      </p>
+      <div className="forecast-goal">
+        <input
+          type="number"
+          min="0"
+          value={goalInput}
+          onChange={e => setGoalInput(e.target.value)}
+          placeholder="Enter a target SP"
+        />
+        <button className="secondary" onClick={calculateRequiredPace}>Check pace needed</button>
+      </div>
+      {requiredPace === 'no-sessions-left' && (
+        <p className="error">No sessions remain — this goal isn't reachable this cohort.</p>
+      )}
+      {typeof requiredPace === 'number' && (
+        <p className={requiredPace > avgSpPerSession * 1.5 ? 'error' : 'muted'}>
+          You'll need about <strong>{requiredPace} SP/session</strong> for your remaining {remainingSessions} sessions
+          {requiredPace > avgSpPerSession * 1.5 ? ' — that\'s a big jump from your current pace.' : ' — achievable at a slightly better pace.'}
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -418,6 +562,49 @@ function buildBadges(profile) {
   if (profile.student.totalSp >= profile.cohort.averageSp) badges.push('Above Average');
   return badges.length ? badges : ['Getting Started'];
 }
+// Full achievement gallery — every possible badge, with locked/unlocked status.
+// Unlike buildBadges() (which only lists what's earned), this shows the complete
+// set so students can see what they're working toward.
+function buildAchievementGallery(profile) {
+  const { student, cohort, attendance, polls } = profile;
+  const qualifiedPct = attendance.length ? attendance.filter(a => a.qualified).length / attendance.length : 0;
+  const pollAttempted = polls.reduce((sum, p) => sum + p.attemptedQuestions, 0);
+  const pollTotal = polls.reduce((sum, p) => sum + p.totalQuestions, 0);
+  const pollPct = pollTotal ? pollAttempted / pollTotal : 0;
+
+  return [
+    {
+      key: 'top50', name: 'Top 50', icon: '🏆',
+      description: 'Rank in the top 50 of the cohort leaderboard.',
+      unlocked: student.rank !== null && student.rank <= 50
+    },
+    {
+      key: 'top10', name: 'Top 10', icon: '🥇',
+      description: 'Rank in the top 10 of the cohort leaderboard.',
+      unlocked: student.rank !== null && student.rank <= 10
+    },
+    {
+      key: 'consistent', name: 'Consistent Attendee', icon: '📅',
+      description: 'Qualify for attendance in at least 75% of sessions.',
+      unlocked: qualifiedPct >= 0.75
+    },
+    {
+      key: 'pollChampion', name: 'Poll Champion', icon: '📊',
+      description: 'Attempt at least 75% of all poll questions.',
+      unlocked: pollPct >= 0.75
+    },
+    {
+      key: 'aboveAverage', name: 'Above Average', icon: '📈',
+      description: 'Have more SP than the cohort average.',
+      unlocked: student.totalSp >= cohort.averageSp
+    },
+    {
+      key: 'legend', name: 'Legend Badge', icon: '🌟',
+      description: 'Reach 1500 SP at least once during the internship.',
+      unlocked: Boolean(student.legendBadgeUnlocked)
+    }
+  ];
+}
 
 function buildNextActions(profile) {
   const actions = [];
@@ -426,6 +613,196 @@ function buildNextActions(profile) {
   if (profile.polls.some(p => p.missedQuestions > 0)) actions.push('Attempt every poll question to avoid poll debit.');
   actions.push('Check your SP Bank after each session to understand every credit and debit.');
   return actions.slice(0, 4);
+}
+function MilestoneCertificate({ student }) {
+  const canvasRef = useRef(null);
+  const eligible = student.legendBadgeUnlocked || (student.rank !== null && student.rank <= 10);
+  const milestoneText = student.legendBadgeUnlocked
+    ? 'Legend Badge — 1500+ Spurti Points'
+    : `Top 10 Cohort Rank — #${student.rank}`;
+
+  useEffect(() => {
+    if (!eligible || !canvasRef.current) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const W = canvas.width, H = canvas.height;
+
+    const gradient = ctx.createLinearGradient(0, 0, W, H);
+    gradient.addColorStop(0, '#0f2418');
+    gradient.addColorStop(1, '#1a1a1a');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, W, H);
+
+    ctx.strokeStyle = '#4caf50';
+    ctx.lineWidth = 6;
+    ctx.strokeRect(20, 20, W - 40, H - 40);
+    ctx.strokeStyle = '#8bc34a';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(32, 32, W - 64, H - 64);
+
+    ctx.fillStyle = '#8bc34a';
+    ctx.font = 'bold 22px Arial';
+    ctx.textAlign = 'center';
+    ctx.fillText('SPURTI MOTIVATION ENGINE', W / 2, 90);
+
+    ctx.fillStyle = '#ffffff';
+    ctx.font = 'bold 36px Arial';
+    ctx.fillText('Certificate of Achievement', W / 2, 150);
+
+    ctx.font = '18px Arial';
+    ctx.fillStyle = '#cccccc';
+    ctx.fillText('This certifies that', W / 2, 210);
+
+    ctx.font = 'bold 32px Arial';
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText(student.name, W / 2, 260);
+
+    ctx.font = '20px Arial';
+    ctx.fillStyle = '#8bc34a';
+    ctx.fillText('has achieved', W / 2, 300);
+
+    ctx.font = 'bold 26px Arial';
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText(milestoneText, W / 2, 340);
+
+    ctx.font = '16px Arial';
+    ctx.fillStyle = '#bbbbbb';
+    ctx.fillText(`Total SP: ${student.totalSp} · ${new Date().toLocaleDateString()}`, W / 2, 390);
+  }, [eligible, student, milestoneText]);
+
+  if (!eligible) return null;
+
+  const downloadCertificate = () => {
+    const canvas = canvasRef.current;
+    const link = document.createElement('a');
+    link.download = `spurti-certificate-${student.name.replace(/\s+/g, '-')}.png`;
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+  };
+
+  const shareOnLinkedIn = () => {
+    const text = encodeURIComponent(`I just earned ${milestoneText} on Spurti! 🎉`);
+    const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(window.location.origin)}&text=${text}`;
+    window.open(url, '_blank');
+  };
+
+  return (
+    <section className="panel">
+      <h2>Milestone Certificate</h2>
+      <canvas ref={canvasRef} width={600} height={420} className="certificate-canvas" />
+      <div className="certificate-actions">
+        <button className="primary" onClick={downloadCertificate}>Download Certificate</button>
+        <button className="secondary" onClick={shareOnLinkedIn}>Share on LinkedIn</button>
+      </div>
+    </section>
+  );
+}
+
+function RedemptionMarketplace({ student }) {
+  const [catalog, setCatalog] = useState([]);
+  const [history, setHistory] = useState([]);
+  const [redeeming, setRedeeming] = useState(null);
+  const [message, setMessage] = useState('');
+  const [currentSp, setCurrentSp] = useState(student.totalSp);
+
+  useEffect(() => {
+    fetch(`${API}/rewards/catalog`).then(r => r.json()).then(setCatalog).catch(() => {});
+    loadHistory();
+  }, []);
+
+  const loadHistory = () => {
+    fetch(`${API}/redeem/history?email=${encodeURIComponent(student.email)}`)
+      .then(r => r.json())
+      .then(setHistory)
+      .catch(() => {});
+  };
+
+  const redeem = async (reward) => {
+    if (currentSp < reward.cost) return;
+    setRedeeming(reward.id);
+    setMessage('');
+    try {
+      const res = await fetch(`${API}/redeem`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: student.email, rewardId: reward.id })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMessage(data.error || 'Redemption failed.');
+        return;
+      }
+      setCurrentSp(data.profile.student.totalSp);
+      setMessage(`Redeemed ${reward.name}! Our team will follow up with next steps.`);
+      loadHistory();
+    } catch {
+      setMessage('Network error — please try again.');
+    } finally {
+      setRedeeming(null);
+    }
+  };
+
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <h2>Redeem SP</h2>
+        <span className="muted">Balance: {currentSp} SP</span>
+      </div>
+      {message && <p className={message.includes('Redeemed') ? 'muted' : 'error'}>{message}</p>}
+      <div className="reward-grid">
+        {catalog.map(reward => {
+          const affordable = currentSp >= reward.cost;
+          return (
+            <div key={reward.id} className={`reward-card ${affordable ? '' : 'unaffordable'}`}>
+              <strong>{reward.name}</strong>
+              <span>{reward.cost} SP</span>
+              <button
+                className="primary"
+                disabled={!affordable || redeeming === reward.id}
+                onClick={() => redeem(reward)}
+              >
+                {redeeming === reward.id ? 'Redeeming...' : affordable ? 'Redeem' : 'Not enough SP'}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {history.length > 0 && (
+        <div className="redemption-history">
+          <h3>Your Redemption History</h3>
+          {history.map(h => (
+            <div key={h._id} className="redemption-row">
+              <span>{h.rewardName}</span>
+              <span>-{h.cost} SP</span>
+              <span>{new Date(h.requestedAt).toLocaleDateString()}</span>
+              <span className={`status-${h.status}`}>{h.status}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AchievementGallery({ gallery }) {
+  const unlockedCount = gallery.filter(b => b.unlocked).length;
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <h2>Achievements</h2>
+        <span className="muted">{unlockedCount}/{gallery.length} unlocked</span>
+      </div>
+      <div className="achievement-grid">
+        {gallery.map(badge => (
+          <div key={badge.key} className={`achievement-card ${badge.unlocked ? 'unlocked' : 'locked'}`}>
+            <span className="achievement-icon">{badge.unlocked ? badge.icon : '🔒'}</span>
+            <strong>{badge.name}</strong>
+            <p>{badge.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 function Tabs({ tab, setTab, tabs }) {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,181 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+.achievement-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 14px;
+  margin-top: 12px;
+}
+
+.achievement-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 6px;
+  padding: 16px 12px;
+  border-radius: 10px;
+  border: 1px solid #333;
+  background: #1a1a1a;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.achievement-card.unlocked {
+  border-color: #4caf50;
+  background: linear-gradient(160deg, #1a1a1a, #16261a);
+}
+
+.achievement-card.locked {
+  opacity: 0.55;
+}
+
+.achievement-icon {
+  font-size: 2em;
+}
+
+.achievement-card strong {
+  font-size: 0.95em;
+  color: #fff;
+}
+
+.achievement-card.locked strong {
+  color: #999;
+}
+.achievement-card p {
+  font-size: 0.8em;
+  color: #999;
+  margin: 0;
+}
+
+.certificate-canvas {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 12px 0;
+  display: block;
+}
+
+.certificate-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.goal-setup, .goal-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.goal-setup input {
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid #444;
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  background: #2a2a2a;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: #4caf50;
+  transition: width 0.3s ease;
+}
+
+.forecast-stats {
+  display: flex;
+  gap: 16px;
+  margin: 8px 0;
+}
+
+.forecast-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.forecast-stat b {
+  font-size: 1.4em;
+}
+
+.forecast-stat em {
+  font-style: normal;
+  color: #999;
+  font-size: 0.85em;
+}
+
+.forecast-goal {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.forecast-goal input {
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid #444;
+  background: #1a1a1a;
+  color: #fff;
+  flex: 1;
+}
+
+.reward-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 14px;
+  margin-top: 12px;
+}
+
+.reward-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  padding: 18px 14px;
+  border-radius: 10px;
+  border: 1px solid #333;
+  background: #1a1a1a;
+}
+
+.reward-card.unaffordable {
+  opacity: 0.55;
+}
+
+.reward-card strong {
+  color: #fff;
+  font-size: 1em;
+}
+
+.reward-card span {
+  color: #8bc34a;
+  font-weight: 600;
+}
+
+.redemption-history {
+  margin-top: 24px;
+  border-top: 1px solid #333;
+  padding-top: 16px;
+}
+
+.redemption-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid #2a2a2a;
+  font-size: 0.9em;
+  color: #ccc;
+}
+
+.status-requested { color: #f0c766; }
+.status-fulfilled { color: #4caf50; }
+.status-cancelled { color: #e57373; }

--- a/server/models/RewardRedemption.js
+++ b/server/models/RewardRedemption.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+// Tracks each reward a student redeems with their Spurti Points. Kept separate
+// from SPTransaction (which just records the SP debit) so admins get a clean
+// view of *what* was redeemed, not just the point movement.
+const rewardRedemptionSchema = new mongoose.Schema({
+  email: { type: String, required: true, lowercase: true, trim: true, index: true },
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', index: true },
+  rewardId: { type: String, required: true },
+  rewardName: { type: String, required: true },
+  cost: { type: Number, required: true },
+  status: { type: String, enum: ['requested', 'fulfilled', 'cancelled'], default: 'requested' },
+  requestedAt: { type: Date, default: Date.now }
+}, { timestamps: true });
+
+export default mongoose.model('RewardRedemption', rewardRedemptionSchema);

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -24,7 +24,10 @@ const studentSchema = new mongoose.Schema({
   // Second perception pop-up ("poll2") — same mechanism as surveyCompleted, but an
   // independent flag so it never disturbs the first survey's completion state.
   poll2Completed: { type: Boolean, default: false, index: true },
-  poll2CompletedAt: { type: Date, default: null }
+  poll2CompletedAt: { type: Date, default: null },
+  // Weekly Goal Tracker — student sets a personal SP target for the current week.
+  weeklyGoalSp: { type: Number, default: 0 },
+  weeklyGoalSetAt: { type: Date, default: null }
 }, { timestamps: true });
 
 studentSchema.index({ name: 'text', email: 'text', alternateEmail: 'text' });

--- a/server/server.js
+++ b/server/server.js
@@ -12,12 +12,22 @@ import AttendanceRecord from './models/AttendanceRecord.js';
 import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
+import RewardRedemption from './models/RewardRedemption.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
 const clientDist = path.join(rootDir, 'client', 'dist');
 const ADMIN_EMAIL = normalizeEmail(process.env.ADMIN_EMAIL || 'dled@iitrpr.ac.in');
+// Fixed reward catalog for the SP Redemption Marketplace. Keeping this as a
+// server-side constant (not DB-driven) keeps costs authoritative — the client
+// can never submit its own price for a reward.
+const REWARD_CATALOG = [
+  { id: 'resume-review', name: 'Resume Review', cost: 150 },
+  { id: 'swag-kit', name: 'Spurti Swag Kit', cost: 100 },
+  { id: 'course-discount', name: 'Course Discount Code', cost: 200 },
+  { id: 'mentor-session', name: 'Priority Mentor Session', cost: 250 }
+];
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'vled-local-admin';
 
 // Survey triangulation pop-up(s). All driven by env so the form link / mode can
@@ -95,6 +105,16 @@ const liveViewers = new Map();
 
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
+
+// Returns the start (Monday 00:00) of the current week, for weekly goal tracking.
+function weekStart(date = new Date()) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = (day === 0 ? 6 : day - 1);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - diff);
+  return d;
+}
 
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
@@ -178,13 +198,14 @@ function excusedPayload(student) {
 async function studentPayload(student) {
   const email = student.email;
   const activeFilter = { status: { $ne: 'excused' } };
-  const [transactions, polls, attendance, rankInfo, leaderboard, allStudents] = await Promise.all([
+  const [transactions, polls, attendance, rankInfo, leaderboard, allStudents, sessions] = await Promise.all([
     SPTransaction.find({ email }).sort({ dateTime: 1, createdAt: 1 }).lean(),
     PollRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     AttendanceRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     rankFor(email),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
-    Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
+    Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean(),
+    Session.find().lean()
   ]);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
@@ -195,6 +216,30 @@ async function studentPayload(student) {
   // Spurti Levels & Trophy Leagues — derived from existing SP (lifetime highest + current).
   const highestSpEver = Math.max(Number(student.highestSpEver) || 0, Number(student.totalSp) || 0);
   const myGroup = leaderboardGroup(student.internshipStartDate);
+  // Weekly Goal Tracker — SP earned since the start of the current week.
+  const currentWeekStart = weekStart();
+  const spEarnedThisWeek = transactions
+    .filter(tx => new Date(tx.dateTime) >= currentWeekStart)
+    .reduce((sum, tx) => sum + Number(tx.appliedDelta || 0), 0);
+  const weeklyGoalSp = Number(student.weeklyGoalSp) || 0;
+
+  // SP Forecast — projects final SP based on average pace across completed sessions.
+  const now = new Date();
+  const completedSessions = sessions.filter(s => new Date(s.endDateTime) <= now);
+  const remainingSessions = sessions.filter(s => new Date(s.endDateTime) > now);
+  const earnedFromSessions = transactions
+    .filter(tx => tx.category === 'attendance' || tx.category === 'poll')
+    .reduce((sum, tx) => sum + Number(tx.appliedDelta || 0), 0);
+  const avgSpPerSession = completedSessions.length
+    ? Math.round((earnedFromSessions / completedSessions.length) * 10) / 10
+    : 0;
+  const projectedFinalSp = Math.round(student.totalSp + (avgSpPerSession * remainingSessions.length));
+  const forecast = {
+    completedSessions: completedSessions.length,
+    remainingSessions: remainingSessions.length,
+    avgSpPerSession,
+    projectedFinalSp
+  };
   const groupStudents = allStudents.filter(s => leaderboardGroup(s.internshipStartDate) === myGroup);
   const mapRow = (row, index) => ({
     rank: index + 1,
@@ -225,7 +270,14 @@ async function studentPayload(student) {
       leaderboardGroup: myGroup,
       leaderboardGroupLabel: groupLabel(myGroup),
       surveyCompleted: Boolean(student.surveyCompleted),
-      poll2Completed: Boolean(student.poll2Completed)
+      poll2Completed: Boolean(student.poll2Completed),
+      forecast,
+      weeklyGoal: {
+        targetSp: weeklyGoalSp,
+        spEarnedThisWeek,
+        progressPct: weeklyGoalSp > 0 ? Math.min(100, Math.round((spEarnedThisWeek / weeklyGoalSp) * 100)) : 0,
+        weekStart: currentWeekStart
+      }
     },
     transactions,
     polls,
@@ -305,6 +357,70 @@ api.post('/confirm', async (req, res) => {
   }
   if (student.status === 'excused') return res.json(excusedPayload(student));
   res.json(await studentPayload(student));
+});
+
+api.post('/goal', async (req, res) => {
+  const { email, targetSp } = req.body || {};
+  const normalized = normalizeEmail(email);
+  const target = Number(targetSp);
+  if (!normalized || !Number.isFinite(target) || target < 0) {
+    return res.status(400).json({ error: 'email and a valid targetSp are required' });
+  }
+  const student = await Student.findOne({ $or: [{ email: normalized }, { alternateEmail: normalized }] });
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  student.weeklyGoalSp = Math.round(target);
+  student.weeklyGoalSetAt = new Date();
+  await student.save();
+  res.json(await studentPayload(student));
+});
+
+api.get('/rewards/catalog', (_req, res) => res.json(REWARD_CATALOG));
+
+api.post('/redeem', async (req, res) => {
+  const { email, rewardId } = req.body || {};
+  const normalized = normalizeEmail(email);
+  const reward = REWARD_CATALOG.find(r => r.id === rewardId);
+  if (!normalized || !reward) {
+    return res.status(400).json({ error: 'email and a valid rewardId are required' });
+  }
+  const student = await Student.findOne({ $or: [{ email: normalized }, { alternateEmail: normalized }] });
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  if (student.totalSp < reward.cost) {
+    return res.status(400).json({ error: 'Not enough SP for this reward' });
+  }
+
+  const newBalance = student.totalSp - reward.cost;
+  student.totalSp = newBalance;
+  await student.save();
+
+  await SPTransaction.create({
+    email: student.email,
+    studentId: student._id,
+    category: 'manual',
+    deltaMode: 'absolute',
+    deltaValue: -reward.cost,
+    appliedDelta: -reward.cost,
+    balanceAfter: newBalance,
+    reason: `Redeemed: ${reward.name}`,
+    dateTime: new Date()
+  });
+
+  const redemption = await RewardRedemption.create({
+    email: student.email,
+    studentId: student._id,
+    rewardId: reward.id,
+    rewardName: reward.name,
+    cost: reward.cost
+  });
+
+  res.json({ redemption, profile: await studentPayload(student) });
+});
+
+api.get('/redeem/history', async (req, res) => {
+  const email = normalizeEmail(req.query.email);
+  if (!email) return res.status(400).json({ error: 'email is required' });
+  const history = await RewardRedemption.find({ email }).sort({ requestedAt: -1 }).lean();
+  res.json(history);
 });
 
 api.get('/leaderboard', async (req, res) => {


### PR DESCRIPTION
## Overview

This PR introduces the **Spurti Recognition & Growth Hub** — a unified 
system that combines recognition, forward-looking growth tracking, and 
tangible rewards into the student dashboard.

The design is inspired by how real companies run employee recognition and 
rewards programs (e.g. Bonusly, Achievers, Motivosity) — platforms built 
around a simple loop: **Earn → Track → Showcase → Redeem**. Instead of 
shipping three unrelated features, this PR ties them into one cohesive 
system, each layer feeding into the next.

---

## 🏅 Recognition Layer

**Achievement Gallery**
- Adds a new "Achievements" tab on the student dashboard showing every 
  possible badge (Top 50, Top 10, Consistent Attendee, Poll Champion, Above 
  Average, Legend Badge) — not just the ones already earned.
- Locked badges are shown greyed out with a 🔒 icon and their unlock 
  criteria, so students know exactly what to work toward next, not just 
  what they've already achieved.
- Built on top of the existing `buildBadges()` logic — added a new 
  `buildAchievementGallery()` function rather than modifying the original, 
  so nothing that currently depends on `buildBadges()` is affected.

**Milestone Certificate**
- When a student unlocks the Legend Badge (1500+ SP) or reaches Top 10, an 
  auto-generated certificate appears — rendered entirely client-side via 
  the HTML5 Canvas API (no image assets or server-side rendering needed).
- Includes a "Download Certificate" button (exports as PNG) and a "Share 
  on LinkedIn" button (opens a pre-filled LinkedIn share dialog).
- Certificate only renders when the student is actually eligible — this is 
  computed from data the profile payload already returns 
  (`legendBadgeUnlocked`, `rank`), so no new backend logic was needed for 
  this part.

---

## 📈 Growth Layer

**Weekly Goal Tracker**
- Students can set a personal SP target for the current week and see a 
  live progress bar (SP earned this week vs. target).
- The "current week" is calculated Monday-based on the backend 
  (`weekStart()` helper), so progress resets automatically without needing 
  a cron job or scheduled task.
- Added two new fields to the `Student` model: `weeklyGoalSp` and 
  `weeklyGoalSetAt`. A new `POST /api/goal` endpoint lets a student update 
  their target; the response is the full updated profile so the UI stays 
  in sync in one round trip.

**SP Forecast & Pace Planner**
- Projects a student's likely final SP by the end of the internship, based 
  on their average SP earned per completed session so far.
- Splits existing `Session` records into completed vs. remaining (by 
  comparing `endDateTime` to now), and calculates average pace from 
  `attendance`/`poll` category `SPTransaction` entries — no new database 
  model was needed for this.
- Includes a small interactive calculator: a student enters a target SP 
  and immediately sees the pace per remaining session needed to hit it. 
  This calculation runs entirely client-side (on data already in the 
  profile response) to avoid an unnecessary extra API call.
- Handles edge cases gracefully: zero completed sessions (pace shows 0, no 
  crash), and zero remaining sessions (shows "not reachable this cohort" 
  instead of dividing by zero).

---

## 🎁 Rewards Layer

**SP Redemption Marketplace**
- Adds a "Redeem SP" tab where students can trade earned SP for real 
  rewards: Resume Review (150 SP), Spurti Swag Kit (100 SP), Course 
  Discount Code (200 SP), Priority Mentor Session (250 SP).
- **This includes the full backend that was previously missing** from an 
  earlier UI-only version of this idea — reward costs live in a 
  server-side constant (`REWARD_CATALOG`) so the client can never submit 
  its own price, balance is checked server-side before any deduction, and 
  the whole redemption is atomic per-request (balance check → deduct → 
  log transaction → record redemption).
- New `RewardRedemption` model tracks what was redeemed, when, and its 
  fulfilment status — kept separate from `SPTransaction` (which just 
  records the point movement) so admins get a clean, readable view of 
  *what* students are actually redeeming.
- Every redemption also creates a normal `SPTransaction` entry (category: 
  `manual`, negative delta), so it shows up correctly in the student's 
  existing SP Bank statement — no special-casing needed there.
- New endpoints: `GET /api/rewards/catalog` (public reward list), 
  `POST /api/redeem` (redeem a reward), `GET /api/redeem/history` 
  (a student's own redemption history).

---

## Testing

- Manually tested all three layers locally against a seeded test student 
  with sample sessions and transactions (past + future sessions, partial 
  attendance/poll data).
- Verified zero-data edge cases don't crash: no sessions, no transactions, 
  weekly goal not yet set, insufficient SP for any reward.
- Confirmed redemption correctly deducts SP, logs a transaction, and 
  reflects the updated balance without a page reload.

## Files changed
- `server/models/Student.js` — added `weeklyGoalSp`, `weeklyGoalSetAt`
- `server/models/RewardRedemption.js` — new model
- `server/server.js` — forecast calculation in `studentPayload`; new routes: 
  `/api/goal`, `/api/rewards/catalog`, `/api/redeem`, `/api/redeem/history`
- `client/src/main.jsx` — new components: `AchievementGallery`, 
  `MilestoneCertificate`, `WeeklyGoalWidget`, `ForecastWidget`, 
  `RedemptionMarketplace`
- `client/src/styles.css` — styling for all five new components[](url)