### PR TITLE
Commitments hub + My Journey (ViBe & Standup commitments)

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -279,9 +279,13 @@ function StudentView({ profile, onBack }) {
       </header>
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'],
+        ...(student.eligibleForVibeGoals ? [['journey','My Journey'], ['vibe','Commitments']] : []),
+        ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
+      {tab === 'journey' && student.eligibleForVibeGoals && <MyJourney student={student} setTab={setTab} />}
+      {tab === 'vibe' && student.eligibleForVibeGoals && <Commitments student={student} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
     </main>
   );
@@ -502,6 +506,437 @@ function Leaderboard({ rows }) {
         <tbody>{rows.map(row => <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}><td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.totalSp}</td></tr>)}</tbody>
       </table>
     </section>
+  );
+}
+
+const fmtDate = d => d ? new Date(d).toLocaleDateString(undefined, { day: 'numeric', month: 'short' }) : '—';
+const toInput = d => d ? new Date(d).toISOString().slice(0, 10) : '';
+
+// The unified phase-by-phase progress + SP tab. Four phases: Standups, ViBe, SPA,
+// Projects. Standups & ViBe show real SP; SPA & Projects are placeholders until the
+// Samagama data (and their SP rule) land. Goal *staking* lives in the Commitments tab.
+function MyJourney({ student, setTab }) {
+  const email = student.email;
+  const [data, setData] = useState(null);
+  const [plan, setPlan] = useState({ vibeBy: '', spaBy: '', projectBy: '' });
+  const [savedMsg, setSavedMsg] = useState(false);
+
+  const load = async () => {
+    const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
+    const j = await r.json();
+    setData(j);
+    if (j.plan) setPlan({ vibeBy: toInput(j.plan.vibeBy), spaBy: toInput(j.plan.spaBy), projectBy: toInput(j.plan.projectBy) });
+  };
+  useEffect(() => { load(); }, [email]);
+
+  const savePlan = async () => {
+    const r = await fetch(`${API}/journey/plan`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, ...plan })
+    });
+    if (r.ok) { setData(await r.json()); setSavedMsg(true); setTimeout(() => setSavedMsg(false), 2000); }
+  };
+
+  if (!data) return <section className="panel">Loading your journey…</section>;
+  if (!data.eligible) return <section className="panel empty">My Journey isn’t available for your cohort yet.</section>;
+
+  const { standups, vibe, spa, projects } = data;
+  const spaPct = spa.total ? Math.round(spa.solved / spa.total * 100) : 0;
+
+  return (
+    <div className="jr">
+      <section className="panel jr-plan">
+        <h2>My internship plan</h2>
+        <p className="muted">Four phases to your Summership. Set the dates you’re aiming for — your cards below track you against them. (SP is staked separately in the <b>Commitments</b> tab.)</p>
+        <div className="jr-plan-row">
+          <label>Finish ViBe by<input type="date" value={plan.vibeBy} onChange={e => setPlan({ ...plan, vibeBy: e.target.value })} /></label>
+          <label>Solve all 53 SPA by<input type="date" value={plan.spaBy} onChange={e => setPlan({ ...plan, spaBy: e.target.value })} /></label>
+          <label>First project PR by<input type="date" value={plan.projectBy} onChange={e => setPlan({ ...plan, projectBy: e.target.value })} /></label>
+          <button className="primary" onClick={savePlan}>Save plan</button>
+          {savedMsg && <span className="jr-saved">✓ Saved</span>}
+        </div>
+      </section>
+
+      <div className="jr-grid">
+        {/* Phase 1 — Standups */}
+        <section className="jr-card phase-standups">
+          <div className="jr-head"><span className="jr-n">1</span><h3>Standups</h3><span className="jr-sp">+{standups.sp} SP</span></div>
+          <p className="jr-sub">Zoom attendance + Spandan polls</p>
+          <div className="jr-stats">
+            <div><strong>{standups.zoomMinutes}</strong><span>Zoom minutes</span></div>
+            <div><strong>{standups.sessionsAttended}</strong><span>sessions attended</span></div>
+            <div><strong>{standups.pollsAttempted}/{standups.pollsTotal}</strong><span>polls attempted</span></div>
+          </div>
+          <div className="jr-splits">
+            <span className="jr-pill">Attendance +{standups.spAttendance}</span>
+            <span className="jr-pill">Polls +{standups.spPolls}</span>
+          </div>
+        </section>
+
+        {/* Phase 2 — ViBe */}
+        <section className="jr-card phase-vibe">
+          <div className="jr-head"><span className="jr-n">2</span><h3>ViBe courses</h3><span className={`jr-sp ${vibe.sp < 0 ? 'neg' : ''}`}>{vibe.sp >= 0 ? '+' : ''}{vibe.sp} SP</span></div>
+          <p className="jr-sub">{vibe.clearedCount}/{vibe.totalCourses} courses complete · plan: by {fmtDate(data.plan.vibeBy)}</p>
+          <div className="jr-dots">
+            {vibe.ladder.map(l => (
+              <div key={l.key} className={`jr-dot ${l.cleared ? 'done' : (vibe.current && vibe.current.key === l.key ? 'current' : '')}`} title={l.name}>
+                <b>{l.cleared ? '✓' : `${l.pct}%`}</b><span>{l.name}</span>
+              </div>
+            ))}
+          </div>
+          <div className="jr-splits">
+            {vibe.current
+              ? <span className="jr-pill">Now: {vibe.current.name} — {vibe.current.pct}%</span>
+              : <span className="jr-pill">All courses complete 🎉</span>}
+            {vibe.activeCommitment && <span className="jr-pill amber">Active commitment: +{vibe.activeCommitment.goalPct}%</span>}
+            <button className="jr-link" onClick={() => setTab('vibe')}>Set a commitment →</button>
+          </div>
+        </section>
+
+        {/* Phase 3 — SPA (placeholder) */}
+        <section className="jr-card phase-spa">
+          <div className="jr-head"><span className="jr-n">3</span><h3>SPA — Matrix Mystics</h3><span className="jr-soon">SP soon</span></div>
+          <p className="jr-sub">53-problem set · plan: by {fmtDate(data.plan.spaBy)}</p>
+          <div className="jr-big"><strong>{spa.solved}</strong><span>/ {spa.total} solved</span></div>
+          <div className="jr-progress"><i style={{ width: `${spaPct}%` }} /></div>
+          <div className="jr-splits">
+            <span className="jr-pill">{spa.spaPoints} SPA points</span>
+            <span className="jr-pill muted">SP rule pending Samagama data</span>
+          </div>
+        </section>
+
+        {/* Phase 4 — Projects (placeholder) */}
+        <section className="jr-card phase-project">
+          <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-soon">SP soon</span></div>
+          <p className="jr-sub">Pull requests · plan: by {fmtDate(data.plan.projectBy)}</p>
+          <div className="jr-stats">
+            <div><strong>{projects.prsRaised}</strong><span>PRs raised</span></div>
+            <div><strong>{projects.prsMerged}</strong><span>PRs merged</span></div>
+          </div>
+          <div className="jr-splits">
+            <span className="jr-pill muted">SP rule pending Samagama data</span>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function courseName(ladder, key) { const c = ladder.find(l => l.key === key); return c ? c.name : key; }
+// net SP over the whole commitment: won -> win minus the debited stake; lost -> stake + penalty
+function netFor(b) { return b.status === 'won' ? b.potentialWin - b.stake : -(b.stake + b.potentialLoss); }
+
+// The Commitments hub: one accordion card per phase. Every phase shares the same SP
+// engine (stake debited → HIT wins it back multiplied / MISS loses a penalty); only
+// the target metric differs. ViBe is live; the other three land one by one.
+const COMMITMENT_TYPES = [
+  { key: 'vibe',    name: 'ViBe courses',        blurb: 'Pledge to raise your current course’s completion by X% before a deadline.', ready: true },
+  { key: 'standup', name: 'Standups',            blurb: 'Pledge to attend all of this week’s standups at a chosen attendance tier.', ready: true },
+  { key: 'spa',     name: 'SPA — Matrix Mystics', blurb: 'Pledge to solve N of the 53 problems by a date.',                          ready: false },
+  { key: 'project', name: 'Projects',            blurb: 'Pledge to raise / merge N pull requests by a date.',                        ready: false }
+];
+
+function Commitments({ student }) {
+  const [open, setOpen] = useState('vibe');
+  return (
+    <div className="cm">
+      <section className="panel">
+        <h2>Commitments</h2>
+        <p className="muted">Stake SP on a goal in any phase — hit it by the deadline and win your stake back multiplied; miss and you lose a penalty on top. <b>One active commitment per phase</b> (up to four running at once).</p>
+      </section>
+      {COMMITMENT_TYPES.map(t => {
+        const isOpen = open === t.key;
+        return (
+          <section key={t.key} className={`cm-acc ${isOpen ? 'open' : ''} phase-${t.key}`}>
+            <button className="cm-accbtn" onClick={() => setOpen(isOpen ? null : t.key)}>
+              <span className="cm-caret">{isOpen ? '▾' : '▸'}</span>
+              <b>{t.name}</b>
+              {!t.ready && <span className="cm-tag">coming soon</span>}
+              <span className="cm-blurb">{t.blurb}</span>
+            </button>
+            {isOpen && (
+              <div className="cm-body">
+                {t.ready
+                  ? (t.key === 'vibe' ? <VibeGoals student={student} /> : <StandupGoals student={student} />)
+                  : <p className="cm-soon">{t.blurb}<br /><b>Coming soon</b> — same stake-and-win mechanic as ViBe, tuned to this phase.</p>}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function VibeGoals({ student }) {
+  const email = student.email;
+  const [data, setData] = useState(null);
+  const [form, setForm] = useState({ goalPct: 20, stake: 100, multiplier: 4, deadline: '' });
+  const [editing, setEditing] = useState(false);
+  const [err, setErr] = useState(null);
+
+  const load = async () => {
+    const r = await fetch(`${API}/vibe/state?email=${encodeURIComponent(email)}`);
+    setData(await r.json());
+  };
+  useEffect(() => {
+    load();
+    const d = new Date(); d.setDate(d.getDate() + 2);
+    setForm(f => ({ ...f, deadline: d.toISOString().slice(0, 10) }));
+  }, [email]);
+
+  if (!data) return <section className="panel">Loading ViBe Goals…</section>;
+  if (!data.eligible) return <section className="panel empty">ViBe Goals isn’t available for your cohort yet.</section>;
+
+  const cur = data.current, cfg = data.config;
+  const s = +form.stake, m = +form.multiplier, g = +form.goalPct;
+  const loss = cfg.penaltyFactor * s * m, win = s * m, need = s + loss;   // stake debited + worst-case penalty
+  const daysOut = form.deadline
+    ? Math.round((new Date(form.deadline).setHours(0, 0, 0, 0) - new Date().setHours(0, 0, 0, 0)) / 86400000) : 0;
+  const availForBet = data.available + (editing && data.active ? data.active.reserved + data.active.stake : 0);
+
+  let problem = null;
+  if (!cur) problem = 'All courses complete — nothing to commit to.';
+  else if (g <= cur.floorPct) problem = `Goal must beat the weekly floor (${cur.floorPct}%).`;
+  else if (daysOut < 1 || daysOut > cfg.maxBetDays) problem = `Deadline must be 1–${cfg.maxBetDays} days out.`;
+  else if (g > cur.remaining) problem = `Goal exceeds your remaining ${cur.remaining}%.`;
+  else if (need > availForBet) problem = `You need ${need} SP (stake ${s} + up to ${loss} loss); you have ${availForBet}.`;
+
+  const post = async (url, body, method = 'POST') => {
+    const r = await fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    const j = await r.json(); if (!r.ok) { setErr(j.error); return null; } setErr(null); return j;
+  };
+  const place = async () => { const j = await post(`${API}/vibe/bet`,
+    { email, course: cur.key, goalPct: g, stake: s, multiplier: m, deadline: form.deadline }); if (j) setData(j); };
+  const saveEdit = async () => { const j = await post(`${API}/vibe/bet/${data.active._id}`,
+    { email, goalPct: g, stake: s, multiplier: m }, 'PUT'); if (j) { setEditing(false); setData(j); } };
+  const settle = async (result) => { const j = await post(`${API}/vibe/bet/${data.active._id}/settle`,
+    { email, result }); if (j) { setEditing(false); setData(j); } };
+
+  const showForm = cur && (!data.active || editing);
+
+  return (
+    <div className="vg">
+      <section className="panel">
+        <h2>Your course path</h2>
+        <p className="muted">Courses unlock in order — you work on and set commitments for your current course only. Prior completions are credited automatically.</p>
+        <div className="vg-ladder">
+          {data.ladder.map((l, i) => (
+            <React.Fragment key={l.key}>
+              {i > 0 && <div className="vg-arrow">→</div>}
+              <div className={`vg-step ${l.cleared ? 'done' : (cur && cur.key === l.key ? 'current' : 'locked')}`}>
+                <span className="n">{i + 1}</span><b>{l.name}</b>
+                <em>{l.prior ? 'credited ✓' : l.cleared ? '100% ✓' : (cur && cur.key === l.key ? `${l.pct}% · in progress` : '🔒 locked')}</em>
+              </div>
+            </React.Fragment>
+          ))}
+        </div>
+      </section>
+
+      {cur && (
+        <section className="panel">
+          <h2>Current course — {cur.name}</h2>
+          <div className="vg-tiles">
+            <div className={`vg-tile ${data.weeklyFloor.met ? 'done' : ''}`}>
+              <span>This week (floor)</span>
+              <strong>{data.weeklyFloor.doneHours} h</strong>
+              <em>{cfg.floorHours} h required · {data.weeklyFloor.met
+                ? <span className="vg-pill green">+{cfg.floorSp} SP earned</span>
+                : <span className="vg-pill amber">not yet</span>}</em>
+            </div>
+            <div className="vg-tile">
+              <span>{cur.name} — completion</span>
+              <strong>{cur.pct}%</strong>
+              <em>{cur.remaining}% left · ≈ {(cur.pct / 100 * cur.hours).toFixed(1)} / {cur.hours} h*</em>
+              <div className="vg-progress"><i style={{ width: `${cur.pct}%` }} /></div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {cur && (
+        <section className="panel">
+          <h2>{editing ? 'Edit your commitment' : 'Set a goal & commit extra SP'}</h2>
+          <p className="muted">Your stake is <b>debited now</b>. Hit your goal by the deadline → win it back multiplied; miss → lose an extra penalty on top. One commitment per course, deadline up to {cfg.maxBetDays} days away.</p>
+          {!showForm && data.active &&
+            <div className="vg-lock">You have an active commitment on {cur.name}. Edit it below, or resolve it with the demo buttons.</div>}
+          {showForm && (
+            <div className="vg-form">
+              <div className="vg-field"><label>Course</label><input value={`${cur.name} (current)`} disabled /></div>
+              <div className="vg-field"><label>Raise completion by</label>
+                <div className="vg-row"><input type="number" min="1" max={cur.remaining} value={form.goalPct}
+                  onChange={e => setForm({ ...form, goalPct: e.target.value })} /><b>%</b></div>
+                <span className="hint">Allowed {cur.floorPct}%–{cur.remaining}% (floor → remaining) · ≈ {(g / 100 * cur.hours).toFixed(1)} h</span>
+              </div>
+              <div className="vg-field"><label>Deadline</label>
+                <input type="date" value={form.deadline} disabled={editing}
+                  onChange={e => setForm({ ...form, deadline: e.target.value })} />
+                <span className="hint">{editing ? 'Fixed — can’t be changed after placing.' : `Up to ${cfg.maxBetDays} days away.`}</span>
+              </div>
+              <div className="vg-field"><label>Stake — <b>{s}</b> SP</label>
+                <input type="range" min={cfg.stakeMin} max={cfg.stakeMax} step="10" value={form.stake}
+                  onChange={e => setForm({ ...form, stake: e.target.value })} />
+                <span className="hint">{cfg.stakeMin}–{cfg.stakeMax} SP.</span>
+              </div>
+              <div className="vg-field vg-wide"><label>Confidence multiplier</label>
+                <div className="vg-mult">{cfg.multipliers.map(x =>
+                  <button key={x} className={m === x ? 'active' : ''} onClick={() => setForm({ ...form, multiplier: x })}>{x}×</button>)}</div>
+              </div>
+              <div className="vg-readout">
+                <div className="r lose"><span>Staked now</span><strong>−{s}</strong></div>
+                <div className="r win"><span>If you HIT</span><strong>+{win}</strong><span className="net">net +{win - s}</span></div>
+                <div className="r lose"><span>If you MISS</span><strong>−{loss}</strong><span className="net">net −{s + loss}</span></div>
+                <div className="r"><span>Left after placing</span><strong>{availForBet - s - loss}</strong></div>
+              </div>
+              <div className="vg-actions">
+                {editing
+                  ? <><button className="primary" disabled={!!problem} onClick={saveEdit}>Save changes</button>
+                      <button className="secondary" onClick={() => { setEditing(false); setErr(null); }}>Cancel</button></>
+                  : <button className="primary" disabled={!!problem} onClick={place}>Place commitment</button>}
+                <span className={problem ? 'vg-warn' : 'vg-ok'}>{problem || `✓ Covered — ${loss} SP reserved until it settles.`}</span>
+              </div>
+              {err && <p className="error">{err}</p>}
+            </div>
+          )}
+        </section>
+      )}
+
+      <section className="panel">
+        <h2>Your active commitment</h2>
+        {data.active ? (
+          <div className="vg-bet">
+            <div>
+              <h4>{courseName(data.ladder, data.active.course)} — raise completion by {data.active.goalPct}%</h4>
+              <div className="meta">staked {data.active.stake} (debited) @ {data.active.multiplier}× · by {new Date(data.active.deadline).toLocaleDateString()} · risk −{data.active.potentialLoss} more on miss</div>
+            </div>
+            <div className="side">
+              <div><span className="win">Hit +{data.active.potentialWin}</span> / <span className="lose">Miss −{data.active.potentialLoss}</span></div>
+              <div className="vg-betbtns">
+                {!editing && <button className="secondary" onClick={() => { setForm({ goalPct: data.active.goalPct, stake: data.active.stake, multiplier: data.active.multiplier, deadline: form.deadline }); setEditing(true); }}>Edit commitment</button>}
+                <button className="secondary" onClick={() => settle('won')}>Demo: Hit</button>
+                <button className="secondary" onClick={() => settle('lost')}>Demo: Miss</button>
+              </div>
+            </div>
+          </div>
+        ) : <p className="muted">No active commitment right now — set one above.</p>}
+      </section>
+
+      <section className="panel">
+        <h2>Past commitments</h2>
+        {data.history.length ? (
+          <table className="table"><thead><tr><th>Course</th><th>Goal</th><th>Stake</th><th>Result</th><th>Net SP</th></tr></thead>
+            <tbody>{data.history.map(b => (
+              <tr key={b._id}><td>{courseName(data.ladder, b.course)}</td><td>+{b.goalPct}%</td><td>{b.stake} @ {b.multiplier}×</td>
+                <td className={b.status === 'won' ? 'vg-hit' : 'vg-miss'}>{b.status === 'won' ? 'HIT' : 'MISS'}</td>
+                <td className={b.status === 'won' ? 'vg-hit' : 'vg-miss'}>{netFor(b) >= 0 ? '+' : ''}{netFor(b)}</td></tr>))}
+            </tbody></table>
+        ) : <p className="muted">No settled commitments yet.</p>}
+      </section>
+    </div>
+  );
+}
+
+// Standup commitment — weekly, attendance-only, keep-the-stake. Student picks a tier
+// (81–90 → stake 20 / 91–100 → stake 50, fixed) and a confidence (2×/3×/4×). HIT pays
+// +stake×conf on top of earned attendance; MISS charges −0.5×stake×conf off the balance.
+function StandupGoals({ student }) {
+  const email = student.email;
+  const [data, setData] = useState(null);
+  const [tierKey, setTierKey] = useState('91-100');
+  const [multiplier, setMultiplier] = useState(4);
+  const [err, setErr] = useState(null);
+
+  const load = async () => {
+    const r = await fetch(`${API}/standup/state?email=${encodeURIComponent(email)}`);
+    setData(await r.json());
+  };
+  useEffect(() => { load(); }, [email]);
+
+  if (!data) return <section className="panel">Loading standups…</section>;
+  if (!data.eligible) return <section className="panel empty">Standup commitments aren’t available for your cohort yet.</section>;
+
+  const tier = data.tiers.find(t => t.key === tierKey) || data.tiers[0];
+  const stake = tier.stake, win = stake * multiplier, loss = data.penaltyFactor * stake * multiplier;
+  const problem = data.active
+    ? 'You already have an active standup commitment this week.'
+    : loss > data.available ? `You need ${loss} SP free to cover a possible miss; you have ${data.available}.` : null;
+
+  const post = async (url, body) => {
+    const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    const j = await r.json(); if (!r.ok) { setErr(j.error); return null; } setErr(null); return j;
+  };
+  const place = async () => { const j = await post(`${API}/standup/commit`, { email, tierKey, multiplier }); if (j) setData(j); };
+  const settle = async (result) => { const j = await post(`${API}/standup/commit/${data.active._id}/settle`, { email, result }); if (j) setData(j); };
+
+  return (
+    <div className="vg">
+      <section className="panel">
+        <h2>This week’s standups — {data.weekLabel}</h2>
+        <p className="muted">Pledge to attend <b>all {data.sessionsThisWeek}</b> standups this week at a chosen attendance tier. Attendance only — polls stay as poll-points. Your stake <b>isn’t deducted</b>: hit your pledge for a bonus on top of the attendance points you earn, miss and a penalty applies.</p>
+        <div className="vg-tiles">
+          <div className="vg-tile"><span>Attended so far</span><strong>{data.attendedThisWeek}/{data.sessionsThisWeek}</strong><em>this week</em></div>
+          <div className="vg-tile"><span>Avg attendance</span><strong>{data.avgPctThisWeek != null ? data.avgPctThisWeek + '%' : '—'}</strong><em>so far</em></div>
+        </div>
+      </section>
+
+      {!data.active && (
+        <section className="panel">
+          <h2>Set a standup commitment</h2>
+          <div className="vg-form">
+            <div className="vg-field vg-wide"><label>Attendance tier (fixed stake)</label>
+              <div className="vg-mult">{data.tiers.map(t =>
+                <button key={t.key} className={tierKey === t.key ? 'active' : ''} onClick={() => setTierKey(t.key)}>{t.label} · stake {t.stake}</button>)}</div>
+              <span className="hint">Higher tier = higher bar and bigger reward. Beating your tier still counts as a hit.</span>
+            </div>
+            <div className="vg-field vg-wide"><label>Confidence multiplier</label>
+              <div className="vg-mult">{data.multipliers.map(x =>
+                <button key={x} className={multiplier === x ? 'active' : ''} onClick={() => setMultiplier(x)}>{x}×</button>)}</div>
+            </div>
+            <div className="vg-readout">
+              <div className="r"><span>Stake (fixed by tier)</span><strong>{stake}</strong></div>
+              <div className="r win"><span>If you HIT</span><strong>+{win}</strong><span className="net">bonus, on top of attendance</span></div>
+              <div className="r lose"><span>If you MISS</span><strong>−{loss}</strong><span className="net">penalty off your balance</span></div>
+            </div>
+            <div className="vg-actions">
+              <button className="primary" disabled={!!problem} onClick={place}>Place commitment</button>
+              <span className={problem ? 'vg-warn' : 'vg-ok'}>{problem || `✓ Covered · settles ${new Date(data.deadline).toLocaleDateString()}`}</span>
+            </div>
+            {err && <p className="error">{err}</p>}
+          </div>
+        </section>
+      )}
+
+      <section className="panel">
+        <h2>Your active commitment</h2>
+        {data.active ? (
+          <div className="vg-bet">
+            <div>
+              <h4>{data.active.label}</h4>
+              <div className="meta">stake {data.active.stake} (kept) · by {new Date(data.active.deadline).toLocaleDateString()} · risk −{data.active.potentialLoss} on miss</div>
+            </div>
+            <div className="side">
+              <div><span className="win">Hit +{data.active.potentialWin}</span> / <span className="lose">Miss −{data.active.potentialLoss}</span></div>
+              <div className="vg-betbtns">
+                <button className="secondary" onClick={() => settle('won')}>Demo: Hit</button>
+                <button className="secondary" onClick={() => settle('lost')}>Demo: Miss</button>
+              </div>
+            </div>
+          </div>
+        ) : <p className="muted">No active standup commitment — set one above.</p>}
+      </section>
+
+      <section className="panel">
+        <h2>Past standup commitments</h2>
+        {data.history.length ? (
+          <table className="table"><thead><tr><th>Week pledge</th><th>Tier</th><th>Result</th><th>SP</th></tr></thead>
+            <tbody>{data.history.map(c => (
+              <tr key={c._id}><td>{c.label}</td><td>{c.tier}</td>
+                <td className={c.status === 'won' ? 'vg-hit' : 'vg-miss'}>{c.status === 'won' ? 'HIT' : 'MISS'}</td>
+                <td className={c.status === 'won' ? 'vg-hit' : 'vg-miss'}>{c.resultDelta >= 0 ? '+' : ''}{c.resultDelta}</td></tr>))}
+            </tbody></table>
+        ) : <p className="muted">No settled standup commitments yet.</p>}
+      </section>
+    </div>
   );
 }
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,129 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* --- ViBe Goals tab -------------------------------------------------------- */
+.vg .muted { color: var(--muted); font-size: 13px; }
+.vg .hint { font-size: 12px; color: var(--muted); }
+.vg-ladder { display: flex; align-items: stretch; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+.vg-step { flex: 1; min-width: 150px; border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; background: #fafdff; position: relative; }
+.vg-step .n { position: absolute; top: 10px; right: 12px; width: 20px; height: 20px; border-radius: 50%; background: #e2e8f0; color: var(--muted); font-size: 12px; font-weight: 900; display: grid; place-items: center; }
+.vg-step b { display: block; font-size: 15px; margin-bottom: 2px; }
+.vg-step em { font-style: normal; font-size: 12px; color: var(--muted); }
+.vg-step.done { background: #eefaf3; border-color: #bbe7cf; }
+.vg-step.done .n { background: var(--green); color: #fff; }
+.vg-step.current { border-color: var(--primary); box-shadow: 0 0 0 2px rgba(23,107,135,.18); }
+.vg-step.current .n { background: var(--primary); color: #fff; }
+.vg-step.locked { opacity: .7; }
+.vg-arrow { display: grid; place-items: center; color: var(--muted); font-size: 20px; font-weight: 900; }
+.vg-tiles { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 12px; }
+.vg-tile { border: 1px solid var(--line); border-radius: 8px; padding: 14px; background: #fafdff; }
+.vg-tile > span { display: block; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; font-weight: 800; }
+.vg-tile > strong { display: block; font-size: 22px; margin: 6px 0 2px; color: var(--primary); }
+.vg-tile > em { display: block; color: var(--muted); font-style: normal; font-size: 12px; }
+.vg-tile.done { background: #eefaf3; border-color: #bbe7cf; }
+.vg-tile.done > strong { color: var(--green); }
+.vg-pill { display: inline-block; border-radius: 999px; padding: 2px 8px; font-size: 12px; font-weight: 800; }
+.vg-pill.green { background: #e9f7ee; color: var(--green); }
+.vg-pill.amber { background: #fef3e2; color: var(--amber); }
+.vg-progress { height: 12px; background: #e2e8f0; border-radius: 999px; overflow: hidden; margin-top: 8px; }
+.vg-progress i { display: block; height: 100%; background: var(--primary); }
+.vg-form { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.vg-field { display: grid; gap: 6px; }
+.vg-field label { font-size: 13px; font-weight: 800; color: #334155; }
+.vg-field input { width: 100%; border: 1px solid var(--line); border-radius: 7px; padding: 10px 12px; background: #fff; color: var(--text); }
+.vg-field input[type=range] { padding: 0; accent-color: var(--primary); }
+.vg-row { display: flex; align-items: center; gap: 8px; }
+.vg-row input { max-width: 120px; }
+.vg-wide { grid-column: 1 / -1; }
+.vg-mult { display: flex; gap: 8px; }
+.vg-mult button { flex: 1; border: 1px solid var(--line); background: #fff; border-radius: 7px; padding: 10px 0; font-weight: 850; color: var(--text); }
+.vg-mult button.active { background: var(--primary); border-color: var(--primary); color: #fff; }
+.vg-readout { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap: 10px; border-top: 1px solid var(--line); padding-top: 14px; }
+.vg-readout .r { border: 1px solid var(--line); border-radius: 8px; padding: 10px; background: #fbfdff; text-align: center; }
+.vg-readout .r span { display: block; font-size: 12px; color: var(--muted); font-weight: 800; }
+.vg-readout .r strong { display: block; font-size: 20px; margin-top: 4px; }
+.vg-readout .win strong { color: var(--green); }
+.vg-readout .lose strong { color: var(--red); }
+.vg-actions { grid-column: 1 / -1; display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+.vg-warn { color: var(--red); font-weight: 800; font-size: 13px; }
+.vg-ok { color: var(--green); font-weight: 800; font-size: 13px; }
+.vg-lock { border: 1px dashed var(--primary); background: #f0f8fb; color: var(--primary-dark); border-radius: 8px; padding: 12px 14px; font-weight: 700; font-size: 14px; margin-bottom: 14px; }
+.vg-bet { border: 1px solid var(--line); border-left: 4px solid var(--primary); border-radius: 8px; padding: 14px; background: #fff; display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
+.vg-bet h4 { margin: 0 0 4px; font-size: 15px; }
+.vg-bet .meta { color: var(--muted); font-size: 13px; }
+.vg-bet .side { text-align: right; }
+.vg-bet .side .win { color: var(--green); font-weight: 850; }
+.vg-bet .side .lose { color: var(--red); font-weight: 850; }
+.vg-betbtns { display: flex; gap: 6px; justify-content: flex-end; margin-top: 8px; flex-wrap: wrap; }
+.vg-betbtns button { min-height: 34px; padding: 0 10px; }
+.vg-hit { color: var(--green); font-weight: 850; }
+.vg-miss { color: var(--red); font-weight: 850; }
+@media (max-width: 820px) { .vg-form { grid-template-columns: 1fr; } .vg-readout { grid-template-columns: 1fr 1fr; } .vg-tiles { grid-template-columns: 1fr; } }
+.vg-readout .net { display: block; font-size: 11px; color: var(--muted); font-weight: 700; margin-top: 2px; }
+
+/* ---- My Journey (phase-by-phase progress + SP) ---------------------------- */
+.jr { display: grid; gap: 16px; }
+.jr-plan-row { display: flex; flex-wrap: wrap; gap: 14px; align-items: flex-end; margin-top: 6px; }
+.jr-plan-row label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; font-weight: 700; color: var(--muted); }
+.jr-plan-row input { min-height: 36px; padding: 0 8px; border: 1px solid var(--line); border-radius: 8px; }
+.jr-saved { color: var(--green); font-weight: 800; font-size: 13px; }
+
+.jr-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+@media (max-width: 720px) { .jr-grid { grid-template-columns: 1fr; } }
+
+.jr-card { background: var(--panel, #fff); border: 1px solid var(--line); border-radius: 12px; padding: 16px; border-top: 4px solid var(--primary); box-shadow: var(--shadow, 0 1px 2px rgba(0,0,0,.04)); }
+.jr-card.phase-standups { border-top-color: #3b82f6; }
+.jr-card.phase-vibe { border-top-color: #8b5cf6; }
+.jr-card.phase-spa { border-top-color: #f59e0b; }
+.jr-card.phase-project { border-top-color: #10b981; }
+
+.jr-head { display: flex; align-items: center; gap: 8px; }
+.jr-head h3 { margin: 0; font-size: 16px; flex: 1; }
+.jr-n { width: 22px; height: 22px; border-radius: 50%; background: var(--text); color: #fff; font-size: 12px; font-weight: 800; display: grid; place-items: center; }
+.jr-sp { font-weight: 850; color: var(--green); font-size: 15px; }
+.jr-sp.neg { color: var(--red); }
+.jr-soon { font-size: 11px; font-weight: 800; color: var(--muted); background: #f1f5f9; border-radius: 999px; padding: 3px 8px; }
+.jr-sub { color: var(--muted); font-size: 13px; margin: 6px 0 12px; }
+
+.jr-stats { display: flex; gap: 18px; flex-wrap: wrap; }
+.jr-stats div { display: flex; flex-direction: column; }
+.jr-stats strong { font-size: 22px; line-height: 1.1; }
+.jr-stats span { font-size: 12px; color: var(--muted); }
+.jr-big { display: flex; align-items: baseline; gap: 6px; }
+.jr-big strong { font-size: 30px; }
+.jr-big span { color: var(--muted); font-size: 13px; }
+
+.jr-dots { display: flex; gap: 8px; }
+.jr-dot { flex: 1; text-align: center; border: 1px solid var(--line); border-radius: 8px; padding: 8px 4px; }
+.jr-dot.done { background: #ede9fe; border-color: #8b5cf6; }
+.jr-dot.current { background: #f5f3ff; border-color: #8b5cf6; box-shadow: inset 0 0 0 1px #8b5cf6; }
+.jr-dot b { display: block; font-size: 15px; }
+.jr-dot span { font-size: 10px; color: var(--muted); }
+
+.jr-progress { height: 12px; background: #e2e8f0; border-radius: 999px; overflow: hidden; margin: 8px 0; }
+.jr-progress i { display: block; height: 100%; background: #f59e0b; }
+
+.jr-splits { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; margin-top: 12px; }
+.jr-pill { display: inline-block; border-radius: 999px; padding: 3px 9px; font-size: 12px; font-weight: 700; background: #eef2ff; color: var(--text); }
+.jr-pill.amber { background: #fef3e2; color: var(--amber); }
+.jr-pill.muted { background: #f1f5f9; color: var(--muted); font-weight: 600; }
+.jr-link { background: none; border: none; color: var(--primary); font-weight: 800; font-size: 12px; cursor: pointer; padding: 0; margin-left: auto; }
+
+/* ---- Commitments hub (accordion, one card per phase) --------------------- */
+.cm { display: grid; gap: 12px; }
+.cm-acc { border: 1px solid var(--line); border-radius: 12px; background: var(--panel, #fff); overflow: hidden; border-left: 4px solid var(--line); }
+.cm-acc.open { box-shadow: var(--shadow, 0 1px 3px rgba(0,0,0,.06)); }
+.cm-acc.phase-vibe.open { border-left-color: #8b5cf6; }
+.cm-acc.phase-standup.open { border-left-color: #3b82f6; }
+.cm-acc.phase-spa.open { border-left-color: #f59e0b; }
+.cm-acc.phase-project.open { border-left-color: #10b981; }
+.cm-accbtn { width: 100%; display: flex; align-items: center; gap: 10px; padding: 14px 16px; background: none; border: none; cursor: pointer; text-align: left; font: inherit; }
+.cm-accbtn b { font-size: 15px; }
+.cm-caret { color: var(--muted); font-size: 12px; width: 12px; }
+.cm-tag { font-size: 11px; font-weight: 800; color: var(--muted); background: #f1f5f9; border-radius: 999px; padding: 2px 8px; }
+.cm-blurb { color: var(--muted); font-size: 12.5px; margin-left: auto; text-align: right; max-width: 46%; }
+@media (max-width: 620px) { .cm-blurb { display: none; } }
+.cm-body { padding: 4px 14px 14px; border-top: 1px solid var(--line); }
+.cm-body .vg { margin-top: 8px; }
+.cm-soon { color: var(--muted); font-size: 14px; line-height: 1.6; padding: 10px 2px; }

--- a/server/models/Commitment.js
+++ b/server/models/Commitment.js
@@ -1,0 +1,41 @@
+import mongoose from 'mongoose';
+
+// A commitment (formerly VibeBet) — a stake-a-goal pledge in ANY internship phase.
+// One shared collection; `type` selects the phase and which fields apply. One active
+// commitment per (email, type). Two economic modes:
+//   - debited (ViBe): the stake is debited at placement, returned ×multiplier on a HIT.
+//   - keep   (Standup): the stake is NOT debited; a HIT pays a +stake×mult bonus on top
+//     of the attendance points earned that week, a MISS charges −0.5×stake×mult.
+const commitmentSchema = new mongoose.Schema({
+  email: { type: String, lowercase: true, trim: true, required: true, index: true },
+  type: { type: String, enum: ['vibe', 'standup'], required: true, index: true },
+
+  // shared economics
+  stake: { type: Number, required: true },            // 20 / 50 (standup tiers) or 50–200 (vibe)
+  multiplier: { type: Number, required: true },       // 2 | 3 | 4
+  potentialWin: { type: Number, required: true },     // stake * multiplier
+  potentialLoss: { type: Number, required: true },    // 0.5 * stake * multiplier
+  reserved: { type: Number, default: 0 },             // SP reserved while active (vibe = loss; standup = 0)
+  debited: { type: Boolean, default: false },         // was the stake debited at placement (vibe true)
+  deadline: { type: Date, required: true },
+  status: { type: String, enum: ['active', 'won', 'lost'], default: 'active', index: true },
+  resultDelta: { type: Number, default: 0 },
+  settledAt: { type: Date, default: null },
+  label: { type: String, default: '' },               // human summary (for history)
+
+  // ViBe-specific
+  course: { type: String, default: '' },              // course key
+  goalPct: { type: Number, default: 0 },              // raise completion by this many %
+  baselinePct: { type: Number, default: 0 },          // completion % at commit time
+
+  // Standup-specific
+  tier: { type: String, default: '' },                // '81-90' | '91-100'
+  tierFloor: { type: Number, default: 0 },            // min average attendance % to hit (81 | 91)
+  sessionsTarget: { type: Number, default: 0 },       // sessions to attend this week (full week Y)
+  weekStart: { type: Date, default: null },
+  weekEnd: { type: Date, default: null }
+}, { timestamps: true });
+
+commitmentSchema.index({ email: 1, type: 1, status: 1 });
+
+export default mongoose.model('Commitment', commitmentSchema);

--- a/server/models/JourneyPlan.js
+++ b/server/models/JourneyPlan.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+// A student's self-declared internship plan: target dates to finish each phase.
+// Soft goals (no SP staked here — that lives in the commitment/ViBe tab). Hitting
+// a planned date can later award a completion bonus. One plan per student.
+const journeyPlanSchema = new mongoose.Schema({
+  email: { type: String, lowercase: true, trim: true, required: true, unique: true, index: true },
+  vibeBy: { type: Date, default: null },      // finish all 3 ViBe courses by
+  spaBy: { type: Date, default: null },       // solve all 53 SPA problems by
+  projectBy: { type: Date, default: null }    // first / target project PR by
+}, { timestamps: true });
+
+export default mongoose.model('JourneyPlan', journeyPlanSchema);

--- a/server/models/JourneyProgress.js
+++ b/server/models/JourneyProgress.js
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+
+// Per-student SPA + Projects progress. PLACEHOLDER source: seeded with dummy values
+// locally so the My-Journey cards have numbers. In production these fields will be
+// refreshed from Samagama (SPA solver counts / SPA points; project PRs raised &
+// merged). The SP-award rule for these two phases is still TBD (decided once the
+// real Samagama data shape is known) — that is why sp is not computed here yet.
+const journeyProgressSchema = new mongoose.Schema({
+  email: { type: String, lowercase: true, trim: true, required: true, unique: true, index: true },
+  // SPA — Matrix Mystics (53 problems)
+  spaSolved: { type: Number, default: 0 },
+  spaTotal: { type: Number, default: 53 },
+  spaPoints: { type: Number, default: 0 },   // existing "SPA points" (separate leaderboard currency)
+  // Projects — PRs (from Samagama)
+  prsRaised: { type: Number, default: 0 },
+  prsMerged: { type: Number, default: 0 }
+}, { timestamps: true });
+
+export default mongoose.model('JourneyProgress', journeyProgressSchema);

--- a/server/models/VibeProgress.js
+++ b/server/models/VibeProgress.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+// Per-student ViBe course progress. In production this is refreshed from the ViBe
+// leaderboard API (completionPercentage). Here it is seeded with DUMMY values so
+// the module can run locally without the live snapshot cron.
+const vibeProgressSchema = new mongoose.Schema({
+  email: { type: String, lowercase: true, trim: true, required: true, index: true },
+  course: { type: String, required: true },          // 'onboarding' | 'ai' | 'mern'
+  pct: { type: Number, default: 0 },                 // completionPercentage 0–100 (from ViBe)
+  weekHours: { type: Number, default: 0 },           // content-hours done this week (for the floor)
+  priorCompleted: { type: Boolean, default: false }  // credited from a prior program (sheet crosswalk)
+}, { timestamps: true });
+
+vibeProgressSchema.index({ email: 1, course: 1 }, { unique: true });
+
+export default mongoose.model('VibeProgress', vibeProgressSchema);

--- a/server/scripts/seedVibeDummy.js
+++ b/server/scripts/seedVibeDummy.js
@@ -1,0 +1,155 @@
+// Seed DUMMY 16-July-cohort students so the ViBe Goals tab can be demoed locally.
+// Idempotent: upserts by email (all end in @dummy.test) and resets their ViBe rows.
+// Existing real students (all onboarded < 16 Jul) stay ineligible and untouched.
+//
+//   node server/scripts/seedVibeDummy.js
+import mongoose from 'mongoose';
+import { MONGO_URI } from '../config.js';
+import Student from '../models/Student.js';
+import VibeProgress from '../models/VibeProgress.js';
+import Commitment from '../models/Commitment.js';
+import SPTransaction from '../models/SPTransaction.js';
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import PollRecord from '../models/PollRecord.js';
+import JourneyProgress from '../models/JourneyProgress.js';
+import JourneyPlan from '../models/JourneyPlan.js';
+
+const D = (y, m, d) => new Date(Date.UTC(y, m - 1, d));
+
+// Build a small SP ledger that ends exactly at `sp`, so the SP Bank has rows.
+function ledgerFor(email, sp, startDay) {
+  const rows = []; let bal = 0;
+  const push = (category, delta, reason, label, day) => {
+    bal += delta;
+    rows.push({ email, category, sessionLabel: label, deltaMode: 'absolute',
+      deltaValue: delta, appliedDelta: delta, balanceAfter: bal, reason, dateTime: D(2026, 7, day) });
+  };
+  // insert in strict chronological order so the running balance stays monotonic
+  push('initial', 100, 'Welcome bonus on joining Summership', '', startDay);
+  push('attendance', 10, 'Attendance credit — evening session', `${startDay + 1} Jul Evening`, startDay + 1);
+  push('poll', 5, 'Poll participation', `${startDay + 1} Jul Evening`, startDay + 1);
+  push('attendance', 10, 'Attendance credit — evening session', `${startDay + 2} Jul Evening`, startDay + 2);
+  push('attendance', 10, 'Attendance credit — evening session', `${startDay + 3} Jul Evening`, startDay + 3);
+  const diff = sp - bal;                        // final adjustment to land exactly on totalSp
+  if (diff !== 0) push('manual', diff, diff > 0 ? 'Instructor award' : 'Attendance shortfall adjustment', '', startDay + 3);
+  return rows;
+}
+
+// Build dummy Standup evidence (Zoom attendance + Spandan poll rows) so the Journey
+// "Standups" card shows real numbers. std = { sessions, minutes, pollsAttempted, pollsTotal }.
+// One AttendanceRecord + one PollRecord per session (PollRecord is a per-session
+// aggregate, unique on email+sessionLabel), with the poll questions spread evenly.
+function standupRecordsFor(email, studentId, std, startDay) {
+  const att = [], polls = [];
+  const spread = (total, n, i) => Math.floor(total / n) + (i < total % n ? 1 : 0);
+  for (let i = 0; i < std.sessions; i++) {
+    const label = `${startDay + i} Jul Evening`;
+    att.push({ email, studentId, sessionLabel: label, attendedMinutes: std.minutes,
+      totalSessionMinutes: 90, attendancePercentage: Math.round(std.minutes / 90 * 100), qualified: std.minutes >= 68 });
+    const tot = spread(std.pollsTotal, std.sessions, i);
+    const done = Math.min(tot, spread(std.pollsAttempted, std.sessions, i));
+    polls.push({ email, studentId, sessionLabel: label, totalQuestions: tot,
+      attemptedQuestions: done, missedQuestions: tot - done, responses: [] });
+  }
+  return { att, polls };
+}
+
+// name, email, start, sp, prog (per ViBe course), std (standups), spa/proj (placeholder), plan
+const DUMMY = [
+  { name: 'Aadhya Rao (dummy)',  email: 'aadhya.vibe@dummy.test', start: D(2026,7,16), sp: 300,
+    prog: { onboarding:{pct:100}, ai:{pct:40, weekHours:1.5}, mern:{pct:0} },
+    std: { sessions:5, minutes:82, pollsAttempted:8, pollsTotal:10 },
+    spa: { spaSolved:18, spaPoints:220 }, proj: { prsRaised:2, prsMerged:1 },
+    plan: { vibeBy: D(2026,8,20), spaBy: D(2026,9,5), projectBy: D(2026,8,28) } },
+  { name: 'Vihaan Menon (dummy)', email: 'vihaan.vibe@dummy.test', start: D(2026,7,17), sp: 150,
+    prog: { onboarding:{pct:100}, ai:{pct:10, weekHours:0.5}, mern:{pct:0} },
+    std: { sessions:3, minutes:64, pollsAttempted:3, pollsTotal:8 },
+    spa: { spaSolved:6, spaPoints:70 }, proj: { prsRaised:0, prsMerged:0 },
+    plan: { vibeBy: D(2026,9,1), spaBy: null, projectBy: null } },
+  { name: 'Diya Nair (dummy)',    email: 'diya.vibe@dummy.test',   start: D(2026,7,18), sp: 120,
+    prog: { onboarding:{pct:60, weekHours:1.2}, ai:{pct:0}, mern:{pct:0} },
+    std: { sessions:4, minutes:78, pollsAttempted:5, pollsTotal:6 },
+    spa: { spaSolved:2, spaPoints:20 }, proj: { prsRaised:0, prsMerged:0 },
+    plan: { vibeBy: null, spaBy: null, projectBy: null } },
+  { name: 'Arjun Iyer (dummy)',   email: 'arjun.vibe@dummy.test',  start: D(2026,7,20), sp: 500,
+    prog: { onboarding:{pct:100}, ai:{pct:100}, mern:{pct:20, weekHours:2} },
+    std: { sessions:6, minutes:88, pollsAttempted:11, pollsTotal:12 },
+    spa: { spaSolved:41, spaPoints:530 }, proj: { prsRaised:5, prsMerged:4 },
+    plan: { vibeBy: D(2026,8,10), spaBy: D(2026,8,25), projectBy: D(2026,8,15) } },
+  { name: 'Kabir Shah (dummy)',   email: 'kabir.vibe@dummy.test',  start: D(2026,7,22), sp: 200,
+    prog: { onboarding:{pct:100}, ai:{prior:true}, mern:{pct:5, weekHours:1} },
+    std: { sessions:2, minutes:71, pollsAttempted:2, pollsTotal:4 },
+    spa: { spaSolved:9, spaPoints:110 }, proj: { prsRaised:1, prsMerged:0 },
+    plan: { vibeBy: D(2026,8,31), spaBy: D(2026,9,10), projectBy: null } }
+];
+
+async function main() {
+  await mongoose.connect(MONGO_URI);
+  const emails = DUMMY.map(d => d.email);
+  await Promise.all([
+    Commitment.deleteMany({ email: { $in: emails } }),
+    VibeProgress.deleteMany({ email: { $in: emails } }),
+    SPTransaction.deleteMany({ email: { $in: emails } }),
+    AttendanceRecord.deleteMany({ email: { $in: emails } }),
+    PollRecord.deleteMany({ email: { $in: emails } }),
+    JourneyProgress.deleteMany({ email: { $in: emails } }),
+    JourneyPlan.deleteMany({ email: { $in: emails } })
+  ]);
+
+  for (const d of DUMMY) {
+    await Student.updateOne(
+      { email: d.email },
+      { $set: {
+          name: d.name, email: d.email, internshipStartDate: d.start,
+          status: 'active', totalSp: d.sp, highestSpEver: d.sp,
+          level: 1, trophyLeague: 'Bronze II', leaderboardGroup: '2026-07-16'
+        } },
+      { upsert: true }
+    );
+    const stu = await Student.findOne({ email: d.email }).lean();
+    for (const [course, p] of Object.entries(d.prog)) {
+      await VibeProgress.updateOne(
+        { email: d.email, course },
+        { $set: { pct: p.pct ?? 0, weekHours: p.weekHours ?? 0, priorCompleted: !!p.prior } },
+        { upsert: true }
+      );
+    }
+    await SPTransaction.insertMany(ledgerFor(d.email, d.sp, d.start.getUTCDate()));
+
+    // Standups — attendance + poll evidence for the Journey card
+    const { att, polls } = standupRecordsFor(d.email, stu._id, d.std, d.start.getUTCDate());
+    if (att.length) await AttendanceRecord.insertMany(att);
+    if (polls.length) await PollRecord.insertMany(polls);
+
+    // SPA + Projects placeholder progress, and the self-declared plan
+    await JourneyProgress.updateOne({ email: d.email },
+      { $set: { spaSolved: d.spa.spaSolved, spaTotal: 53, spaPoints: d.spa.spaPoints,
+                prsRaised: d.proj.prsRaised, prsMerged: d.proj.prsMerged } }, { upsert: true });
+    await JourneyPlan.updateOne({ email: d.email },
+      { $set: { vibeBy: d.plan.vibeBy, spaBy: d.plan.spaBy, projectBy: d.plan.projectBy } }, { upsert: true });
+  }
+
+  // A little settled history so the "Past" tables aren't empty.
+  await Commitment.create({
+    email: 'aadhya.vibe@dummy.test', type: 'vibe', debited: true,
+    course: 'ai', goalPct: 20, baselinePct: 20,
+    deadline: D(2026,7,18), stake: 100, multiplier: 2,
+    potentialWin: 200, potentialLoss: 100, reserved: 0,
+    label: '+20% Fundamentals of AI (stake 100 @ 2×)',
+    status: 'won', resultDelta: 200, settledAt: D(2026,7,18)
+  });
+  // A settled standup commitment for Arjun (keep-the-stake: HIT credited the +150 bonus).
+  await Commitment.create({
+    email: 'arjun.vibe@dummy.test', type: 'standup', debited: false, reserved: 0,
+    stake: 50, multiplier: 3, potentialWin: 150, potentialLoss: 75,
+    tier: '91-100', tierFloor: 91, sessionsTarget: 6,
+    label: 'Attend all 6 standups @ 91–100% (3×)',
+    deadline: D(2026,7,19), status: 'won', resultDelta: 150, settledAt: D(2026,7,19)
+  });
+
+  console.log(`Seeded ${DUMMY.length} dummy 16-July students:`);
+  DUMMY.forEach(d => console.log(`  ${d.email}  (start ${d.start.toISOString().slice(0,10)}, ${d.sp} SP)`));
+  await mongoose.disconnect();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,10 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import Commitment from './models/Commitment.js';
+import { isVibeEligible, buildVibeState, validateBet, settleBetDemo, applySpDelta, courseByKey } from './services/vibe.js';
+import { buildStandupState, placeStandup, settleStandupDemo } from './services/standup.js';
+import { buildJourneyState, saveJourneyPlan } from './services/journey.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -225,7 +229,8 @@ async function studentPayload(student) {
       leaderboardGroup: myGroup,
       leaderboardGroupLabel: groupLabel(myGroup),
       surveyCompleted: Boolean(student.surveyCompleted),
-      poll2Completed: Boolean(student.poll2Completed)
+      poll2Completed: Boolean(student.poll2Completed),
+      eligibleForVibeGoals: isVibeEligible(student)
     },
     transactions,
     polls,
@@ -268,6 +273,120 @@ api.get('/me', async (req, res) => {
   if (!student) return res.status(404).json({ authenticated: false, error: 'Student not found' });
   if (student.status === 'excused') return res.json({ authenticated: true, ...excusedPayload(student) });
   res.json({ authenticated: true, profile: await studentPayload(student) });
+});
+
+// ---- ViBe Goals (commitment-SP module; 16 July cohort onward) ----------------
+async function vibeStudent(req) {
+  const email = normalizeEmail(req.body?.email || req.query.email) || await studentEmailFromRequest(req);
+  if (!email) return null;
+  return Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+}
+
+api.get('/vibe/state', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  if (!isVibeEligible(student)) return res.json({ eligible: false });
+  res.json(await buildVibeState(student));
+});
+
+api.post('/vibe/bet', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student || !isVibeEligible(student)) return res.status(403).json({ error: 'Not eligible for ViBe Goals.' });
+  const { course, goalPct, stake, multiplier, deadline } = req.body || {};
+  const state = await buildVibeState(student);
+  const v = validateBet({ state, course, goalPct: +goalPct, stake: +stake, multiplier: +multiplier, deadline });
+  if (v.errs.length) return res.status(400).json({ error: v.errs.join(' ') });
+  const c = courseByKey(course);
+  // debit the stake now (the "cost of the bet"), visible in the SP Bank
+  await applySpDelta(student.email, -(+stake),
+    `Staked ${stake} SP on ViBe goal: +${goalPct}% ${c ? c.name : course} (${multiplier}×)`);
+  await Commitment.create({
+    email: student.email, type: 'vibe', debited: true,
+    course, goalPct: +goalPct, baselinePct: v.baselinePct,
+    deadline: new Date(deadline), stake: +stake, multiplier: +multiplier,
+    potentialWin: v.win, potentialLoss: v.loss, reserved: v.loss, status: 'active',
+    label: `+${goalPct}% ${c ? c.name : course} (stake ${stake} @ ${multiplier}×)`
+  });
+  const fresh = await Student.findOne({ email: student.email }).lean();
+  res.json(await buildVibeState(fresh));
+});
+
+api.put('/vibe/bet/:id', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student || !isVibeEligible(student)) return res.status(403).json({ error: 'Not eligible.' });
+  const bet = await Commitment.findOne({ _id: req.params.id, email: student.email, type: 'vibe', status: 'active' });
+  if (!bet) return res.status(404).json({ error: 'No active bet to edit.' });
+  const { goalPct, stake, multiplier } = req.body || {};   // deadline & course are NOT editable
+  const state = await buildVibeState(student);
+  const v = validateBet({ state, course: bet.course, goalPct: +goalPct, stake: +stake, multiplier: +multiplier, ignoreActive: true });
+  if (v.errs.length) return res.status(400).json({ error: v.errs.join(' ') });
+  // reconcile the already-debited stake: refund the difference (old − new)
+  const stakeDiff = bet.stake - (+stake);
+  if (stakeDiff !== 0) {
+    const c = courseByKey(bet.course);
+    await applySpDelta(student.email, stakeDiff,
+      `ViBe goal edited — stake ${bet.stake}→${stake} on +${goalPct}% ${c ? c.name : bet.course}`);
+  }
+  Object.assign(bet, { goalPct: +goalPct, stake: +stake, multiplier: +multiplier,
+    potentialWin: v.win, potentialLoss: v.loss, reserved: v.loss });
+  await bet.save();
+  const fresh = await Student.findOne({ email: student.email }).lean();
+  res.json(await buildVibeState(fresh));
+});
+
+// DEMO: resolve a bet (no live settlement cron locally). result = 'won' | 'lost'.
+api.post('/vibe/bet/:id/settle', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  const bet = await Commitment.findOne({ _id: req.params.id, email: student.email, type: 'vibe', status: 'active' });
+  if (!bet) return res.status(404).json({ error: 'No active bet.' });
+  const result = req.body?.result === 'lost' ? 'lost' : 'won';
+  await settleBetDemo(bet, result);
+  const fresh = await Student.findOne({ email: student.email }).lean();
+  res.json(await buildVibeState(fresh));
+});
+
+// ---- Standup commitments (weekly, attendance-only; keep-the-stake) -----------
+api.get('/standup/state', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  if (!isVibeEligible(student)) return res.json({ eligible: false });
+  res.json(await buildStandupState(student));
+});
+
+api.post('/standup/commit', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student || !isVibeEligible(student)) return res.status(403).json({ error: 'Not eligible for standup commitments.' });
+  const { tierKey, multiplier } = req.body || {};
+  const r = await placeStandup(student, { tierKey, multiplier });
+  if (r.error) return res.status(400).json({ error: r.error });
+  res.json(await buildStandupState(student));
+});
+
+// DEMO: resolve a standup commitment (no live weekly settlement cron yet).
+api.post('/standup/commit/:id/settle', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  const c = await Commitment.findOne({ _id: req.params.id, email: student.email, type: 'standup', status: 'active' });
+  if (!c) return res.status(404).json({ error: 'No active standup commitment.' });
+  await settleStandupDemo(c, req.body?.result === 'lost' ? 'lost' : 'won');
+  const fresh = await Student.findOne({ email: student.email }).lean();
+  res.json(await buildStandupState(fresh));
+});
+
+// ---- My Journey (phase-by-phase progress + SP; 16 July cohort onward) ---------
+api.get('/journey/state', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  if (!isVibeEligible(student)) return res.json({ eligible: false });
+  res.json(await buildJourneyState(student));
+});
+
+api.put('/journey/plan', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student || !isVibeEligible(student)) return res.status(403).json({ error: 'Not eligible for My Journey.' });
+  await saveJourneyPlan(student.email, req.body || {});
+  res.json(await buildJourneyState(student));
 });
 
 api.get('/search', async (req, res) => {

--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -1,0 +1,95 @@
+// "My Journey" — the unified phase-by-phase progress + SP view (16 July cohort).
+// Four phases: (1) Standups = Zoom attendance + Spandan polls, (2) ViBe = 3 courses,
+// (3) SPA = Matrix Mystics 53 problems, (4) Projects = PRs.
+//
+// SP attribution per phase:
+//   - Standups: ALREADY awarded (attendance + poll SPTransactions) — we just aggregate.
+//   - ViBe:     net SP from settled commitments (+ the weekly floor) — from the ViBe module.
+//   - SPA / Projects: rule TBD until Samagama data lands — shown as "coming soon" (sp = 0).
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import PollRecord from '../models/PollRecord.js';
+import SPTransaction from '../models/SPTransaction.js';
+import Commitment from '../models/Commitment.js';
+import JourneyPlan from '../models/JourneyPlan.js';
+import JourneyProgress from '../models/JourneyProgress.js';
+import { buildVibeState } from './vibe.js';
+
+export const SPA_TOTAL = 53;
+
+export async function buildJourneyState(student) {
+  const email = student.email;
+
+  // --- Phase 1: Standups (attendance + Spandan polls) — existing SP, aggregated ---
+  const [att, polls, txns] = await Promise.all([
+    AttendanceRecord.find({ email }).lean(),
+    PollRecord.find({ email }).lean(),
+    SPTransaction.find({ email }).lean()
+  ]);
+  const spByCat = cats => txns
+    .filter(t => cats.includes(t.category))
+    .reduce((a, t) => a + (t.appliedDelta || 0), 0);
+  const standups = {
+    zoomMinutes: att.reduce((a, r) => a + (r.attendedMinutes || 0), 0),
+    sessionsAttended: att.filter(r => (r.attendedMinutes || 0) > 0).length,
+    pollSessions: polls.length,
+    pollsAttempted: polls.reduce((a, p) => a + (p.attemptedQuestions || 0), 0),
+    pollsTotal: polls.reduce((a, p) => a + (p.totalQuestions || 0), 0),
+    spAttendance: spByCat(['attendance']),
+    spPolls: spByCat(['poll'])
+  };
+  standups.sp = standups.spAttendance + standups.spPolls;
+
+  // --- Phase 2: ViBe (3 courses) — summarise the commitment module ---
+  const v = await buildVibeState(student);
+  const settled = await Commitment.find({ email, type: 'vibe', status: { $in: ['won', 'lost'] } }).lean();
+  const vibe = {
+    ladder: v.ladder,
+    current: v.current,
+    clearedCount: v.ladder.filter(l => l.cleared).length,
+    totalCourses: v.ladder.length,
+    activeCommitment: v.active
+      ? { course: v.active.course, goalPct: v.active.goalPct, deadline: v.active.deadline }
+      : null,
+    settledCount: settled.length,
+    sp: settled.reduce((a, b) => a + (b.resultDelta || 0), 0)  // net SP from settled commitments
+  };
+
+  // --- Phase 3 & 4: SPA + Projects — PLACEHOLDER (Samagama data + SP rule TBD) ---
+  const jp = (await JourneyProgress.findOne({ email }).lean()) || {};
+  const spa = {
+    solved: jp.spaSolved || 0,
+    total: jp.spaTotal || SPA_TOTAL,
+    spaPoints: jp.spaPoints || 0,
+    sp: 0, pending: true              // SP rule decided once Samagama data arrives
+  };
+  const projects = {
+    prsRaised: jp.prsRaised || 0,
+    prsMerged: jp.prsMerged || 0,
+    sp: 0, pending: true              // SP rule decided once Samagama data arrives
+  };
+
+  const plan = await JourneyPlan.findOne({ email }).lean();
+
+  return {
+    eligible: true,
+    name: student.name,
+    totalSp: student.totalSp || 0,
+    plan: {
+      vibeBy: plan?.vibeBy || null,
+      spaBy: plan?.spaBy || null,
+      projectBy: plan?.projectBy || null
+    },
+    phaseSp: { standups: standups.sp, vibe: vibe.sp, spa: spa.sp, projects: projects.sp },
+    standups, vibe, spa, projects
+  };
+}
+
+// Upsert the student's self-declared plan dates. Only the three date fields are set.
+export async function saveJourneyPlan(email, { vibeBy, spaBy, projectBy }) {
+  const set = {};
+  const parse = d => (d ? new Date(d) : null);
+  set.vibeBy = parse(vibeBy);
+  set.spaBy = parse(spaBy);
+  set.projectBy = parse(projectBy);
+  await JourneyPlan.updateOne({ email }, { $set: set }, { upsert: true });
+}

--- a/server/services/standup.js
+++ b/server/services/standup.js
@@ -1,0 +1,114 @@
+// Standup commitment — a WEEKLY, attendance-only pledge (polls stay as poll-points).
+// The student pledges to attend ALL of this week's standups at a chosen attendance
+// tier, with a confidence multiplier. "Keep-the-stake" economics: the stake is NOT
+// debited (it represents the attendance points you earn that week); a HIT pays a
+// +stake×mult bonus on top of your earned attendance, a MISS charges −0.5×stake×mult.
+//
+// Anti-mining: the tier floor is ≥81% and the pledge is the FULL week — you can't
+// farm SP by pledging a low bar or a single session.
+import Student from '../models/Student.js';
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import Commitment from '../models/Commitment.js';
+import { applySpDelta } from './vibe.js';
+
+export const STANDUP = {
+  sessionsPerWeek: 6,           // Y — standups scheduled per week (6/6)
+  multipliers: [2, 3, 4],
+  penaltyFactor: 0.5,
+  // Two attendance tiers. Higher tier = higher bar (≥91%) and a larger stake cap,
+  // to nudge students toward consistent 91–100% attendance.
+  tiers: [
+    { key: '81-90',  label: '81–90%',  floor: 81, stake: 20 },
+    { key: '91-100', label: '91–100%', floor: 91, stake: 50 }
+  ]
+};
+
+export const tierByKey = k => STANDUP.tiers.find(t => t.key === k);
+
+// Current calendar week, Monday 00:00 → Sunday 23:59:59 (local server time).
+function weekWindow(now = new Date()) {
+  const start = new Date(now); start.setHours(0, 0, 0, 0);
+  const dow = (start.getDay() + 6) % 7;           // 0 = Monday
+  start.setDate(start.getDate() - dow);
+  const end = new Date(start); end.setDate(end.getDate() + 6); end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+const fmt = d => d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+
+export async function buildStandupState(student) {
+  const email = student.email;
+  const { start, end } = weekWindow();
+
+  // Attendance already logged this week (informational — the demo settles by button).
+  const wk = await AttendanceRecord.find({ email }).lean();
+  const thisWeek = wk.filter(r => r.createdAt && new Date(r.createdAt) >= start && new Date(r.createdAt) <= end);
+  const attendedThisWeek = thisWeek.filter(r => (r.attendedMinutes || 0) > 0).length;
+  const avgPctThisWeek = attendedThisWeek
+    ? Math.round(thisWeek.reduce((a, r) => a + (r.attendancePercentage || 0), 0) / attendedThisWeek)
+    : null;
+
+  const commits = await Commitment.find({ email, type: 'standup' }).sort({ createdAt: -1 }).lean();
+  const active = commits.find(c => c.status === 'active') || null;
+  const history = commits.filter(c => c.status !== 'active');
+  const reserved = active ? active.reserved : 0;
+  const available = Math.max(0, (student.totalSp || 0) - reserved);
+
+  return {
+    eligible: true,
+    name: student.name,
+    weekLabel: `${fmt(start)} – ${fmt(end)}`,
+    deadline: end,
+    sessionsThisWeek: STANDUP.sessionsPerWeek,
+    attendedThisWeek, avgPctThisWeek,
+    tiers: STANDUP.tiers, multipliers: STANDUP.multipliers, penaltyFactor: STANDUP.penaltyFactor,
+    totalSp: student.totalSp || 0, available,
+    active, history
+  };
+}
+
+// Validate a standup pledge. Stake is FIXED at the tier cap (not chosen). Returns
+// { errs, win, loss, stake, tier, deadline, label }.
+export function validateStandup({ state, tierKey, multiplier }) {
+  const errs = [];
+  const tier = tierByKey(tierKey);
+  if (!tier) errs.push('Pick an attendance tier.');
+  if (!STANDUP.multipliers.includes(multiplier)) errs.push('Invalid confidence multiplier.');
+  if (state.active) errs.push('You already have an active standup commitment this week.');
+
+  const stake = tier ? tier.stake : 0;
+  const win = stake * multiplier;
+  const loss = STANDUP.penaltyFactor * stake * multiplier;
+  // Keep-the-stake: nothing is debited now, but a MISS charges the penalty — so the
+  // student must be able to cover the potential loss (SP never goes negative).
+  if (loss > state.available) {
+    errs.push(`You need ${loss} SP free to cover a possible miss (−${loss}); you have ${state.available}.`);
+  }
+  const label = tier ? `Attend all ${state.sessionsThisWeek} standups @ ${tier.label} (${multiplier}×)` : '';
+  return { errs, win, loss, stake, tier, deadline: state.deadline, label };
+}
+
+export async function placeStandup(student, { tierKey, multiplier }) {
+  const state = await buildStandupState(student);
+  const v = validateStandup({ state, tierKey, multiplier: +multiplier });
+  if (v.errs.length) return { error: v.errs.join(' ') };
+  const { start, end } = weekWindow();
+  await Commitment.create({
+    email: student.email, type: 'standup', debited: false, reserved: 0,
+    stake: v.stake, multiplier: +multiplier, potentialWin: v.win, potentialLoss: v.loss,
+    tier: v.tier.key, tierFloor: v.tier.floor, sessionsTarget: state.sessionsThisWeek,
+    weekStart: start, weekEnd: end, deadline: end, label: v.label, status: 'active'
+  });
+  return { ok: true };
+}
+
+// DEMO: resolve a standup commitment (no live weekly settlement cron yet). Keep-the-
+// stake: a HIT credits +potentialWin, a MISS debits −potentialLoss. No prior debit to
+// reconcile. In production this is judged automatically at week's end:
+//   HIT  ⇔  sessions attended ≥ target  AND  average attendance % ≥ tier floor.
+export async function settleStandupDemo(commitment, result) {
+  const delta = result === 'won' ? commitment.potentialWin : -commitment.potentialLoss;
+  await applySpDelta(commitment.email, delta,
+    `Standup goal ${result === 'won' ? 'HIT' : 'MISS'}: ${commitment.label}`);
+  await Commitment.updateOne({ _id: commitment._id },
+    { $set: { status: result, resultDelta: delta, settledAt: new Date() } });
+}

--- a/server/services/vibe.js
+++ b/server/services/vibe.js
@@ -1,0 +1,149 @@
+// ViBe Commitment-SP module logic (16 July cohort onward).
+// Config + eligibility + state builder + bet validation + demo settlement.
+// Progress here comes from VibeProgress (dummy locally; ViBe API in production).
+import Student from '../models/Student.js';
+import VibeProgress from '../models/VibeProgress.js';
+import Commitment from '../models/Commitment.js';
+import SPTransaction from '../models/SPTransaction.js';
+
+export const ELIGIBILITY_CUTOFF = new Date('2026-07-16T00:00:00.000Z');
+
+// Progressive ladder order: Onboarding -> AI -> MERN.
+export const COURSES = [
+  { key: 'onboarding', name: 'Onboarding',          hours: 10, courseId: '6a14258a4fa5339bade5d732', versionId: '6a14258a4fa5339bade5d733' },
+  { key: 'ai',         name: 'Fundamentals of AI',  hours: 6,  courseId: '6a055c4c79eef782c2548388', versionId: '6a055c4c79eef782c2548389' },
+  { key: 'mern',       name: 'MERN Stack',          hours: 10, courseId: '6a0ec8254658465536acb121', versionId: '6a0ec8254658465536acb122' }
+];
+
+export const CONFIG = {
+  stakeMin: 50, stakeMax: 200,
+  multipliers: [2, 3, 4], // 1x dropped: under stake-debit, a 1x hit only returns the stake (net 0)
+  penaltyFactor: 0.5,     // miss loses 0.5 * stake * multiplier
+  maxBetDays: 3,          // deadline window 1–3 days
+  floorHours: 1,          // 1 hour of content/week is mandatory
+  floorSp: 10             // flat SP for hitting the weekly floor
+};
+
+export function isVibeEligible(student) {
+  return Boolean(student?.internshipStartDate) &&
+         new Date(student.internshipStartDate) >= ELIGIBILITY_CUTOFF;
+}
+export const courseByKey = k => COURSES.find(c => c.key === k);
+export const floorPctFor = course => Math.round(CONFIG.floorHours / course.hours * 100);
+
+function daysFromToday(deadline) {
+  const t = new Date(); t.setHours(0, 0, 0, 0);
+  const d = new Date(deadline); d.setHours(0, 0, 0, 0);
+  return Math.round((d - t) / 86400000);
+}
+
+// Build the full student-facing ViBe state.
+export async function buildVibeState(student) {
+  const email = student.email;
+  const rows = await VibeProgress.find({ email }).lean();
+  const prog = {};
+  rows.forEach(r => { prog[r.course] = { pct: r.pct, week: r.weekHours, prior: !!r.priorCompleted }; });
+
+  const ladder = COURSES.map(c => {
+    const p = prog[c.key] || { pct: 0, week: 0, prior: false };
+    const pct = p.prior ? 100 : p.pct;
+    return { key: c.key, name: c.name, hours: c.hours, pct, prior: p.prior, cleared: p.prior || pct >= 100 };
+  });
+  const currentLadder = ladder.find(l => !l.cleared) || null;
+  const currentCourse = currentLadder ? courseByKey(currentLadder.key) : null;
+
+  const bets = await Commitment.find({ email, type: 'vibe' }).sort({ createdAt: -1 }).lean();
+  const active = bets.find(b => b.status === 'active') || null;
+  const history = bets.filter(b => b.status !== 'active');
+  const reserved = active ? active.reserved : 0;
+  const available = Math.max(0, (student.totalSp || 0) - reserved);
+
+  const current = currentLadder ? {
+    key: currentLadder.key,
+    name: currentLadder.name,
+    pct: currentLadder.pct,
+    hours: currentLadder.hours,
+    floorPct: floorPctFor(currentCourse),
+    remaining: 100 - currentLadder.pct,
+    weekHours: prog[currentLadder.key]?.week ?? 0
+  } : null;
+
+  return {
+    eligible: true,
+    name: student.name,
+    totalSp: student.totalSp || 0,
+    available, reserved,
+    ladder, current,
+    weeklyFloor: current
+      ? { requiredHours: CONFIG.floorHours, doneHours: current.weekHours, met: current.weekHours >= CONFIG.floorHours, sp: CONFIG.floorSp }
+      : null,
+    active, history,
+    config: CONFIG
+  };
+}
+
+// Validate a place/edit request against the locked rules. Returns { errs, win, loss, baselinePct }.
+export function validateBet({ state, course, goalPct, stake, multiplier, deadline, ignoreActive = false }) {
+  const errs = [];
+  const c = courseByKey(course);
+  if (!c) errs.push('Unknown course.');
+  if (!state.current || state.current.key !== course) errs.push('You can only bet on your current course.');
+  if (!ignoreActive && state.active) errs.push('You already have an active bet.');
+  if (!CONFIG.multipliers.includes(multiplier)) errs.push('Invalid multiplier.');
+  if (!(stake >= CONFIG.stakeMin && stake <= CONFIG.stakeMax)) errs.push(`Stake must be ${CONFIG.stakeMin}–${CONFIG.stakeMax} SP.`);
+
+  const floorPct = c ? floorPctFor(c) : 0;
+  const remaining = state.current ? state.current.remaining : 0;
+  if (goalPct <= floorPct) errs.push(`Goal must beat the weekly floor (${floorPct}%).`);
+  if (goalPct > remaining) errs.push(`Goal exceeds your remaining ${remaining}%.`);
+
+  if (deadline !== undefined) {
+    const days = daysFromToday(deadline);
+    if (days < 1 || days > CONFIG.maxBetDays) errs.push(`Deadline must be 1–${CONFIG.maxBetDays} days out.`);
+  }
+
+  const loss = CONFIG.penaltyFactor * stake * multiplier;
+  const win = stake * multiplier;
+  // The stake is debited up-front; a miss debits the penalty on top. So you must
+  // be able to cover BOTH (worst case = stake + loss). When editing, this bet's
+  // already-debited stake and reserved penalty are unwound first.
+  const avail = state.available + (ignoreActive && state.active ? state.active.reserved + state.active.stake : 0);
+  const need = stake + loss;
+  if (need > avail) {
+    errs.push(`You need ${need} SP to place this (stake ${stake} + up to ${loss} loss); you have ${avail}.`);
+  }
+  return { errs, win, loss, baselinePct: state.current ? state.current.pct : 0 };
+}
+
+// Apply an SP change AND write a matching SP-Bank transaction so the student sees
+// it. Stamps the entry after the latest one so the running balance stays ordered
+// (dummy seed dates can be future-ish). Returns the new balance.
+export async function applySpDelta(email, delta, reason) {
+  const student = await Student.findOne({ email });
+  const newTotal = (student.totalSp || 0) + delta;
+  student.totalSp = newTotal;
+  if (newTotal > (student.highestSpEver || 0)) student.highestSpEver = newTotal;
+  await student.save();
+  const last = await SPTransaction.findOne({ email }).sort({ dateTime: -1 }).lean();
+  const when = new Date(Math.max(Date.now(), (last?.dateTime ? new Date(last.dateTime).getTime() + 60000 : 0)));
+  await SPTransaction.create({
+    email, studentId: student._id, category: 'manual', sessionLabel: '',
+    deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: newTotal, reason, dateTime: when
+  });
+  return newTotal;
+}
+
+// DEMO ONLY: resolve a bet (there is no live settlement cron locally). The stake
+// was already debited at placement; here we apply the win (credit) or the miss
+// penalty (debit), advance progress, and mark the bet.
+export async function settleBetDemo(bet, result) {
+  const course = courseByKey(bet.course);
+  const label = `+${bet.goalPct}% ${course ? course.name : bet.course} (stake ${bet.stake} @ ${bet.multiplier}×)`;
+  const delta = result === 'won' ? bet.potentialWin : -bet.potentialLoss;
+  await applySpDelta(bet.email, delta, `ViBe goal ${result === 'won' ? 'HIT' : 'MISS'}: ${label}`);
+  const newPct = result === 'won'
+    ? Math.min(100, bet.baselinePct + bet.goalPct)
+    : Math.min(100, bet.baselinePct + Math.floor(bet.goalPct * 0.6)); // fell short of goal
+  await VibeProgress.updateOne({ email: bet.email, course: bet.course }, { $set: { pct: newPct } }, { upsert: true });
+  await Commitment.updateOne({ _id: bet._id }, { $set: { status: result, resultDelta: delta, settledAt: new Date() } });
+}


### PR DESCRIPTION
## What this adds

A unified **My Journey** tab and a **Commitments** hub for the 16-July Summership cohort, built on a shared commitment engine.

### My Journey tab
Phase-by-phase progress + SP in one view — four cards (**Standups / ViBe / SPA / Projects**) plus a self-declared **internship plan** (target dates per phase).
- **Standups**: surfaces existing Zoom minutes + attendance/poll SP (no new rule).
- **ViBe**: ladder + SP from settled commitments.
- **SPA (Matrix Mystics 53) / Projects (PRs)**: progress shown, SP marked "coming soon" — placeholder data (`JourneyProgress`) to be sourced from Samagama, with the SP rule decided once that data lands.

### Commitments hub (accordion, one card per phase)
Shared **`Commitment`** model (`type: vibe | standup`) with a stake-and-settle engine. One active commitment per phase.
- **ViBe** (migrated onto the shared model): pledge to raise course completion by X%, stake debited on placement.
- **Standup** (new): weekly, attendance-only, **keep-the-stake** — pledge to attend all 6 of the week's standups at tier **81–90% (stake 20)** or **91–100% (stake 50)**, confidence **2×/3×/4×**. HIT pays `+stake × conf` on top of earned attendance; MISS charges `−0.5 × stake × conf`. Anti-mining: tier floor ≥81%, full-week pledge, cover rule.

## New files
`server/models/Commitment.js`, `JourneyPlan.js`, `JourneyProgress.js`, `VibeProgress.js`; `server/services/vibe.js`, `journey.js`, `standup.js`; `server/scripts/seedVibeDummy.js`.

## Notes
- Gated on the existing `eligibleForVibeGoals` flag (`internshipStartDate >= 2026-07-16`), so pre-16-July students don't see it.
- Demo **Hit/Miss** buttons stand in for the not-yet-built weekly settlement cron.
- Replaces the old `VibeBet` model (removed) with the shared `Commitment` model.

## Production TODO (not in this PR)
- Weekly ViBe-snapshot cron into `VibeProgress` + automatic deadline-settlement job.
- SPA/Projects data ingestion from Samagama + their SP rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
