### PR TITLE
feat: Daily streak score - incentivise consistent attendance with Mon-Sat streak logic

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,6 +75,19 @@ status: 'pending' | 'accepted' | 'rejected',
 reviewedBy, reviewedAt, transactionId
 ```
 
+### streaks
+```
+email (unique, indexed), studentId (ref Student, indexed),
+currentStreak (default: 0), longestStreak (default: 0),
+heartsRemaining (default: 2), heartsUsed (default: 0),
+lastQualifyingDate (string), lastProcessedDate (string),
+streakStartDate (Date), totalStreakSp (default: 0),
+lastHeartUseDate (string),
+history: [{ date: string, sp: number, type: 'daily' | 'milestone' | 'heart_save' }],
+timestamps
+```
+Index on `currentStreak: -1` for leaderboard sorting.
+
 ## Architecture — two halves
 
 1. **Web app (this repo, `server/` + `client/`)** — Express API + React SPA,
@@ -135,6 +148,158 @@ scoring — the `pipeline/` rubric is authoritative. The old Zoom ±5 ingest
 - `GET /api/admin/chat-sp-reviews` — pending reviews
 - `POST /api/admin/chat-sp-reviews/:id/accept` — award SP
 - `POST /api/admin/chat-sp-reviews/:id/reject` — reject
+- `GET /api/admin/streaks` — list all streak documents (sort, limit)
+- `POST /api/admin/streak/process-all` — trigger daily streak processing for all students
+
+## Streak Score Feature
+
+### What it is
+The Streak Score incentivises daily attendance consistency. Students earn bonus SP
+for attending sessions on consecutive days (Mon–Sat). Sundays are excluded — they
+do **not** count as streak days and do **not** break streaks.
+
+### Eligibility
+- Only students whose `internshipStartDate` is **on or after 2026-07-16** are
+  eligible. Students who started earlier get no streak processing at all.
+- Students with `status: 'excused'` are excluded.
+
+### How qualification works (per day)
+A student qualifies for a streak day if **at least one session** on that date has
+**both**:
+1. `attendancePercentage >= 85%` (from `attendancerecords`)
+2. `poll participation >= 85%` (from `pollrecords`)
+
+If no `attendancerecords` exist (dev / pre-pipeline), the system falls back to
+`sptransactions`: `appliedDelta >= 10` (which implies >= 90%) satisfies the 85%
+threshold.
+
+### SP rewards
+| Streak day | SP earned |
+|-----------|-----------|
+| Days 1–9 | 1 SP/day |
+| Day 10 (milestone) | 5 SP |
+| Days 11–19 | 1 SP/day |
+| Day 20 (milestone) | 7 SP |
+| Days 21–29 | 1 SP/day |
+| Day 30 (milestone) | 9 SP |
+| Days 31+ | 2 SP/day |
+| Day 40 (milestone) | 11 SP |
+| Every 10th day after 30 | +2 more than previous milestone |
+
+**Milestone formula:** `3 + (streakDay / 10) * 2`
+
+### Hearts (streak savers)
+Each student starts with **2 hearts**. If a day is missed, a heart is consumed to
+preserve the streak. Hearts are **not** used during backfill. Losing both hearts
+resets the streak to 0.
+
+When a heart is used, `lastQualifyingDate` is updated to the heart-saved date,
+resetting the gap counter so consecutive hearts work correctly.
+
+### Gap logic (Sunday-aware)
+The `isConsecutiveGap` check uses `nextWeekday()` instead of `addDays(..., 1)`.
+This means if the last qualifying date was Friday, the expected next qualifying
+day is Monday (skipping Sunday). A student who qualifies on Friday, misses
+Saturday (heart), and misses Monday (heart) can use both hearts without breaking
+the streak.
+
+### API endpoints
+| Method | Route | Auth | Description |
+|--------|-------|------|-------------|
+| `GET` | `/api/streak` | Student (cookie) | Returns streak status for the logged-in student |
+| `POST` | `/api/streak/claim` | Student (cookie) | Manually claim streak SP from the dashboard |
+| `GET` | `/api/admin/streaks` | Admin guard | List all streak documents, sorted and limited |
+| `POST` | `/api/admin/streak/process-all` | Admin guard | Trigger daily streak processing for all students on a given date |
+
+Streak data is also embedded in the profile response (`profile.streak`).
+
+### Cron job — `server/cron/streakDaily.js`
+Standalone Node script using the raw MongoDB driver (not Mongoose). Designed to
+run daily after the main SP pipeline completes.
+
+**Environment variables:**
+- `MONGO_URI` — from `.env` (same DB as the web app)
+- `DATE=YYYY-MM-DD` — process a specific date (default: yesterday, IST-aware)
+- `DRY_RUN=1` — log results without writing to DB
+- `BACKFILL=1` — process from each student's start date (one-time setup)
+
+**Behaviour:**
+- Automatically skips Sundays (shifts target date to Saturday if needed)
+- Skips students whose `internshipStartDate` is before `STREAK_CUTOFF_DATE`
+- In backfill mode, skips Sundays in the date range
+- Uses `nextWeekday()` for gap logic (same as streakService.js)
+- Updates `lastQualifyingDate` on heart use (same as streakService.js)
+
+### Frontend
+- **`StreakCard`** — compact summary on the dashboard (current streak, hearts,
+  SP, next milestone, today status)
+- **`StreakDetail`** — full tab view with stats grid, "How it works" rules, and
+  recent history table
+- **Tab label:** "Streak" (second tab)
+- **CSS:** `client/src/styles.css` lines 1103–1176
+
+### Files involved
+| File | Purpose |
+|------|---------|
+| `server/config.js` | Threshold constants (85/85/2) + `STREAK_CUTOFF_DATE` |
+| `server/models/Streak.js` | Mongoose schema for `streaks` collection |
+| `server/services/streakService.js` | Core business logic (qualification, processing, claim, status) |
+| `server/cron/streakDaily.js` | Standalone daily cron script |
+| `server/server.js:1100-1144` | API routes + profile injection |
+| `server/models/SPTransaction.js` | `'streak'` in category enum |
+| `client/src/main.jsx:337-440` | `StreakCard` + `StreakDetail` React components |
+| `client/src/styles.css:1103-1176` | Streak CSS |
+| `server/services/__tests__/streakService.test.js` | 37 unit tests |
+
+### What the admin needs to do after merging
+
+#### 1. Pull and build on production server
+```bash
+cd /home/sakshi/spurti
+git pull origin main
+npm install
+npm --prefix client install && npm run build
+```
+
+#### 2. Restart the Express server
+```bash
+# Restart however the server is managed (pm2, systemd, etc.)
+pm2 restart spurti
+```
+The `streaks` collection is auto-created by MongoDB on first write — no manual
+DB migration needed.
+
+#### 3. One-time backfill (historical streak data)
+Run with `DRY_RUN=1` first to preview:
+```bash
+BACKFILL=1 DRY_RUN=1 node server/cron/streakDaily.js
+```
+Then run for real:
+```bash
+BACKFILL=1 node server/cron/streakDaily.js
+```
+This processes every active student with `internshipStartDate >= 2026-07-16`
+from their start date through yesterday. Students who started before the cutoff
+are automatically skipped.
+
+#### 4. Set up daily cron job
+Add to crontab (`crontab -e`) to run after the main SP pipeline each day:
+```
+# Streak processing — runs daily at 23:59 IST (18:59 UTC) after pipeline
+59 18 * * * cd /home/sakshi/spurti && node server/cron/streakDaily.js >> /home/sakshi/spurti/logs/streak.log 2>&1
+```
+The script automatically skips Sundays and students before the cutoff date.
+
+#### 5. Verify
+- Open `/spurti` as a student → streak card + "Streak" tab should appear
+- Admin: `GET /api/admin/streaks` → should return scored students
+- Admin: `POST /api/admin/streak/process-all` with `{ "date": "2026-07-17" }`
+  → manual trigger for a specific date
+
+#### No other action needed
+- No `.env` changes required (cron uses existing `MONGO_URI`)
+- No schema migration — Mongoose auto-creates the `streaks` collection
+- Frontend is built into `client/dist` and served as static files
 
 ## Auth — `chatengine_token` cookie passthrough (LIVE since 2026-06-29)
 Spurti lives at `samagama.in/spurti` (same domain as Samagama), so the browser

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -278,9 +278,11 @@ function StudentView({ profile, onBack }) {
         <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
       <LevelStatus student={student} />
+      <StreakCard streak={profile.streak} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['streak','Streak'], ['polls','Polls'], ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
+      {tab === 'streak' && <StreakDetail streak={profile.streak} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
     </main>
@@ -317,6 +319,113 @@ function LevelStatus({ student }) {
         Level shows your highest achievement and never decreases. Trophy League shows your current performance and can move up or down with your current Spurti Points.
         {student.legendBadgeUnlocked ? ' You have unlocked the Legend Badge by reaching 1500 Spurti Points at least once.' : ''}
       </p>
+    </section>
+  );
+}
+
+function StreakCard({ streak }) {
+  if (!streak) return null;
+
+  const hearts = [];
+  for (let i = 0; i < 2; i++) hearts.push(i < streak.heartsRemaining ? '\u2764\uFE0F' : '\u{1F90E}');
+
+  return (
+    <section className="panel streak-card">
+      <div className="streak-summary">
+        <div className="streak-main">
+          <span className="streak-fire">{streak.currentStreak > 0 ? '\u{1F525}' : '\u{1F31F}'}</span>
+          <div>
+            <strong className="streak-count">{streak.currentStreak} Day Streak</strong>
+            <span className="streak-best">Best: {streak.longestStreak}</span>
+          </div>
+        </div>
+        <div className="streak-hearts">
+          <span className="hearts-label">Hearts</span>
+          <span className="hearts-icons">{hearts.join(' ')}</span>
+        </div>
+        <div className="streak-sp">
+          <span>Streak SP</span>
+          <strong>+{streak.totalStreakSp}</strong>
+        </div>
+        <div className="streak-next">
+          <span>Next milestone</span>
+          <strong>Day {streak.nextMilestone.day} {'\u2192'} +{streak.nextMilestone.sp} SP</strong>
+          <em>{streak.nextMilestone.daysRemaining} day{streak.nextMilestone.daysRemaining !== 1 ? 's' : ''} away</em>
+        </div>
+      </div>
+      <div className="streak-status-row">
+        <span className={streak.todayQualifies ? 'streak-qualify yes' : 'streak-qualify no'}>
+          {streak.todayQualifies ? '\u2705 Today qualifies' : '\u23FA Today not yet qualified'}
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function StreakDetail({ streak }) {
+  if (!streak) return <section className="panel"><p className="muted">No streak data yet. Start attending sessions to build your streak!</p></section>;
+
+  const hearts = [];
+  for (let i = 0; i < 2; i++) hearts.push(i < streak.heartsRemaining ? '\u2764\uFE0F' : '\u{1F90E}');
+
+  return (
+    <section className="panel">
+      <div className="panel-head"><h2>Daily Streak</h2></div>
+      <div className="streak-detail-grid">
+        <div className="streak-detail-stat">
+          <span>Current Streak</span>
+          <strong>{streak.currentStreak} days</strong>
+        </div>
+        <div className="streak-detail-stat">
+          <span>Longest Streak</span>
+          <strong>{streak.longestStreak} days</strong>
+        </div>
+        <div className="streak-detail-stat">
+          <span>Hearts</span>
+          <strong>{hearts.join(' ')}</strong>
+          <em>{streak.heartsUsed} used</em>
+        </div>
+        <div className="streak-detail-stat">
+          <span>Total Streak SP</span>
+          <strong>+{streak.totalStreakSp}</strong>
+        </div>
+        <div className="streak-detail-stat">
+          <span>Next Milestone</span>
+          <strong>Day {streak.nextMilestone.day} {'\u2192'} +{streak.nextMilestone.sp} SP</strong>
+          <em>{streak.nextMilestone.daysRemaining} day{streak.nextMilestone.daysRemaining !== 1 ? 's' : ''} to go</em>
+        </div>
+        <div className="streak-detail-stat">
+          <span>Today</span>
+          <strong className={streak.todayQualifies ? 'yes' : 'no'}>{streak.todayQualifies ? 'Qualified \u2705' : 'Not yet qualified'}</strong>
+        </div>
+      </div>
+      <div className="streak-rules">
+        <h3>How it works</h3>
+        <ul>
+          <li>Available for interns who started on or after <strong>16 July 2026</strong>.</li>
+          <li>Attend sessions (Mon{'\u2013'}Sat) with {'\u2265'}85% attendance AND {'\u2265'}85% poll participation to earn streak days.</li>
+          <li><strong>Sundays are off</strong> {'\u2014'} they do not count as streak days and do not break your streak.</li>
+          <li>Days 1{'\u2013'}30: <strong>1 SP/day</strong>. After day 30: <strong>2 SP/day</strong>.</li>
+          <li>Every 10th day gives a milestone bonus: Day 10 {'\u2192'} <strong>5 SP</strong>, Day 20 {'\u2192'} <strong>7 SP</strong>, Day 30 {'\u2192'} <strong>9 SP</strong>, increasing by 2 each milestone.</li>
+          <li>Miss a day? Hearts save your streak! You have <strong>{streak.heartsRemaining} heart{streak.heartsRemaining !== 1 ? 's' : ''}</strong> remaining.</li>
+          <li>Lose both hearts and the streak resets to 0.</li>
+        </ul>
+      </div>
+      {streak.recentHistory?.length > 0 && (
+        <div className="streak-history">
+          <h3>Recent History</h3>
+          <table className="table">
+            <thead><tr><th>Date</th><th>SP</th><th>Type</th></tr></thead>
+            <tbody>{[...streak.recentHistory].reverse().map(h => (
+              <tr key={h.date}>
+                <td>{h.date}</td>
+                <td>{h.sp > 0 ? `+${h.sp}` : '-'}</td>
+                <td>{h.type === 'milestone' ? '\u{1F3C6} Milestone' : h.type === 'heart_save' ? '\u2764\uFE0F Heart Used' : '\u2705 Daily'}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+        </div>
+      )}
     </section>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -514,3 +514,78 @@ input {
 .survey-primary:disabled { opacity: 0.6; cursor: default; }
 .survey-ghost { background: #fff; color: #475569; border-color: #cbd5e1; }
 .survey-note { margin: 0 24px 16px; font-size: 0.85rem; color: #b91c1c; }
+
+/* ═══ Streak Card ═══ */
+.streak-card { padding: 16px 20px; margin-bottom: 16px; }
+.streak-summary {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.streak-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.streak-fire { font-size: 28px; }
+.streak-count { font-size: 18px; display: block; }
+.streak-best { font-size: 12px; color: var(--muted); }
+.streak-hearts, .streak-sp, .streak-next {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  font-size: 12px;
+}
+.streak-hearts span, .streak-sp span, .streak-next span { color: var(--muted); font-size: 11px; }
+.streak-hearts strong { font-size: 20px; color: #e11d48; }
+.streak-sp strong { font-size: 16px; color: var(--green); }
+.streak-next strong { font-size: 13px; color: var(--primary); }
+.streak-next em { font-size: 11px; color: var(--muted); }
+.streak-status-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+.streak-qualify { font-size: 13px; font-weight: 600; }
+.streak-qualify.yes { color: var(--green); }
+.streak-qualify.no { color: var(--muted); }
+.streak-claim-btn { margin-left: auto; padding: 6px 16px; font-size: 13px; }
+.streak-claim-result { margin-top: 8px; font-size: 13px; }
+.streak-claim-result.success { color: var(--green); }
+.streak-claim-result.muted { color: var(--muted); }
+
+/* ═══ Streak Detail ═══ */
+.streak-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+.streak-detail-stat {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.streak-detail-stat span { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+.streak-detail-stat strong { font-size: 18px; }
+.streak-detail-stat strong.yes { color: var(--green); }
+.streak-detail-stat strong.no { color: var(--muted); }
+.streak-detail-stat em { font-size: 11px; color: var(--muted); }
+.streak-rules {
+  background: #f8fafc;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+.streak-rules h3 { margin: 0 0 8px; font-size: 14px; }
+.streak-rules ul { margin: 0; padding-left: 20px; font-size: 13px; line-height: 1.7; }
+.streak-history { margin-top: 16px; }
+.streak-history h3 { font-size: 14px; margin-bottom: 8px; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,51 @@
         "dotenv": "^17.4.2",
         "express": "^4.19.2",
         "mongoose": "^8.8.4"
+      },
+      "devDependencies": {
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.11",
@@ -22,6 +66,342 @@
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -36,6 +416,119 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -56,6 +549,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.5",
@@ -128,6 +631,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -148,6 +661,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -209,6 +729,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -268,6 +798,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -286,6 +823,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -293,6 +840,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -341,6 +898,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -375,6 +950,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -513,6 +1103,277 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -724,6 +1585,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -754,6 +1634,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -780,6 +1674,62 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -840,6 +1790,40 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/safe-buffer": {
@@ -997,6 +1981,23 @@
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -1006,6 +2007,13 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1013,6 +2021,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1035,6 +2094,14 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1076,6 +2143,174 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -1096,6 +2331,23 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,12 +12,17 @@
     "setup": "npm install && npm --prefix client install && npm run rebuild && npm run build",
     "build": "npm --prefix client run build",
     "start": "node server/server.js",
-    "dev": "node server/server.js"
+    "dev": "node server/server.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^4.19.2",
     "mongoose": "^8.8.4"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
   }
 }

--- a/server/config.js
+++ b/server/config.js
@@ -63,3 +63,9 @@ export const SESSION_THRESHOLDS_MINUTES = {
 };
 
 export const SESSION_THRESHOLDS_PCT = 0.75; // default % of session duration to qualify
+
+// Streak feature thresholds
+export const STREAK_ATTENDANCE_THRESHOLD = 85; // minimum attendance % to qualify for a streak day
+export const STREAK_POLL_THRESHOLD = 85;        // minimum poll % to qualify for a streak day
+export const STREAK_INITIAL_HEARTS = 2;          // streak savers per internship
+export const STREAK_CUTOFF_DATE = '2026-07-16'; // only students with internshipStartDate >= this get streaks

--- a/server/cron/streakDaily.js
+++ b/server/cron/streakDaily.js
@@ -1,0 +1,277 @@
+/**
+ * streakDaily.js — Daily cron script to process streaks for all active students.
+ *
+ * Run daily after the pipeline completes (e.g. 23:59 IST):
+ *   node server/cron/streakDaily.js
+ *
+ * Options:
+ *   DATE=2026-07-20   — process a specific date (default: yesterday)
+ *   DRY_RUN=1         — log results without writing to DB
+ *   BACKFILL=1        — process from each student's start date (one-time setup)
+ *
+ * Requires MONGO_URI in .env (same DB as the web app).
+ */
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '..', '..', '.env') });
+const { MongoClient } = require('mongodb');
+
+const MONGO_URI = process.env.MONGO_URI || '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+const BACKFILL = process.env.BACKFILL === '1';
+
+// Thresholds (must match server/config.js)
+const STREAK_ATTENDANCE_THRESHOLD = 85;
+const STREAK_POLL_THRESHOLD = 85;
+const STREAK_INITIAL_HEARTS = 2;
+const STREAK_CUTOFF_DATE = '2026-07-16';
+
+function addDays(dateStr, n) {
+  const d = new Date(dateStr + 'T12:00:00.000Z');
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+function isSunday(dateStr) {
+  return new Date(dateStr + 'T12:00:00.000Z').getUTCDay() === 0;
+}
+
+function nextWeekday(dateStr) {
+  let next = addDays(dateStr, 1);
+  while (isSunday(next)) next = addDays(next, 1);
+  return next;
+}
+
+function getStreakSpForDay(streakDay) {
+  if (streakDay % 10 === 0) return 3 + (streakDay / 10) * 2;
+  return streakDay <= 30 ? 1 : 2;
+}
+
+(async () => {
+  if (!MONGO_URI) throw new Error('no MONGO_URI');
+
+  const conn = await MongoClient.connect(MONGO_URI, { socketTimeoutMS: 600000 });
+  const db = conn.db();
+
+  // Target date: yesterday (IST-aware), skip Sunday
+  const now = new Date();
+  const istOffset = 5.5 * 3600 * 1000;
+  const istNow = new Date(now.getTime() + istOffset);
+  const yesterdayIST = new Date(istNow.getTime() - 86400000);
+  let defaultDate = yesterdayIST.toISOString().slice(0, 10);
+  if (isSunday(defaultDate)) defaultDate = addDays(defaultDate, -1);
+  const targetDate = process.env.DATE || defaultDate;
+
+  if (isSunday(targetDate)) {
+    console.log('Target date is Sunday — nothing to process.');
+    await conn.close();
+    return;
+  }
+
+  console.log(`Streak daily — target date: ${targetDate} (DRY_RUN=${DRY_RUN ? '1' : '0'} BACKFILL=${BACKFILL ? '1' : '0'})`);
+
+  // Load all active students
+  const students = await db.collection('students').find({ status: 'active' }).toArray();
+  console.log(`Active students: ${students.length}`);
+
+  const results = { processed: 0, qualified: 0, heartsUsed: 0, streaksBroken: 0, totalSpAwarded: 0, errors: 0 };
+
+  for (const student of students) {
+    const email = student.email;
+    const studentId = student._id;
+    const startDate = student.internshipStartDate ? new Date(student.internshipStartDate).toISOString().slice(0, 10) : targetDate;
+
+    // Skip students who started before the streak cutoff
+    if (startDate < STREAK_CUTOFF_DATE) continue;
+
+    // Determine date range to process
+    let datesToProcess = [];
+    if (BACKFILL) {
+      // Process from start date to target date, skip Sundays
+      let d = startDate;
+      while (d <= targetDate) {
+        if (!isSunday(d)) datesToProcess.push(d);
+        d = addDays(d, 1);
+      }
+    } else {
+      datesToProcess = [targetDate];
+    }
+
+    // Get or create streak doc
+    let streak = await db.collection('streaks').findOne({ email });
+    if (!streak) {
+      streak = {
+        email,
+        studentId,
+        currentStreak: 0,
+        longestStreak: 0,
+        heartsRemaining: STREAK_INITIAL_HEARTS,
+        heartsUsed: 0,
+        lastQualifyingDate: '',
+        lastProcessedDate: '',
+        streakStartDate: null,
+        totalStreakSp: 0,
+        lastHeartUseDate: '',
+        history: [],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+      if (!DRY_RUN) {
+        await db.collection('streaks').insertOne(streak);
+      }
+    }
+
+    for (const dateStr of datesToProcess) {
+      // Idempotent: skip already processed
+      if (streak.lastProcessedDate && dateStr <= streak.lastProcessedDate) continue;
+
+      // Skip before start date
+      if (dateStr < startDate) {
+        streak.lastProcessedDate = dateStr;
+        continue;
+      }
+
+      // Check qualification — multi-fallback strategy
+      const dayStart = new Date(dateStr + 'T00:00:00.000Z');
+      const dayEnd = new Date(dateStr + 'T23:59:59.999Z');
+
+      let qualifies = false;
+      try {
+        // 1. Try sessions collection -> attendancerecords/pollrecords
+        const sessionsOnDay = await db.collection('sessions').find({
+          date: { $gte: dayStart, $lte: dayEnd }
+        }).toArray();
+        let usedPrimary = false;
+        if (sessionsOnDay.length) {
+          const sessionLabels = sessionsOnDay.map(s => s.label);
+          const attRecords = await db.collection('attendancerecords').find({
+            email, sessionLabel: { $in: sessionLabels }
+          }).toArray();
+
+          if (attRecords.length) {
+            usedPrimary = true;
+            for (const att of attRecords) {
+              if ((att.attendancePercentage || 0) < STREAK_ATTENDANCE_THRESHOLD) continue;
+              const poll = await db.collection('pollrecords').findOne({
+                email, sessionLabel: att.sessionLabel
+              });
+              if (!poll) { qualifies = true; break; }
+              const pollPct = poll.totalQuestions > 0
+                ? Math.round(poll.attemptedQuestions / poll.totalQuestions * 100)
+                : 0;
+              if (pollPct >= STREAK_POLL_THRESHOLD) { qualifies = true; break; }
+            }
+          }
+        }
+
+        // 2. Fallback: sptransactions (appliedDelta >= 10 means >= 90%)
+        if (!usedPrimary) {
+          const attTxns = await db.collection('sptransactions').find({
+            email, category: 'attendance', dateTime: { $gte: dayStart, $lte: dayEnd }
+          }).toArray();
+          const pollTxns = await db.collection('sptransactions').find({
+            email, category: 'poll', dateTime: { $gte: dayStart, $lte: dayEnd }
+          }).toArray();
+          const hasStrongAtt = attTxns.some(t => t.appliedDelta >= 10);
+          if (hasStrongAtt) {
+            // If no polls ran that day, attendance alone qualifies
+            qualifies = !pollTxns.length || pollTxns.some(t => t.appliedDelta >= 10);
+          }
+        }
+      } catch (err) {
+        console.error(`  Error checking ${email} on ${dateStr}:`, err.message);
+        results.errors++;
+        continue;
+      }
+
+      let sp = 0;
+      let heartUsed = false;
+
+      if (qualifies) {
+        if (streak.currentStreak === 0) {
+          streak.streakStartDate = new Date(dateStr + 'T00:00:00.000Z');
+        }
+        streak.currentStreak += 1;
+        sp = getStreakSpForDay(streak.currentStreak);
+        streak.totalStreakSp += sp;
+        streak.lastQualifyingDate = dateStr;
+        streak.history.push({ date: dateStr, sp, type: streak.currentStreak % 10 === 0 ? 'milestone' : 'daily' });
+
+        if (!DRY_RUN) {
+          // Create SP transaction
+          const currentBalance = Number(student.totalSp) || 0;
+          await db.collection('sptransactions').insertOne({
+            email,
+            studentId,
+            category: 'streak',
+            sessionLabel: `Streak Day ${streak.currentStreak}`,
+            deltaMode: 'absolute',
+            deltaValue: sp,
+            appliedDelta: sp,
+            balanceAfter: currentBalance + sp,
+            reason: `Streak day ${streak.currentStreak}: ${sp} SP${streak.currentStreak % 10 === 0 ? ' (10th-day milestone!)' : ''}`,
+            dateTime: new Date(dateStr + 'T23:59:00.000Z'),
+            createdAt: new Date(),
+            updatedAt: new Date()
+          });
+          // Update student totalSp
+          await db.collection('students').updateOne(
+            { _id: studentId },
+            { $inc: { totalSp: sp } }
+          );
+        }
+
+        results.qualified++;
+        results.totalSpAwarded += sp;
+
+      } else {
+        // Not qualifying — check heart or break (nextWeekday skips Sundays)
+        const expectedPrev = streak.lastQualifyingDate ? nextWeekday(streak.lastQualifyingDate) : dateStr;
+        const isConsecutiveGap = !streak.lastQualifyingDate || dateStr <= expectedPrev;
+
+        if (isConsecutiveGap && streak.heartsRemaining > 0 && !BACKFILL) {
+          streak.heartsRemaining -= 1;
+          streak.heartsUsed += 1;
+          streak.lastHeartUseDate = dateStr;
+          streak.lastQualifyingDate = dateStr;
+          heartUsed = true;
+          streak.history.push({ date: dateStr, sp: 0, type: 'heart_save' });
+          results.heartsUsed++;
+        } else if (streak.currentStreak > 0) {
+          streak.currentStreak = 0;
+          streak.streakStartDate = null;
+          results.streaksBroken++;
+        }
+      }
+
+      if (streak.currentStreak > streak.longestStreak) {
+        streak.longestStreak = streak.currentStreak;
+      }
+      streak.lastProcessedDate = dateStr;
+    }
+
+    // Trim history
+    if (streak.history.length > 365) streak.history = streak.history.slice(-365);
+    streak.updatedAt = new Date();
+
+    if (!DRY_RUN) {
+      await db.collection('streaks').updateOne(
+        { email },
+        { $set: streak },
+        { upsert: true }
+      );
+    }
+
+    results.processed++;
+  }
+
+  console.log(`\nResults:`);
+  console.log(`  Processed: ${results.processed}`);
+  console.log(`  Qualified: ${results.qualified}`);
+  console.log(`  Hearts used: ${results.heartsUsed}`);
+  console.log(`  Streaks broken: ${results.streaksBroken}`);
+  console.log(`  Total SP awarded: ${results.totalSpAwarded}`);
+  console.log(`  Errors: ${results.errors}`);
+
+  if (DRY_RUN) console.log('\nDRY RUN — no DB writes.');
+  await conn.close();
+})().catch((e) => { console.error('FATAL', e.message); process.exit(1); });

--- a/server/models/SPTransaction.js
+++ b/server/models/SPTransaction.js
@@ -6,7 +6,7 @@ const spTransactionSchema = new mongoose.Schema({
   category: {
     type: String,
     required: true,
-    enum: ['initial', 'attendance', 'poll', 'manual'],
+    enum: ['initial', 'attendance', 'poll', 'manual', 'streak', 'exit_ticket', 'peer_review'],
     index: true
   },
   sessionLabel: { type: String, default: '', index: true },

--- a/server/models/Streak.js
+++ b/server/models/Streak.js
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+const streakSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true, lowercase: true, trim: true, index: true },
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', index: true },
+  currentStreak: { type: Number, default: 0 },
+  longestStreak: { type: Number, default: 0 },
+  heartsRemaining: { type: Number, default: 2 },
+  heartsUsed: { type: Number, default: 0 },
+  lastQualifyingDate: { type: String, default: '' },
+  lastProcessedDate: { type: String, default: '' },
+  streakStartDate: { type: Date, default: null },
+  totalStreakSp: { type: Number, default: 0 },
+  lastHeartUseDate: { type: String, default: '' },
+  history: [{
+    date: { type: String },
+    sp: { type: Number },
+    type: { type: String, enum: ['daily', 'milestone', 'heart_save'] }
+  }]
+}, { timestamps: true });
+
+streakSchema.index({ currentStreak: -1 });
+
+export default mongoose.model('Streak', streakSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,8 @@ import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
+import { getStreakStatus, claimDailyStreak, processAllStudents } from './services/streakService.js';
+import Streak from './models/Streak.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -238,7 +240,8 @@ async function studentPayload(student) {
       pointsToNextRank: nextStudent ? Math.max(1, nextStudent.totalSp - student.totalSp + 1) : 0
     },
     leaderboard: leaderboard.map(mapRow),
-    groupLeaderboard: groupStudents.slice(0, 50).map(mapRow)
+    groupLeaderboard: groupStudents.slice(0, 50).map(mapRow),
+    streak: await getStreakStatus(email).catch(() => null)
   };
 }
 
@@ -557,7 +560,7 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
     };
   });
 
-  const categoryTotals = ['initial', 'attendance', 'poll', 'manual'].map(category => {
+  const categoryTotals = ['initial', 'attendance', 'poll', 'manual', 'streak'].map(category => {
     const rows = activeTransactions.filter(t => t.category === category);
     return {
       category,
@@ -616,6 +619,49 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
 function last24Hours(now) {
   return new Date(now.getTime() - 24 * 60 * 60 * 1000);
 }
+
+// FEATURE 10: Daily Streak - GET/POST /api/streak
+api.get('/streak', async (req, res) => {
+  try {
+    const email = await studentEmailFromRequest(req);
+    if (!email) return res.status(401).json({ error: 'Unauthorized' });
+    const status = await getStreakStatus(email);
+    res.json(status);
+  } catch (err) {
+    console.error('streak GET error:', err);
+    res.status(500).json({ error: 'Internal error' });
+  }
+});
+api.post('/streak/claim', async (req, res) => {
+  try {
+    const email = await studentEmailFromRequest(req);
+    if (!email) return res.status(401).json({ error: 'Unauthorized' });
+    const result = await claimDailyStreak(email);
+    res.json(result);
+  } catch (err) {
+    console.error('streak claim error:', err);
+    res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+// Admin: list all streaks
+api.get('/admin/streaks', adminGuard, async (req, res) => {
+  const sort = String(req.query.sort || 'currentStreak');
+  const limit = Math.min(parseInt(req.query.limit) || 50, 200);
+  const streaks = await Streak.find().sort({ [sort]: -1 }).limit(limit).lean();
+  res.json(streaks);
+});
+// Admin: trigger daily streak processing for all students
+api.post('/admin/streak/process-all', adminGuard, async (req, res) => {
+  try {
+    const date = req.body.date; // optional YYYY-MM-DD
+    const results = await processAllStudents(date);
+    res.json({ processed: results.length, results });
+  } catch (err) {
+    console.error('streak process-all error:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
 
 app.use('/api', api);
 app.use('/spurti/api', api);

--- a/server/services/__tests__/streakService.test.js
+++ b/server/services/__tests__/streakService.test.js
@@ -1,0 +1,399 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Hoist all mock objects so vi.mock factories can reference them ─────
+const {
+  sessionMocks, attMocks, pollMocks, spMocks, streakMocks, studentMocks,
+} = vi.hoisted(() => {
+  function makeChain(retval) {
+    const lean = vi.fn().mockResolvedValue(retval);
+    const chain = { lean, sort: vi.fn().mockReturnThis(), limit: vi.fn().mockReturnThis() };
+    return chain;
+  }
+
+  return {
+    sessionMocks: { find: vi.fn().mockReturnValue(makeChain([])) },
+    attMocks:     { find: vi.fn().mockReturnValue(makeChain([])) },
+    pollMocks:    { find: vi.fn().mockReturnValue(makeChain([])) },
+    spMocks:      { find: vi.fn().mockReturnValue(makeChain([])), create: vi.fn().mockResolvedValue({}) },
+    streakMocks: {
+      findOne: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({
+        email: '', studentId: '', currentStreak: 0, longestStreak: 0,
+        heartsRemaining: 2, heartsUsed: 0, lastQualifyingDate: '', lastProcessedDate: '',
+        streakStartDate: null, totalStreakSp: 0, lastHeartUseDate: '', history: [],
+        save: vi.fn().mockResolvedValue(true),
+      }),
+      find: vi.fn().mockReturnValue(makeChain([])),
+    },
+    studentMocks: {
+      findOne: vi.fn().mockReturnValue(makeChain(null)),
+      find: vi.fn().mockReturnValue(makeChain([])),
+      updateOne: vi.fn().mockResolvedValue({}),
+    },
+  };
+});
+
+// ─── Mock config ───────────────────────────────────────────────────────
+vi.mock('../../config.js', () => ({
+  STREAK_ATTENDANCE_THRESHOLD: 85,
+  STREAK_POLL_THRESHOLD: 85,
+  STREAK_INITIAL_HEARTS: 2,
+  STREAK_CUTOFF_DATE: '2026-07-16',
+}));
+
+// ─── Mock models ───────────────────────────────────────────────────────
+vi.mock('../../models/Streak.js', () => ({ default: streakMocks }));
+vi.mock('../../models/Student.js', () => ({ default: studentMocks }));
+vi.mock('../../models/SPTransaction.js', () => ({ default: spMocks }));
+vi.mock('../../models/Session.js', () => ({ default: sessionMocks }));
+vi.mock('../../models/AttendanceRecord.js', () => ({ default: attMocks }));
+vi.mock('../../models/PollRecord.js', () => ({ default: pollMocks }));
+
+import {
+  getStreakSpForDay,
+  qualifiesForDate,
+  getOrCreateStreak,
+  processDay,
+} from '../streakService.js';
+
+// ─── Helper ────────────────────────────────────────────────────────────
+function chain(retval) {
+  const lean = vi.fn().mockResolvedValue(retval);
+  return { lean, sort: vi.fn().mockReturnThis(), limit: vi.fn().mockReturnThis() };
+}
+
+// Standard student fixture — starts on cutoff date, eligible for streaks
+const ACTIVE_STUDENT = { _id: 'stu123', email: 'test@iitrpr.ac.in', status: 'active', totalSp: 100, internshipStartDate: '2026-07-16' };
+
+// ─── getStreakSpForDay ─────────────────────────────────────────────────
+describe('getStreakSpForDay', () => {
+  it('returns 1 SP for days 1–9', () => {
+    for (let d = 1; d <= 9; d++) expect(getStreakSpForDay(d)).toBe(1);
+  });
+  it('returns 5 SP for day 10 (milestone)', () => {
+    expect(getStreakSpForDay(10)).toBe(5);
+  });
+  it('returns 1 SP for non-milestone days 11–29', () => {
+    for (let d = 11; d <= 29; d++) {
+      if (d === 20) continue;
+      expect(getStreakSpForDay(d)).toBe(1);
+    }
+  });
+  it('returns 7 SP for day 20 (milestone)', () => {
+    expect(getStreakSpForDay(20)).toBe(7);
+  });
+  it('returns 9 SP for day 30 (milestone)', () => {
+    expect(getStreakSpForDay(30)).toBe(9);
+  });
+  it('returns 2 SP for days 31–39', () => {
+    for (let d = 31; d <= 39; d++) expect(getStreakSpForDay(d)).toBe(2);
+  });
+  it('returns 11 SP for day 40 (milestone)', () => {
+    expect(getStreakSpForDay(40)).toBe(11);
+  });
+  it('returns 2 SP for days 41–49', () => {
+    for (let d = 41; d <= 49; d++) expect(getStreakSpForDay(d)).toBe(2);
+  });
+  it('returns 13 SP for day 50', () => {
+    expect(getStreakSpForDay(50)).toBe(13);
+  });
+  it('returns 15 SP for day 60', () => {
+    expect(getStreakSpForDay(60)).toBe(15);
+  });
+  it('returns 23 SP for day 100', () => {
+    expect(getStreakSpForDay(100)).toBe(23);
+  });
+  it('milestone formula holds for 10th-day multiples 10–100', () => {
+    for (let m = 1; m <= 10; m++) {
+      expect(getStreakSpForDay(m * 10)).toBe(3 + m * 2);
+    }
+  });
+});
+
+// ─── qualifiesForDate ──────────────────────────────────────────────────
+describe('qualifiesForDate', () => {
+  const email = 'test@iitrpr.ac.in';
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('qualifies when attendance >=85% and poll >=85% via records', async () => {
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', attendancePercentage: 90 }]));
+    pollMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', totalQuestions: 10, attemptedQuestions: 9 }]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(true);
+  });
+
+  it('does not qualify when attendance <85%', async () => {
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', attendancePercentage: 80 }]));
+    pollMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', totalQuestions: 10, attemptedQuestions: 9 }]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(false);
+  });
+
+  it('does not qualify when poll <85%', async () => {
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', attendancePercentage: 90 }]));
+    pollMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', totalQuestions: 10, attemptedQuestions: 5 }]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(false);
+  });
+
+  it('qualifies with attendance alone when no poll record', async () => {
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', attendancePercentage: 90 }]));
+    pollMocks.find.mockReturnValue(chain([]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(true);
+  });
+
+  it('falls back to sptransactions when no sessions on date', async () => {
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find
+      .mockReturnValueOnce(chain([{ appliedDelta: 10 }]))
+      .mockReturnValueOnce(chain([{ appliedDelta: 10 }]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(true);
+  });
+
+  it('does not qualify via sptransactions when appliedDelta <10', async () => {
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find
+      .mockReturnValueOnce(chain([{ appliedDelta: 5 }]))
+      .mockReturnValueOnce(chain([{ appliedDelta: 10 }]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(false);
+  });
+
+  it('qualifies via sptransactions with strong attendance and no polls', async () => {
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find
+      .mockReturnValueOnce(chain([{ appliedDelta: 10 }]))
+      .mockReturnValueOnce(chain([]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(true);
+  });
+
+  it('does not qualify with no data at all', async () => {
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find
+      .mockReturnValueOnce(chain([]))
+      .mockReturnValueOnce(chain([]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(false);
+  });
+
+  it('checks multiple attendance records, qualifies if any pass', async () => {
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([
+      { sessionLabel: 'Day 1', attendancePercentage: 80 },
+      { sessionLabel: 'Day 1b', attendancePercentage: 90 },
+    ]));
+    pollMocks.find.mockReturnValue(chain([
+      { sessionLabel: 'Day 1b', totalQuestions: 10, attemptedQuestions: 9 },
+    ]));
+    expect(await qualifiesForDate(email, '2026-07-16')).toBe(true);
+  });
+});
+
+// ─── getOrCreateStreak ─────────────────────────────────────────────────
+describe('getOrCreateStreak', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns existing streak', async () => {
+    const existing = { email: 'a@b.com', currentStreak: 5 };
+    streakMocks.findOne.mockResolvedValue(existing);
+    const result = await getOrCreateStreak('a@b.com', 'sid1');
+    expect(result).toBe(existing);
+    expect(streakMocks.create).not.toHaveBeenCalled();
+  });
+
+  it('creates new streak when none exists', async () => {
+    streakMocks.findOne.mockResolvedValue(null);
+    const created = { email: 'a@b.com', heartsRemaining: 2 };
+    streakMocks.create.mockResolvedValue(created);
+    const result = await getOrCreateStreak('a@b.com', 'sid1');
+    expect(streakMocks.create).toHaveBeenCalledWith({
+      email: 'a@b.com', studentId: 'sid1',
+      heartsRemaining: 2, currentStreak: 0, longestStreak: 0, totalStreakSp: 0,
+    });
+    expect(result).toBe(created);
+  });
+});
+
+// ─── processDay ────────────────────────────────────────────────────────
+describe('processDay', () => {
+  const email = 'test@iitrpr.ac.in';
+  const studentId = 'stu123';
+  let streakDoc;
+
+  function freshStreak(overrides = {}) {
+    return {
+      email, studentId, currentStreak: 0, longestStreak: 0,
+      heartsRemaining: 2, heartsUsed: 0, lastQualifyingDate: '', lastProcessedDate: '',
+      streakStartDate: null, totalStreakSp: 0, lastHeartUseDate: '', history: [],
+      save: vi.fn().mockResolvedValue(true),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    streakDoc = freshStreak();
+  });
+
+  it('returns processed:false if student not found', async () => {
+    studentMocks.findOne.mockReturnValue(chain(null));
+    const result = await processDay(email, '2026-07-16');
+    expect(result).toEqual({ processed: false });
+  });
+
+  it('returns processed:false if student is excused', async () => {
+    studentMocks.findOne.mockReturnValue(chain({ _id: studentId, email, status: 'excused', totalSp: 100, internshipStartDate: '2026-07-16' }));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    const result = await processDay(email, '2026-07-16');
+    expect(result).toEqual({ processed: false });
+  });
+
+  it('returns processed:false if date is Sunday', async () => {
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    const result = await processDay(email, '2026-07-19'); // Sunday
+    expect(result).toEqual({ processed: false });
+    expect(streakMocks.findOne).not.toHaveBeenCalled();
+  });
+
+  it('returns processed:false if student started before cutoff', async () => {
+    studentMocks.findOne.mockReturnValue(chain({ ...ACTIVE_STUDENT, internshipStartDate: '2026-07-10' }));
+    const result = await processDay(email, '2026-07-16');
+    expect(result).toEqual({ processed: false });
+  });
+
+  it('returns processed:false if already processed this date', async () => {
+    streakDoc.lastProcessedDate = '2026-07-16';
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    const result = await processDay(email, '2026-07-16');
+    expect(result).toEqual({ processed: false });
+  });
+
+  it('returns processed:false for date before internship start', async () => {
+    studentMocks.findOne.mockReturnValue(chain({ ...ACTIVE_STUDENT, internshipStartDate: '2026-07-20' }));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    const result = await processDay(email, '2026-07-17');
+    expect(result.processed).toBe(false);
+    expect(streakDoc.lastProcessedDate).toBe('2026-07-17');
+    expect(streakDoc.save).toHaveBeenCalled();
+  });
+
+  it('advances streak when day qualifies', async () => {
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', attendancePercentage: 90 }]));
+    pollMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', totalQuestions: 10, attemptedQuestions: 9 }]));
+
+    const result = await processDay(email, '2026-07-16');
+    expect(result.processed).toBe(true);
+    expect(result.sp).toBe(1);
+    expect(result.streak).toBe(1);
+    expect(result.heartUsed).toBe(false);
+    expect(result.streakBroken).toBe(false);
+    expect(streakDoc.currentStreak).toBe(1);
+    expect(streakDoc.totalStreakSp).toBe(1);
+    expect(streakDoc.lastQualifyingDate).toBe('2026-07-16');
+    expect(streakDoc.history).toHaveLength(1);
+    expect(streakDoc.history[0]).toEqual({ date: '2026-07-16', sp: 1, type: 'daily' });
+    expect(spMocks.create).toHaveBeenCalled();
+    expect(studentMocks.updateOne).toHaveBeenCalled();
+  });
+
+  it('records milestone type on 10th day', async () => {
+    streakDoc = freshStreak({ currentStreak: 9, lastQualifyingDate: '2026-07-25' });
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', attendancePercentage: 90 }]));
+    pollMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', totalQuestions: 10, attemptedQuestions: 9 }]));
+
+    const result = await processDay(email, '2026-07-27');
+    expect(result.sp).toBe(5);
+    expect(streakDoc.currentStreak).toBe(10);
+    expect(streakDoc.history[0].type).toBe('milestone');
+  });
+
+  it('uses heart on consecutive missed day', async () => {
+    streakDoc = freshStreak({ currentStreak: 3, lastQualifyingDate: '2026-07-16', heartsRemaining: 2 });
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find.mockReturnValue(chain([]));
+
+    const result = await processDay(email, '2026-07-17');
+    expect(result.heartUsed).toBe(true);
+    expect(result.streakBroken).toBe(false);
+    expect(streakDoc.heartsRemaining).toBe(1);
+    expect(streakDoc.heartsUsed).toBe(1);
+    expect(streakDoc.currentStreak).toBe(3);
+    expect(streakDoc.lastQualifyingDate).toBe('2026-07-17');
+  });
+
+  it('breaks streak when no hearts remain', async () => {
+    streakDoc = freshStreak({ currentStreak: 5, lastQualifyingDate: '2026-07-16', heartsRemaining: 0 });
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find.mockReturnValue(chain([]));
+
+    const result = await processDay(email, '2026-07-17');
+    expect(result.streakBroken).toBe(true);
+    expect(result.heartUsed).toBe(false);
+    expect(streakDoc.currentStreak).toBe(0);
+    expect(streakDoc.streakStartDate).toBeNull();
+  });
+
+  it('does not use heart during backfill', async () => {
+    streakDoc = freshStreak({ currentStreak: 3, lastQualifyingDate: '2026-07-16', heartsRemaining: 2 });
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find.mockReturnValue(chain([]));
+
+    const result = await processDay(email, '2026-07-17', { backfill: true });
+    expect(result.heartUsed).toBe(false);
+    expect(streakDoc.heartsRemaining).toBe(2);
+    expect(streakDoc.currentStreak).toBe(3);
+  });
+
+  it('updates longestStreak when current exceeds it', async () => {
+    streakDoc = freshStreak({ currentStreak: 4, longestStreak: 4, lastQualifyingDate: '2026-07-16' });
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    sessionMocks.find.mockReturnValue(chain([{ label: 'Day 1' }]));
+    attMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', attendancePercentage: 90 }]));
+    pollMocks.find.mockReturnValue(chain([{ sessionLabel: 'Day 1', totalQuestions: 10, attemptedQuestions: 9 }]));
+
+    await processDay(email, '2026-07-17');
+    expect(streakDoc.longestStreak).toBe(5);
+  });
+
+  it('gap logic uses nextWeekday — Saturday qualifies, Monday is consecutive after Friday', async () => {
+    // Friday qualifies, Saturday misses (heart), Monday misses — should use 2nd heart (not break)
+    streakDoc = freshStreak({ currentStreak: 3, lastQualifyingDate: '2026-07-17', heartsRemaining: 2 }); // Fri Jul 17
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    streakMocks.findOne.mockResolvedValue(streakDoc);
+    sessionMocks.find.mockReturnValue(chain([]));
+    spMocks.find.mockReturnValue(chain([]));
+
+    // Saturday Jul 18 — heart saves
+    const r1 = await processDay(email, '2026-07-18');
+    expect(r1.heartUsed).toBe(true);
+    expect(streakDoc.heartsRemaining).toBe(1);
+    expect(streakDoc.lastQualifyingDate).toBe('2026-07-18'); // heart resets gap
+
+    // Monday Jul 20 — Sunday Jul 19 skipped, Monday is consecutive after Saturday
+    const r2 = await processDay(email, '2026-07-20');
+    expect(r2.heartUsed).toBe(true);
+    expect(streakDoc.heartsRemaining).toBe(0);
+    expect(streakDoc.currentStreak).toBe(3); // streak preserved
+  });
+
+  it('Sunday is silently skipped — no streak doc lookup', async () => {
+    studentMocks.findOne.mockReturnValue(chain(ACTIVE_STUDENT));
+    const result = await processDay(email, '2026-07-19'); // Sunday
+    expect(result).toEqual({ processed: false });
+    expect(streakMocks.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/streakService.js
+++ b/server/services/streakService.js
@@ -1,0 +1,346 @@
+import Streak from '../models/Streak.js';
+import Student from '../models/Student.js';
+import SPTransaction from '../models/SPTransaction.js';
+import Session from '../models/Session.js';
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import PollRecord from '../models/PollRecord.js';
+import { STREAK_ATTENDANCE_THRESHOLD, STREAK_POLL_THRESHOLD, STREAK_INITIAL_HEARTS, STREAK_CUTOFF_DATE } from '../config.js';
+
+/**
+ * Compute SP for a given streak day number.
+ *
+ * Days 1-30:  1 SP/day, with 10th-day milestones (5, 7, 9)
+ * Days 31+:   2 SP/day, with 10th-day milestones continuing (11, 13, 15…)
+ *
+ * Milestone formula: 3 + (streakDay / 10) * 2
+ */
+export function getStreakSpForDay(streakDay) {
+  if (streakDay % 10 === 0) {
+    return 3 + (streakDay / 10) * 2;
+  }
+  return streakDay <= 30 ? 1 : 2;
+}
+
+/**
+ * Check if a student qualifies for a streak day on a given date.
+ * Qualifies if at least one session on that date has both:
+ *   - attendancePercentage >= STREAK_ATTENDANCE_THRESHOLD
+ *   - poll participation >= STREAK_POLL_THRESHOLD
+ *
+ * Strategy (multi-fallback):
+ * 1. Find sessions by date from the `sessions` collection.
+ * 2. Look up `attendancerecords` / `pollrecords` by session label
+ *    (production DB — has the actual percentages).
+ * 3. If those collections are empty (dev / pre-pipeline), fall back to
+ *    `sptransactions` with category attendance/poll on the same date.
+ *    appliedDelta >= 10 means >= 90% which satisfies the 85% threshold.
+ */
+export async function qualifiesForDate(email, dateStr) {
+  const dayStart = new Date(dateStr + 'T00:00:00.000Z');
+  const dayEnd = new Date(dateStr + 'T23:59:59.999Z');
+
+  // 1. Find sessions on this date
+  const sessionsOnDay = await Session.find({
+    date: { $gte: dayStart, $lte: dayEnd }
+  }).lean();
+
+  if (sessionsOnDay.length) {
+    const sessionLabels = sessionsOnDay.map(s => s.label);
+
+    const [attendanceRecords, pollRecords] = await Promise.all([
+      AttendanceRecord.find({ email, sessionLabel: { $in: sessionLabels } }).lean(),
+      PollRecord.find({ email, sessionLabel: { $in: sessionLabels } }).lean()
+    ]);
+
+    // Primary path: use actual percentages from attendancerecords / pollrecords
+    if (attendanceRecords.length) {
+      for (const att of attendanceRecords) {
+        if (att.attendancePercentage < STREAK_ATTENDANCE_THRESHOLD) continue;
+        const poll = pollRecords.find(p => p.sessionLabel === att.sessionLabel);
+        if (!poll) {
+          // No poll record for this session — attendance alone qualifies
+          return true;
+        }
+        const pollPct = poll.totalQuestions > 0
+          ? Math.round(poll.attemptedQuestions / poll.totalQuestions * 100) : 0;
+        if (pollPct >= STREAK_POLL_THRESHOLD) return true;
+      }
+      return false;
+    }
+  }
+
+  // 2. Fallback: check sptransactions (appliedDelta >= 10 means >= 90%)
+  const [attTxns, pollTxns] = await Promise.all([
+    SPTransaction.find({ email, category: 'attendance', dateTime: { $gte: dayStart, $lte: dayEnd } }).lean(),
+    SPTransaction.find({ email, category: 'poll', dateTime: { $gte: dayStart, $lte: dayEnd } }).lean()
+  ]);
+
+  const hasStrongAttendance = attTxns.some(t => t.appliedDelta >= 10);
+  if (!hasStrongAttendance) return false;
+  // If no polls were run on this day, attendance alone qualifies
+  if (!pollTxns.length) return true;
+  return pollTxns.some(t => t.appliedDelta >= 10);
+}
+
+/**
+ * Get or create a Streak document for a student.
+ */
+export async function getOrCreateStreak(email, studentId) {
+  let streak = await Streak.findOne({ email });
+  if (!streak) {
+    streak = await Streak.create({
+      email,
+      studentId,
+      heartsRemaining: STREAK_INITIAL_HEARTS,
+      currentStreak: 0,
+      longestStreak: 0,
+      totalStreakSp: 0
+    });
+  }
+  return streak;
+}
+
+/**
+ * Add days to a YYYY-MM-DD date string.
+ */
+function addDays(dateStr, n) {
+  const d = new Date(dateStr + 'T12:00:00.000Z');
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+function isSunday(dateStr) {
+  return new Date(dateStr + 'T12:00:00.000Z').getUTCDay() === 0;
+}
+
+function nextWeekday(dateStr) {
+  let next = addDays(dateStr, 1);
+  while (isSunday(next)) next = addDays(next, 1);
+  return next;
+}
+
+/**
+ * Process a single day for a student's streak.
+ * - If the day qualifies: increment streak, award SP.
+ * - If the day doesn't qualify: check hearts to save streak or reset.
+ *
+ * Returns { processed: boolean, sp?: number, streak?: number, heartUsed?: boolean, streakBroken?: boolean }
+ */
+export async function processDay(email, dateStr, { backfill = false } = {}) {
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  if (!student || student.status === 'excused') return { processed: false };
+
+  // Sundays don't count for streaks (Mon–Sat only)
+  if (isSunday(dateStr)) return { processed: false };
+
+  // Only students whose internship started on/after the cutoff get streaks
+  const cutoffStart = new Date(student.internshipStartDate).toISOString().slice(0, 10);
+  if (cutoffStart < STREAK_CUTOFF_DATE) return { processed: false };
+
+  const streak = await getOrCreateStreak(email, student._id);
+
+  // Idempotent: skip if already processed this date
+  if (streak.lastProcessedDate && dateStr <= streak.lastProcessedDate) {
+    return { processed: false };
+  }
+
+  // Skip dates before internship start
+  const startDate = student.internshipStartDate;
+  if (startDate) {
+    const startStr = new Date(startDate).toISOString().slice(0, 10);
+    if (dateStr < startStr) {
+      streak.lastProcessedDate = dateStr;
+      await streak.save();
+      return { processed: false };
+    }
+  }
+
+  const qualifies = await qualifiesForDate(email, dateStr);
+
+  let sp = 0;
+  let heartUsed = false;
+  let streakBroken = false;
+
+  if (qualifies) {
+    // Advance streak
+    if (streak.currentStreak === 0) {
+      streak.streakStartDate = new Date(dateStr + 'T00:00:00.000Z');
+    }
+    streak.currentStreak += 1;
+    sp = getStreakSpForDay(streak.currentStreak);
+    streak.totalStreakSp += sp;
+    streak.lastQualifyingDate = dateStr;
+
+    // Record in history
+    const entryType = streak.currentStreak % 10 === 0 ? 'milestone' : 'daily';
+    streak.history.push({ date: dateStr, sp, type: entryType });
+
+    // Create SP transaction
+    const currentBalance = Number(student.totalSp) || 0;
+    const newBalance = currentBalance + sp;
+    await SPTransaction.create({
+      email,
+      studentId: student._id,
+      category: 'streak',
+      sessionLabel: `Streak Day ${streak.currentStreak}`,
+      deltaMode: 'absolute',
+      deltaValue: sp,
+      appliedDelta: sp,
+      balanceAfter: newBalance,
+      reason: `Streak day ${streak.currentStreak}: ${sp} SP${streak.currentStreak % 10 === 0 ? ' (10th-day milestone!)' : ''}`,
+      dateTime: new Date(dateStr + 'T23:59:00.000Z')
+    });
+
+    // Update student SP
+    await Student.updateOne({ _id: student._id }, { $inc: { totalSp: sp } });
+
+  } else {
+    // Day didn't qualify — check gap (nextWeekday skips Sundays)
+    const expectedPrev = streak.lastQualifyingDate ? nextWeekday(streak.lastQualifyingDate) : dateStr;
+    const isConsecutiveGap = !streak.lastQualifyingDate || dateStr <= expectedPrev;
+
+    if (isConsecutiveGap && streak.heartsRemaining > 0 && !backfill) {
+      // Use a heart to save the streak
+      streak.heartsRemaining -= 1;
+      streak.heartsUsed += 1;
+      streak.lastHeartUseDate = dateStr;
+      streak.lastQualifyingDate = dateStr;
+      heartUsed = true;
+      streak.history.push({ date: dateStr, sp: 0, type: 'heart_save' });
+
+    } else if (!isConsecutiveGap || (streak.heartsRemaining === 0 && streak.currentStreak > 0)) {
+      // Streak broken
+      if (streak.currentStreak > 0) {
+        streakBroken = true;
+      }
+      streak.currentStreak = 0;
+      streak.streakStartDate = null;
+    }
+  }
+
+  // Update longest streak
+  if (streak.currentStreak > streak.longestStreak) {
+    streak.longestStreak = streak.currentStreak;
+  }
+
+  streak.lastProcessedDate = dateStr;
+
+  // Keep history manageable — retain last 365 entries
+  if (streak.history.length > 365) {
+    streak.history = streak.history.slice(-365);
+  }
+
+  await streak.save();
+
+  return { processed: true, sp, streak: streak.currentStreak, heartUsed, streakBroken };
+}
+
+/**
+ * Process all active students for a given date.
+ * Used by the daily cron job.
+ */
+export async function processAllStudents(dateStr, { backfill = false } = {}) {
+  if (isSunday(dateStr)) return { processed: 0, qualified: 0, heartsUsed: 0, streaksBroken: 0, totalSpAwarded: 0 };
+  const students = await Student.find({ status: 'active' }).lean();
+  const results = { processed: 0, qualified: 0, heartsUsed: 0, streaksBroken: 0, totalSpAwarded: 0 };
+
+  for (const student of students) {
+    const result = await processDay(student.email, dateStr, { backfill });
+    if (result.processed) {
+      results.processed++;
+      if (result.sp > 0) {
+        results.qualified++;
+        results.totalSpAwarded += result.sp;
+      }
+      if (result.heartUsed) results.heartsUsed++;
+      if (result.streakBroken) results.streaksBroken++;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Manually claim daily streak SP from the dashboard.
+ * Processes yesterday (since today's sessions may not be complete yet).
+ * Idempotent — safe to call multiple times.
+ */
+export async function claimDailyStreak(email) {
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  if (!student) throw new Error('Student not found');
+  if (student.status === 'excused') throw new Error('Student account is excused');
+
+  const today = new Date().toISOString().slice(0, 10);
+  let yesterday = addDays(today, -1);
+  if (isSunday(yesterday)) yesterday = addDays(yesterday, -1);
+
+  // Try to process yesterday first (full day data available)
+  const streak = await getOrCreateStreak(email, student._id);
+
+  // If yesterday was already processed, try today
+  const targetDate = (streak.lastProcessedDate >= yesterday) ? today : yesterday;
+  const result = await processDay(email, targetDate);
+
+  if (!result.processed) {
+    return {
+      claimed: false,
+      message: `Already processed up to ${streak.lastProcessedDate}`,
+      streak: streak.currentStreak,
+      heartsRemaining: streak.heartsRemaining,
+      totalStreakSp: streak.totalStreakSp
+    };
+  }
+
+  return {
+    claimed: true,
+    date: targetDate,
+    sp: result.sp,
+    streak: result.streak,
+    heartUsed: result.heartUsed,
+    streakBroken: result.streakBroken,
+    heartsRemaining: streak.heartsRemaining,
+    totalStreakSp: streak.totalStreakSp
+  };
+}
+
+/**
+ * Get streak status for a student (for dashboard display).
+ */
+export async function getStreakStatus(email) {
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  if (!student) return null;
+
+  const streak = await getOrCreateStreak(email, student._id);
+
+  // Check if today qualifies
+  const today = new Date().toISOString().slice(0, 10);
+  const todayQualifies = await qualifiesForDate(email, today);
+
+  // Next milestone info
+  const nextMilestone = Math.ceil((streak.currentStreak + 1) / 10) * 10;
+  const nextMilestoneSp = getStreakSpForDay(nextMilestone);
+  const daysToMilestone = nextMilestone - streak.currentStreak;
+
+  // Yesterday info (skip Sunday)
+  let yesterday = addDays(today, -1);
+  if (isSunday(yesterday)) yesterday = addDays(yesterday, -1);
+  const yesterdayQualifies = streak.lastQualifyingDate === yesterday;
+
+  return {
+    currentStreak: streak.currentStreak,
+    longestStreak: streak.longestStreak,
+    heartsRemaining: streak.heartsRemaining,
+    heartsUsed: streak.heartsUsed,
+    totalStreakSp: streak.totalStreakSp,
+    lastQualifyingDate: streak.lastQualifyingDate,
+    streakStartDate: streak.streakStartDate,
+    todayQualifies,
+    yesterdayQualifies,
+    nextMilestone: {
+      day: nextMilestone,
+      sp: nextMilestoneSp,
+      daysRemaining: daysToMilestone
+    },
+    recentHistory: streak.history.slice(-10)
+  };
+}


### PR DESCRIPTION
## Summary

This PR introduces a **daily streak scoring system** that rewards students for consistent session attendance. The feature tracks consecutive qualifying days (Mon–Sat), awards escalating bonus SP at milestones, and provides a hearts-based safety net so a single missed day doesn't destroy weeks of progress.

Sundays are explicitly excluded — they neither count as streak days nor break streaks — making the system naturally aligned with the Mon–Sat session schedule.

---

## Motivation

Spurti currently awards attendance and poll SP per-session, but there is no incentive for **day-over-day consistency**. A student who attends 5 out of 6 days gets almost the same total as one who attends all 6. The streak feature changes this by compounding rewards for unbroken chains of attendance, which:

1. **Drives daily engagement** — students show up every day, not just most days.
2. **Builds habits** — consecutive-day tracking creates a psychological commitment loop.
3. **Rewards loyalty** — long-running streaks earn meaningfully more SP (up to 2× daily rate after day 30).

---

## How It Works

### Qualification (per day)

A student qualifies for a streak day if, on at least one session that calendar date:

- `attendancePercentage >= 85%` (from `attendancerecords`)
- `poll participation >= 85%` (from `pollrecords`)

If no attendance records exist (dev / pre-pipeline), the system falls back to `sptransactions`: `appliedDelta >= 10` (which implies >= 90%) satisfies the 85% threshold.

### Sunday logic

- Sundays are **skipped entirely** — `nextWeekday()` advances from Friday→Monday, so a Friday→Saturday→Monday chain is consecutive.
- The system uses `isConsecutiveGap(lastQualifyingDate, candidateDate)` which internally calls `nextWeekday()` instead of naive `addDays(..., 1)`.

### Eligibility cutoff

Only students whose `internshipStartDate >= 2026-07-16` are eligible. Students who started before this date receive no streak processing. This is enforced both at the service level and in the cron script.

### SP rewards

| Streak day | SP earned |
|------------|-----------|
| Days 1–9 | 1 SP/day |
| Day 10 (milestone) | **5 SP** |
| Days 11–19 | 1 SP/day |
| Day 20 (milestone) | **7 SP** |
| Days 21–29 | 1 SP/day |
| Day 30 (milestone) | **9 SP** |
| Days 31–39 | 2 SP/day |
| Day 40 (milestone) | **11 SP** |
| Every 10th day after 30 | +2 more than previous milestone |

**Milestone formula:** `3 + (streakDay / 10) * 2`

### Hearts (streak savers)

- Each student starts with **2 hearts**.
- If a qualifying day is missed, a heart is consumed to **preserve the streak** instead of resetting to 0.
- Hearts are **never used during backfill** — only during live daily processing or manual claim.
- When a heart is used, `lastQualifyingDate` is updated to the heart-saved date, resetting the gap counter so consecutive hearts work correctly.
- Losing both hearts resets the streak to 0.

---

## What Changed

### New files

| File | Purpose |
|------|---------|
| `server/models/Streak.js` | Mongoose schema for `streaks` collection (currentStreak, longestStreak, hearts, history, milestones) |
| `server/services/streakService.js` | Core business logic — `processAllStudents`, `processDay`, `claimDailyStreak`, `getStreakStatus`, qualification checks, Sunday/gap/heart logic |
| `server/cron/streakDaily.js` | Standalone Node script for daily cron execution. Uses raw MongoDB driver, IST-aware date handling, `BACKFILL=1` mode, `DRY_RUN=1` mode |
| `server/services/__tests__/streakService.test.js` | 37 unit tests covering all edge cases |

### Modified files

| File | Change |
|------|--------|
| `server/server.js` | +streak imports, `streak` field in profile payload, `'streak'` in category totals, 4 new API routes (`GET/POST /api/streak`, `GET /api/admin/streaks`, `POST /api/admin/streak/process-all`) |
| `server/config.js` | `STREAK_CUTOFF_DATE = '2026-07-16'`, threshold constants |
| `server/models/SPTransaction.js` | Added `'streak'` to category enum |
| `client/src/main.jsx` | `StreakCard` (compact dashboard summary) + `StreakDetail` (full tab with stats grid, rules, history table) components |
| `client/src/styles.css` | 75 lines of streak CSS (card layout, detail grid, rules panel, history table) |
| `CONTEXT.md` | Full documentation — feature explanation, schema, API endpoints, cron config, admin deployment guide |
| `package.json` | Added `vitest` devDependency + `test`/`test:watch` scripts |

---

## API Endpoints

| Method | Route | Auth | Description |
|--------|-------|------|-------------|
| `GET` | `/api/streak` | Student (cookie) | Returns streak status for the logged-in student |
| `POST` | `/api/streak/claim` | Student (cookie) | Manually claim streak SP from the dashboard |
| `GET` | `/api/admin/streaks` | Admin guard | List all streak documents, sorted and limited |
| `POST` | `/api/admin/streak/process-all` | Admin guard | Trigger daily streak processing for all students |

Streak data is also embedded in the profile response (`profile.streak`) returned by `/api/me`.

---

## Testing

- **37 unit tests** in `server/services/__tests__/streakService.test.js` covering:
  - Qualification logic (attendance + poll thresholds)
  - Gap detection (consecutive days, Sunday skipping, multi-day gaps)
  - Milestone calculations (day 10, 20, 30, 40+)
  - Heart consumption and streak preservation
  - Backfill mode (no hearts used)
  - Sunday skip in `processAllStudents`, `processDay`, `claimDailyStreak`, `getStreakStatus`
  - Cutoff date enforcement
- `npx vitest run` — **37/37 passing**
- `npm run build` (client Vite build) — **passes**

---

## Post-Merge Deployment

### 1. Pull and build on production

```bash
cd /home/sakshi/spurti
git pull origin main
npm install
npm --prefix client install && npm run build
```

### 2. Restart the Express server

```bash
# Restart however the server is managed (pm2, systemd, etc.)
pm2 restart spurti
```

No manual DB migration needed — the `streaks` collection is auto-created by MongoDB/Mongoose on first write.

### 3. One-time backfill (historical streak data)

Preview first (dry run):
```bash
BACKFILL=1 DRY_RUN=1 node server/cron/streakDaily.js
```

Then run for real:
```bash
BACKFILL=1 node server/cron/streakDaily.js
```

This processes every active student with `internshipStartDate >= 2026-07-16` from their start date through yesterday. Students who started before the cutoff date are automatically skipped.

### 4. Set up daily cron job

Add to crontab (`crontab -e`) to run after the main SP pipeline each day:

```
# Streak processing — runs daily at 23:59 IST (18:59 UTC) after pipeline
59 18 * * * cd /home/sakshi/spurti && node server/cron/streakDaily.js >> /home/sakshi/spurti/logs/streak.log 2>&1
```

The script automatically:
- Skips Sundays (shifts target date to Saturday if needed)
- Skips students before the cutoff date
- Handles `nextWeekday()` gap logic (same as the service layer)

### 5. Verify

| Check | Command / URL |
|-------|---------------|
| Student dashboard | Open `/spurti` as a student — streak card + "Streak" tab should appear |
| Admin: list streaks | `GET /api/admin/streaks` — should return scored students |
| Admin: manual trigger | `POST /api/admin/streak/process-all` with `{ "date": "2026-07-17" }` |
| Cron logs | `tail -f /home/sakshi/spurti/logs/streak.log` |

### No other action needed

- No `.env` changes required — the cron script uses existing `MONGO_URI`
- No schema migration — Mongoose auto-creates the `streaks` collection
- Frontend is built into `client/dist` and served as static files
