### PR TITLE
feat: add voting feature for challenges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ sp-runs/
 
 # student data — LOCAL ONLY, never commit (untracked 2026-07-14)
 data/
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,3 @@ pipeline/.env
 server.log
 sp-runs/
 
-# student data — LOCAL ONLY, never commit (untracked 2026-07-14)
-data/
-
-

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+    <option name="applicationTheme" value="default" />
+    <option name="iconsTheme" value="default" />
+    <option name="button1Title" value="" />
+    <option name="button1Url" value="" />
+    <option name="button2Title" value="" />
+    <option name="button2Url" value="" />
+    <option name="customApplicationId" value="" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/project-demo.iml" filepath="$PROJECT_DIR$/.idea/project-demo.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/project-demo.iml
+++ b/.idea/project-demo.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,25 @@
+# Upvote Challenge System
+
+Adds a voting-based weekly challenge system to Spurti. Students spend SP to vote on proposed challenges. The challenge with the most SP wins and becomes active. Only voters of the winning challenge are eligible to participate; on completion they receive their invested SP back multiplied by the challenge's `rewardMultiplier`.
+
+## How it works
+
+- Proposed challenges appear in a new **Challenges** tab in the student dashboard, each with a voting window, type (`attendance` / `poll_participation`), and reward multiplier.
+- Students spend SP to vote. They can add more SP to an existing vote or withdraw (full refund) any time before voting closes.
+- An admin resolves the round once voting ends. The challenge with the highest `totalSpInvested` transitions to `active` with a 7-day live window; all others are archived.
+- Students who voted for the winning challenge are enrolled. On completion they earn `spInvested * rewardMultiplier` SP credited back via `challenge_reward` transactions.
+- SP spent on losing challenges is forfeited. Withdrawals are only possible during the voting phase.
+
+## Endpoints
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/api/challenges/proposed` | Open challenges + user's votes + SP balance |
+| `GET` | `/api/challenges/active` | Currently active challenge + enrollment status |
+| `POST` | `/api/challenges/:id/vote` | Cast or increment a vote (`{ spPoints: number }`) |
+| `POST` | `/api/challenges/:id/withdraw` | Withdraw vote, refund SP |
+| `POST` | `/api/admin/challenges/:id/resolve` | Resolve round — pick winner, activate, archive losers |
+
+## Seed data
+
+Run `node server/scripts/seedChallenges.js` to create 3 sample proposed challenges with 7-day voting windows (idempotent — skips if challenges already exist).

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -782,9 +782,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,9 +794,6 @@
       "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -814,9 +808,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -829,9 +820,6 @@
       "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -846,9 +834,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -861,9 +846,6 @@
       "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -878,9 +860,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -893,9 +872,6 @@
       "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -910,9 +886,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -925,9 +898,6 @@
       "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -942,9 +912,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,9 +925,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -973,9 +937,6 @@
       "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -279,11 +279,12 @@ function StudentView({ profile, onBack }) {
       </header>
       <LevelStatus student={student} />
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'],
+      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'], ['challenges','Challenges'],
         ...(student.eligibleForVibeGoals ? [['journey','My Journey'], ['vibe','Commitments']] : []),
         ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
+      {tab === 'challenges' && <ChallengesHub student={student} />}
       {tab === 'journey' && student.eligibleForVibeGoals && <MyJourney student={student} setTab={setTab} />}
       {tab === 'vibe' && student.eligibleForVibeGoals && <Commitments student={student} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
@@ -1205,6 +1206,154 @@ function AllStudentsPanel({ stats, onStudent, auth }) {
         </table>
       )}
     </section>
+  );
+}
+
+
+function ChallengesHub({ student }) {
+  const [data, setData] = useState(null);
+  const [active, setActive] = useState(null);
+  const [voteInputs, setVoteInputs] = useState({});
+  const [err, setErr] = useState(null);
+
+  const load = async () => {
+    const [propRes, actRes] = await Promise.all([
+      fetch(`${API}/challenges/proposed?email=${encodeURIComponent(student.email)}`),
+      fetch(`${API}/challenges/active?email=${encodeURIComponent(student.email)}`)
+    ]);
+    if (propRes.ok) setData(await propRes.json());
+    if (actRes.ok) setActive(await actRes.json());
+  };
+  useEffect(() => { load(); }, [student.email]);
+
+  const post = async (url, body) => {
+    const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    const j = await r.json();
+    if (!r.ok) { setErr(j.error); return null; }
+    setErr(null);
+    return j;
+  };
+
+  const vote = async (challengeId) => {
+    const sp = +voteInputs[challengeId] || 0;
+    if (sp <= 0) return;
+    const j = await post(`${API}/challenges/${challengeId}/vote`, { email: student.email, spPoints: sp });
+    if (j) { setData(j); setVoteInputs({ ...voteInputs, [challengeId]: '' }); }
+  };
+
+  const withdraw = async (challengeId) => {
+    const j = await post(`${API}/challenges/${challengeId}/withdraw`, { email: student.email });
+    if (j) setData(j);
+  };
+
+  if (!data) return <section className="panel">Loading challenges…</section>;
+
+  const { challenges, userVotes, totalSp } = data;
+  const balance = totalSp;
+
+  return (
+    <div className="ch">
+      <section className="panel">
+        <h2>Upvote Challenges</h2>
+        <p className="muted">Spend your SP to vote for the next weekly challenge. The challenge with the most SP wins and becomes active — only voters can participate. If your challenge wins, you get your invested SP back multiplied!</p>
+      </section>
+
+      {/* Active challenge */}
+      {active?.challenge && (
+        <section className="panel">
+          <h2>Active Challenge</h2>
+          <div className="vg-bet ch-active-card">
+            <div>
+              <h4>{active.challenge.title}</h4>
+              <p className="meta">{active.challenge.description}</p>
+              <div className="meta">Runs until {new Date(active.challenge.liveEndDate).toLocaleDateString()} · {active.challenge.rewardMultiplier}× reward</div>
+            </div>
+            <div className="side">
+              {active.enrolled
+                ? <span className="vg-pill green">You're in! 🎯</span>
+                : <span className="vg-pill amber">Not enrolled</span>}
+            </div>
+          </div>
+          <p className="muted" style={{ marginTop: 8 }}>
+            {active.enrolled
+              ? `Challenge runs until ${new Date(active.challenge.liveEndDate).toLocaleDateString()}. Complete it to earn ${active.challenge.rewardMultiplier}× your invested SP!`
+              : 'This challenge is exclusive to voters. Vote in the next round to participate.'}
+          </p>
+        </section>
+      )}
+
+      {/* SP balance */}
+      <section className="panel ch-balance">
+        <h2>Your SP</h2>
+        <strong>{balance} SP</strong>
+        <span>available for voting</span>
+      </section>
+
+      {/* Proposed challenges */}
+      <section className="panel">
+        <h2>Vote for the next challenge</h2>
+        <p className="muted">Voting closes when the deadline passes. Put your SP behind the challenge you want to see next!</p>
+      </section>
+
+      {challenges.length === 0 ? (
+        <section className="panel empty">No proposed challenges right now — check back later.</section>
+      ) : (
+        <div className="ch-grid">
+          {challenges.map(c => {
+            const myVote = userVotes[c._id] || 0;
+            const inputVal = voteInputs[c._id] || '';
+            const inputSp = +inputVal || 0;
+            const tooHigh = inputSp > balance - myVote;
+            const totalInvested = c.totalSpInvested || 0;
+            const maxInvested = Math.max(1, ...challenges.map(x => x.totalSpInvested || 0));
+            const barPct = Math.round((totalInvested / maxInvested) * 100);
+
+            return (
+              <article className="ch-card" key={c._id}>
+                <div className="ch-card-head">
+                  <strong>{c.title}</strong>
+                  <div className="ch-badges">
+                    <span className="ch-badge">{c.type === 'attendance' ? 'Attendance' : 'Poll Master'}</span>
+                    <span className="ch-badge ch-badge-mult">{c.rewardMultiplier}× reward</span>
+                  </div>
+                  <p className="ch-desc">{c.description}</p>
+                </div>
+
+                <div className="ch-bar-wrap">
+                  <span className="ch-bar-label">Total SP invested: <b>{totalInvested}</b></span>
+                  <div className="vg-progress ch-bar"><i style={{ width: `${barPct}%` }} /></div>
+                </div>
+
+                <div className="ch-meta">
+                  Voting closes {new Date(c.votingEndDate).toLocaleDateString()}
+                </div>
+
+                {myVote > 0 && (
+                  <div className="ch-my-vote">
+                    <span className="vg-pill green">Your vote: {myVote} SP</span>
+                  </div>
+                )}
+
+                <div className="ch-actions">
+                  <input type="number" min="1" max={balance - myVote}
+                    placeholder="SP to vote"
+                    value={inputVal}
+                    onChange={e => setVoteInputs({ ...voteInputs, [c._id]: e.target.value })} />
+                  <button className="primary" disabled={!inputVal || inputSp <= 0 || tooHigh}
+                    onClick={() => vote(c._id)}>Vote</button>
+                  {myVote > 0 && (
+                    <button className="secondary" onClick={() => withdraw(c._id)}>Withdraw</button>
+                  )}
+                </div>
+                {tooHigh && <p className="ch-warn">Not enough SP (balance: {balance - myVote})</p>}
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      {err && <p className="error">{err}</p>}
+    </div>
   );
 }
 

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1303,10 +1303,15 @@ function ChallengesHub({ student }) {
             const myVote = userVotes[c._id] || 0;
             const inputVal = voteInputs[c._id] || '';
             const inputSp = +inputVal || 0;
-            const tooHigh = inputSp > balance - myVote;
+            const tooHigh = inputSp > balance;
             const totalInvested = c.totalSpInvested || 0;
             const maxInvested = Math.max(1, ...challenges.map(x => x.totalSpInvested || 0));
             const barPct = Math.round((totalInvested / maxInvested) * 100);
+
+            const now = Date.now();
+            const votingStarted = now >= new Date(c.votingStartDate).getTime();
+            const votingEnded = now > new Date(c.votingEndDate).getTime();
+            const votingOpen = votingStarted && !votingEnded;
 
             return (
               <article className="ch-card" key={c._id}>
@@ -1325,7 +1330,13 @@ function ChallengesHub({ student }) {
                 </div>
 
                 <div className="ch-meta">
-                  Voting closes {new Date(c.votingEndDate).toLocaleDateString()}
+                  {!votingStarted ? (
+                    `Voting starts ${new Date(c.votingStartDate).toLocaleDateString()}`
+                  ) : votingEnded ? (
+                    `Voting ended on ${new Date(c.votingEndDate).toLocaleDateString()} · Awaiting resolution`
+                  ) : (
+                    `Voting closes ${new Date(c.votingEndDate).toLocaleDateString()}`
+                  )}
                 </div>
 
                 {myVote > 0 && (
@@ -1335,17 +1346,18 @@ function ChallengesHub({ student }) {
                 )}
 
                 <div className="ch-actions">
-                  <input type="number" min="1" max={balance - myVote}
+                  <input type="number" min="1" max={balance}
                     placeholder="SP to vote"
+                    disabled={!votingOpen}
                     value={inputVal}
                     onChange={e => setVoteInputs({ ...voteInputs, [c._id]: e.target.value })} />
-                  <button className="primary" disabled={!inputVal || inputSp <= 0 || tooHigh}
+                  <button className="primary" disabled={!votingOpen || !inputVal || inputSp <= 0 || tooHigh}
                     onClick={() => vote(c._id)}>Vote</button>
                   {myVote > 0 && (
-                    <button className="secondary" onClick={() => withdraw(c._id)}>Withdraw</button>
+                    <button className="secondary" disabled={!votingOpen} onClick={() => withdraw(c._id)}>Withdraw</button>
                   )}
                 </div>
-                {tooHigh && <p className="ch-warn">Not enough SP (balance: {balance - myVote})</p>}
+                {tooHigh && <p className="ch-warn">Not enough SP (balance: {balance})</p>}
               </article>
             );
           })}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -640,3 +640,30 @@ input {
 .cm-body { padding: 4px 14px 14px; border-top: 1px solid var(--line); }
 .cm-body .vg { margin-top: 8px; }
 .cm-soon { color: var(--muted); font-size: 14px; line-height: 1.6; padding: 10px 2px; }
+
+/* ---- Upvote Challenges tab -------------------------------------------------- */
+.ch { display: grid; gap: 16px; }
+.ch .panel h2 { margin-bottom: 4px; }
+.ch-balance { display: flex; align-items: center; gap: 12px; padding: 16px 20px; }
+.ch-balance strong { font-size: 28px; color: var(--primary); }
+.ch-balance span { color: var(--muted); font-size: 14px; }
+.ch-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+@media (max-width: 720px) { .ch-grid { grid-template-columns: 1fr; } }
+.ch-card { border: 1px solid var(--line); border-radius: 10px; padding: 16px; background: var(--panel); box-shadow: var(--shadow); display: flex; flex-direction: column; gap: 10px; }
+.ch-card-head strong { display: block; font-size: 16px; margin-bottom: 6px; }
+.ch-badges { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 6px; }
+.ch-badge { display: inline-block; border-radius: 999px; padding: 2px 8px; font-size: 11px; font-weight: 800; background: #eef2ff; color: var(--text); }
+.ch-badge-mult { background: #fef3e2; color: var(--amber); }
+.ch-desc { color: var(--muted); font-size: 13px; margin: 0; line-height: 1.5; }
+.ch-bar-wrap { }
+.ch-bar-label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+.ch-bar-label b { color: var(--text); }
+.ch-bar { margin-top: 0; }
+.ch-meta { color: var(--muted); font-size: 12px; }
+.ch-my-vote { }
+.ch-actions { display: flex; gap: 8px; align-items: center; }
+.ch-actions input { flex: 1; min-width: 0; border: 1px solid var(--line); border-radius: 7px; padding: 8px 10px; background: #fff; color: var(--text); font-size: 13px; }
+.ch-actions button { white-space: nowrap; min-height: 36px; }
+.ch-warn { color: var(--red); font-size: 12px; font-weight: 700; margin: 0; }
+.ch-active-card { margin-bottom: 0; }
+.ch-active-card .side .vg-pill { font-size: 13px; padding: 4px 12px; }

--- a/server/models/Challenge.js
+++ b/server/models/Challenge.js
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+
+const challengeSchema = new mongoose.Schema({
+  title: { type: String, required: true, index: true },
+  description: { type: String, default: '' },
+  type: {
+    type: String,
+    required: true,
+    enum: ['attendance', 'poll_participation'],
+    index: true
+  },
+  status: {
+    type: String,
+    enum: ['proposed', 'active', 'completed', 'archived'],
+    default: 'proposed',
+    index: true
+  },
+  rewardMultiplier: { type: Number, default: 2 },
+  votingStartDate: { type: Date, required: true, index: true },
+  votingEndDate: { type: Date, required: true, index: true },
+  liveStartDate: { type: Date, default: null },
+  liveEndDate: { type: Date, default: null },
+  totalSpInvested: { type: Number, default: 0 },
+  winnerEmails: { type: [String], default: [] }
+}, { timestamps: true });
+
+challengeSchema.index({ status: 1, votingEndDate: 1 });
+
+export default mongoose.model('Challenge', challengeSchema);

--- a/server/models/ChallengeVote.js
+++ b/server/models/ChallengeVote.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+const challengeVoteSchema = new mongoose.Schema({
+  email: { type: String, required: true, lowercase: true, trim: true, index: true },
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', index: true },
+  challengeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Challenge', required: true, index: true },
+  spInvested: { type: Number, required: true },
+  status: { type: String, enum: ['active', 'withdrawn'], default: 'active', index: true },
+  withdrawnAt: { type: Date, default: null }
+}, { timestamps: true });
+
+challengeVoteSchema.index({ email: 1, challengeId: 1, status: 1 }, { unique: true });
+
+export default mongoose.model('ChallengeVote', challengeVoteSchema);

--- a/server/models/ChallengeVote.js
+++ b/server/models/ChallengeVote.js
@@ -9,6 +9,6 @@ const challengeVoteSchema = new mongoose.Schema({
   withdrawnAt: { type: Date, default: null }
 }, { timestamps: true });
 
-challengeVoteSchema.index({ email: 1, challengeId: 1, status: 1 }, { unique: true });
+challengeVoteSchema.index({ email: 1, challengeId: 1 }, { unique: true });
 
 export default mongoose.model('ChallengeVote', challengeVoteSchema);

--- a/server/models/SPTransaction.js
+++ b/server/models/SPTransaction.js
@@ -6,7 +6,7 @@ const spTransactionSchema = new mongoose.Schema({
   category: {
     type: String,
     required: true,
-    enum: ['initial', 'attendance', 'poll', 'manual'],
+    enum: ['initial', 'attendance', 'poll', 'manual', 'challenge_vote', 'challenge_reward'],
     index: true
   },
   sessionLabel: { type: String, default: '', index: true },

--- a/server/scripts/rebuild.js
+++ b/server/scripts/rebuild.js
@@ -195,7 +195,7 @@ async function run() {
   await mongoose.connect(MONGO_URI);
 
   await Promise.all([
-    // Student.deleteMany({}), // SKIPPED - students already seeded
+    Student.deleteMany({}),
     Session.deleteMany({}),
     AttendanceRecord.deleteMany({}),
     PollRecord.deleteMany({}),
@@ -204,7 +204,7 @@ async function run() {
   ]);
 
   const roster = parseRoster();
-  // await Student.insertMany(roster); // SKIPPED - students already seeded
+  await Student.insertMany(roster);
   const students = await Student.find().sort({ name: 1 });
   const byEmail = new Map();
   const byAltEmail = new Map();
@@ -219,7 +219,7 @@ async function run() {
 
   const balances = new Map();
   for (const student of students) {
-    await addTransaction(student, 'initial', '', 100, 'Initial Spurti Points credited by system on onboarding.', student.internshipStartDate, balances);
+    await addTransaction(student, 'initial', '', 100, 'Initial Spurti Points credited by system on onboarding.', student.internshipStartDate || new Date(), balances);
   }
 
   for (const sessionConfig of SESSIONS) {

--- a/server/scripts/seedChallenges.js
+++ b/server/scripts/seedChallenges.js
@@ -1,0 +1,54 @@
+// Seed sample proposed challenges for the Upvote Challenge system.
+// Idempotent — skips if challenges already exist.
+import mongoose from 'mongoose';
+import { MONGO_URI } from '../config.js';
+import Challenge from '../models/Challenge.js';
+
+const SAMPLE_CHALLENGES = [
+  {
+    title: 'Perfect Attendance Week',
+    description: 'Attend every session this week without missing a single one. Perfect attendance earns you the reward!',
+    type: 'attendance',
+    rewardMultiplier: 3,
+    votingStartDate: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000),    // tomorrow
+    votingEndDate: new Date(Date.now() + 8 * 24 * 60 * 60 * 1000),      // 7 days voting
+  },
+  {
+    title: 'Poll Master',
+    description: 'Attempt every single poll question for the week. Show your engagement by answering all polls completely.',
+    type: 'poll_participation',
+    rewardMultiplier: 2,
+    votingStartDate: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000),
+    votingEndDate: new Date(Date.now() + 8 * 24 * 60 * 60 * 1000),
+  },
+  {
+    title: 'Engagement Champion',
+    description: 'Maintain perfect attendance throughout the week to qualify as an Engagement Champion.',
+    type: 'attendance',
+    rewardMultiplier: 4,
+    votingStartDate: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000),
+    votingEndDate: new Date(Date.now() + 8 * 24 * 60 * 60 * 1000),
+  }
+];
+
+async function seed() {
+  await mongoose.connect(MONGO_URI);
+  console.log('Connected to MongoDB');
+
+  const existing = await Challenge.countDocuments();
+  if (existing > 0) {
+    console.log(`Found ${existing} existing challenges — skipping seed.`);
+    await mongoose.disconnect();
+    return;
+  }
+
+  await Challenge.insertMany(SAMPLE_CHALLENGES);
+  console.log(`Inserted ${SAMPLE_CHALLENGES.length} sample challenges.`);
+  await mongoose.disconnect();
+  console.log('Done.');
+}
+
+seed().catch(err => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -14,9 +14,12 @@ import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import Commitment from './models/Commitment.js';
+import Challenge from './models/Challenge.js';
+import ChallengeVote from './models/ChallengeVote.js';
 import { isVibeEligible, buildVibeState, validateBet, settleBetDemo, applySpDelta, courseByKey } from './services/vibe.js';
 import { buildStandupState, placeStandup, settleStandupDemo } from './services/standup.js';
 import { buildJourneyState, saveJourneyPlan } from './services/journey.js';
+import { castVote, withdrawVote, resolveChallenge, buildActiveState, buildProposedState } from './services/challenge.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -516,6 +519,66 @@ function registerSurveyRoutes(base, cfg) {
 }
 registerSurveyRoutes('/survey', SURVEY);
 registerSurveyRoutes('/poll2', POLL2);
+
+// ---- Upvote Challenges (voting + resolution) ---------------------------------
+async function challengeStudent(req) {
+  const email = normalizeEmail(req.query.email || req.body?.email) || await studentEmailFromRequest(req);
+  if (!email) return null;
+  return Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+}
+
+api.get('/challenges/proposed', async (req, res) => {
+  const student = await challengeStudent(req);
+  if (!student) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const state = await buildProposedState(student.email);
+    res.json(state);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+api.get('/challenges/active', async (req, res) => {
+  const student = await challengeStudent(req);
+  if (!student) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const state = await buildActiveState(student.email);
+    res.json(state);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+api.post('/challenges/:id/vote', async (req, res) => {
+  const student = await challengeStudent(req);
+  if (!student) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const state = await castVote(student.email, req.params.id, req.body?.spPoints);
+    res.json(state);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+api.post('/challenges/:id/withdraw', async (req, res) => {
+  const student = await challengeStudent(req);
+  if (!student) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const state = await withdrawVote(student.email, req.params.id);
+    res.json(state);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+api.post('/admin/challenges/:id/resolve', adminGuard, async (req, res) => {
+  try {
+    const challenge = await resolveChallenge(req.params.id);
+    res.json({ challenge });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
 
 api.get('/admin/stats', adminGuard, async (_req, res) => {
   const [yetToOnboard, excusedStudents, sessions, txns, activeStudents] = await Promise.all([

--- a/server/services/challenge.js
+++ b/server/services/challenge.js
@@ -1,0 +1,154 @@
+// Challenge Upvote System — vote/resolve logic.
+import Student from '../models/Student.js';
+import Challenge from '../models/Challenge.js';
+import ChallengeVote from '../models/ChallengeVote.js';
+import SPTransaction from '../models/SPTransaction.js';
+
+// Apply an SP change and write a matching SP-Bank transaction. Based on applySpDelta
+// from vibe.js but uses the challenge category so the SP Bank shows the right reason.
+async function applySpWithCategory(email, delta, category, reason) {
+  const student = await Student.findOne({ email });
+  if (!student) throw new Error('Student not found');
+  const newTotal = (student.totalSp || 0) + delta;
+  student.totalSp = newTotal;
+  if (newTotal > (student.highestSpEver || 0)) student.highestSpEver = newTotal;
+  await student.save();
+  const last = await SPTransaction.findOne({ email }).sort({ dateTime: -1 }).lean();
+  const when = new Date(Math.max(Date.now(), (last?.dateTime ? new Date(last.dateTime).getTime() + 60000 : 0)));
+  await SPTransaction.create({
+    email, studentId: student._id, category, sessionLabel: '',
+    deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: newTotal, reason, dateTime: when
+  });
+  return newTotal;
+}
+
+// Cast a vote (or add SP to an existing active vote) for a proposed challenge.
+// Returns the updated state: { challenges, userVotes, totalSp }.
+export async function castVote(email, challengeId, spPoints) {
+  const [challenge, student] = await Promise.all([
+    Challenge.findById(challengeId).lean(),
+    Student.findOne({ $or: [{ email }, { alternateEmail: email }] })
+  ]);
+  if (!challenge) throw new Error('Challenge not found');
+  if (challenge.status !== 'proposed') throw new Error('Voting is closed for this challenge');
+  const now = new Date();
+  if (now < new Date(challenge.votingStartDate)) throw new Error('Voting has not started yet');
+  if (now > new Date(challenge.votingEndDate)) throw new Error('Voting has ended');
+  if (!student) throw new Error('Student not found');
+  if (spPoints <= 0) throw new Error('SP must be positive');
+  if (student.totalSp < spPoints) throw new Error('Not enough SP');
+
+  // Upsert the vote: if an active vote exists, increment it; otherwise create one.
+  const existing = await ChallengeVote.findOne({ email, challengeId: challengeId, status: 'active' });
+  if (existing) {
+    existing.spInvested += spPoints;
+    await existing.save();
+  } else {
+    await ChallengeVote.create({ email, studentId: student._id, challengeId, spInvested: spPoints, status: 'active' });
+  }
+
+  await applySpWithCategory(email, -spPoints, 'challenge_vote',
+    `Voted ${spPoints} SP on challenge: ${challenge.title}`);
+  await Challenge.findByIdAndUpdate(challengeId, { $inc: { totalSpInvested: spPoints } });
+
+  return buildProposedState(email);
+}
+
+// Withdraw an active vote and refund the SP.
+// Returns the updated state: { challenges, userVotes, totalSp }.
+export async function withdrawVote(email, challengeId) {
+  const vote = await ChallengeVote.findOne({ email, challengeId, status: 'active' });
+  if (!vote) throw new Error('No active vote found for this challenge');
+
+  const challenge = await Challenge.findById(challengeId).lean();
+  if (!challenge) throw new Error('Challenge not found');
+  if (challenge.status !== 'proposed') throw new Error('Can only withdraw during voting phase');
+
+  vote.status = 'withdrawn';
+  vote.withdrawnAt = new Date();
+  await vote.save();
+
+  await applySpWithCategory(email, vote.spInvested, 'challenge_vote',
+    `Withdrew vote — refunded ${vote.spInvested} SP from challenge: ${challenge.title}`);
+  await Challenge.findByIdAndUpdate(challengeId, { $inc: { totalSpInvested: -vote.spInvested } });
+
+  return buildProposedState(email);
+}
+
+// Admin: resolve the voting round — pick the challenge with the highest totalSpInvested,
+// set it ACTIVE, archive all others, store winner emails. Returns the winning challenge.
+export async function resolveChallenge(resolvingChallengeId) {
+  const challenge = await Challenge.findById(resolvingChallengeId).lean();
+  if (!challenge) throw new Error('Challenge not found');
+  if (challenge.status !== 'proposed') throw new Error('Challenge is not in proposed state');
+
+  // Find the challenge with the highest totalSpInvested
+  const winner = await Challenge.findOne({
+    status: 'proposed',
+    votingEndDate: { $lte: new Date() }
+  }).sort({ totalSpInvested: -1 }).lean();
+  if (!winner) throw new Error('No eligible challenge to resolve');
+
+  const now = new Date();
+  const liveEnd = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  // Set winner as active
+  await Challenge.findByIdAndUpdate(winner._id, {
+    $set: { status: 'active', liveStartDate: now, liveEndDate: liveEnd }
+  });
+
+  // Archive all other proposed challenges
+  await Challenge.updateMany(
+    { status: 'proposed', _id: { $ne: winner._id } },
+    { $set: { status: 'archived' } }
+  );
+
+  // Store winner emails from active votes on the winning challenge
+  const activeVotes = await ChallengeVote.find({
+    challengeId: winner._id,
+    status: 'active'
+  }).lean();
+  const winnerEmails = activeVotes.map(v => v.email);
+  await Challenge.findByIdAndUpdate(winner._id, { $set: { winnerEmails } });
+
+  return Challenge.findById(winner._id).lean();
+}
+
+// Build the proposed challenges state for a student.
+async function buildProposedState(email) {
+  const now = new Date();
+  const challenges = await Challenge.find({
+    status: 'proposed',
+    votingEndDate: { $gt: now }
+  }).sort({ votingEndDate: 1 }).lean();
+
+  const userVotesDocs = await ChallengeVote.find({
+    email,
+    status: 'active',
+    challengeId: { $in: challenges.map(c => c._id) }
+  }).lean();
+
+  const userVotes = {};
+  for (const v of userVotesDocs) {
+    userVotes[v.challengeId.toString()] = v.spInvested;
+  }
+
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  return { challenges, userVotes, totalSp: student ? student.totalSp : 0 };
+}
+
+// Build the active challenge state for a student.
+export async function buildActiveState(email) {
+  const challenge = await Challenge.findOne({ status: 'active' }).lean();
+  if (!challenge) return { challenge: null, enrolled: false };
+
+  const vote = await ChallengeVote.findOne({
+    email,
+    challengeId: challenge._id,
+    status: 'active'
+  }).lean();
+
+  return { challenge, enrolled: !!vote };
+}
+
+export { buildProposedState };

--- a/server/services/challenge.js
+++ b/server/services/challenge.js
@@ -7,16 +7,17 @@ import SPTransaction from '../models/SPTransaction.js';
 // Apply an SP change and write a matching SP-Bank transaction. Based on applySpDelta
 // from vibe.js but uses the challenge category so the SP Bank shows the right reason.
 async function applySpWithCategory(email, delta, category, reason) {
-  const student = await Student.findOne({ email });
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] });
   if (!student) throw new Error('Student not found');
+  const canonicalEmail = student.email;
   const newTotal = (student.totalSp || 0) + delta;
   student.totalSp = newTotal;
   if (newTotal > (student.highestSpEver || 0)) student.highestSpEver = newTotal;
   await student.save();
-  const last = await SPTransaction.findOne({ email }).sort({ dateTime: -1 }).lean();
+  const last = await SPTransaction.findOne({ email: canonicalEmail }).sort({ dateTime: -1 }).lean();
   const when = new Date(Math.max(Date.now(), (last?.dateTime ? new Date(last.dateTime).getTime() + 60000 : 0)));
   await SPTransaction.create({
-    email, studentId: student._id, category, sessionLabel: '',
+    email: canonicalEmail, studentId: student._id, category, sessionLabel: '',
     deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: newTotal, reason, dateTime: when
   });
   return newTotal;
@@ -25,6 +26,11 @@ async function applySpWithCategory(email, delta, category, reason) {
 // Cast a vote (or add SP to an existing active vote) for a proposed challenge.
 // Returns the updated state: { challenges, userVotes, totalSp }.
 export async function castVote(email, challengeId, spPoints) {
+  const points = Number(spPoints);
+  if (!Number.isInteger(points) || points <= 0) {
+    throw new Error('SP points must be a positive integer');
+  }
+
   const [challenge, student] = await Promise.all([
     Challenge.findById(challengeId).lean(),
     Student.findOne({ $or: [{ email }, { alternateEmail: email }] })
@@ -35,61 +41,82 @@ export async function castVote(email, challengeId, spPoints) {
   if (now < new Date(challenge.votingStartDate)) throw new Error('Voting has not started yet');
   if (now > new Date(challenge.votingEndDate)) throw new Error('Voting has ended');
   if (!student) throw new Error('Student not found');
-  if (spPoints <= 0) throw new Error('SP must be positive');
-  if (student.totalSp < spPoints) throw new Error('Not enough SP');
+  if (student.totalSp < points) throw new Error('Not enough SP');
 
-  // Upsert the vote: if an active vote exists, increment it; otherwise create one.
-  const existing = await ChallengeVote.findOne({ email, challengeId: challengeId, status: 'active' });
+  const canonicalEmail = student.email;
+
+  // Re-use existing vote record for this student and challenge (whether active or withdrawn)
+  const existing = await ChallengeVote.findOne({ email: canonicalEmail, challengeId });
   if (existing) {
-    existing.spInvested += spPoints;
+    if (existing.status === 'active') {
+      existing.spInvested += points;
+    } else {
+      existing.status = 'active';
+      existing.spInvested = points;
+      existing.withdrawnAt = null;
+    }
     await existing.save();
   } else {
-    await ChallengeVote.create({ email, studentId: student._id, challengeId, spInvested: spPoints, status: 'active' });
+    await ChallengeVote.create({ email: canonicalEmail, studentId: student._id, challengeId, spInvested: points, status: 'active' });
   }
 
-  await applySpWithCategory(email, -spPoints, 'challenge_vote',
-    `Voted ${spPoints} SP on challenge: ${challenge.title}`);
-  await Challenge.findByIdAndUpdate(challengeId, { $inc: { totalSpInvested: spPoints } });
+  await applySpWithCategory(canonicalEmail, -points, 'challenge_vote',
+    `Voted ${points} SP on challenge: ${challenge.title}`);
+  await Challenge.findByIdAndUpdate(challengeId, { $inc: { totalSpInvested: points } });
 
-  return buildProposedState(email);
+  return buildProposedState(canonicalEmail);
 }
 
 // Withdraw an active vote and refund the SP.
 // Returns the updated state: { challenges, userVotes, totalSp }.
 export async function withdrawVote(email, challengeId) {
-  const vote = await ChallengeVote.findOne({ email, challengeId, status: 'active' });
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  if (!student) throw new Error('Student not found');
+  const canonicalEmail = student.email;
+
+  const vote = await ChallengeVote.findOne({ email: canonicalEmail, challengeId, status: 'active' });
   if (!vote) throw new Error('No active vote found for this challenge');
 
   const challenge = await Challenge.findById(challengeId).lean();
   if (!challenge) throw new Error('Challenge not found');
   if (challenge.status !== 'proposed') throw new Error('Can only withdraw during voting phase');
 
+  const refundedSp = vote.spInvested;
   vote.status = 'withdrawn';
   vote.withdrawnAt = new Date();
+  vote.spInvested = 0;
   await vote.save();
 
-  await applySpWithCategory(email, vote.spInvested, 'challenge_vote',
-    `Withdrew vote — refunded ${vote.spInvested} SP from challenge: ${challenge.title}`);
-  await Challenge.findByIdAndUpdate(challengeId, { $inc: { totalSpInvested: -vote.spInvested } });
+  await applySpWithCategory(canonicalEmail, refundedSp, 'challenge_vote',
+    `Withdrew vote — refunded ${refundedSp} SP from challenge: ${challenge.title}`);
+  await Challenge.findByIdAndUpdate(challengeId, { $inc: { totalSpInvested: -refundedSp } });
 
-  return buildProposedState(email);
+  return buildProposedState(canonicalEmail);
 }
 
 // Admin: resolve the voting round — pick the challenge with the highest totalSpInvested,
 // set it ACTIVE, archive all others, store winner emails. Returns the winning challenge.
 export async function resolveChallenge(resolvingChallengeId) {
-  const challenge = await Challenge.findById(resolvingChallengeId).lean();
-  if (!challenge) throw new Error('Challenge not found');
-  if (challenge.status !== 'proposed') throw new Error('Challenge is not in proposed state');
-
-  // Find the challenge with the highest totalSpInvested
-  const winner = await Challenge.findOne({
-    status: 'proposed',
-    votingEndDate: { $lte: new Date() }
-  }).sort({ totalSpInvested: -1 }).lean();
-  if (!winner) throw new Error('No eligible challenge to resolve');
+  const targetChallenge = await Challenge.findById(resolvingChallengeId).lean();
+  if (!targetChallenge) throw new Error('Challenge not found');
+  if (targetChallenge.status !== 'proposed') throw new Error('Challenge is not in proposed state');
 
   const now = new Date();
+  if (new Date(targetChallenge.votingEndDate) > now) {
+    throw new Error('Cannot resolve: voting window has not ended yet');
+  }
+
+  // Find all proposed challenges in the same round (voting ended on or before now)
+  const roundChallenges = await Challenge.find({
+    status: 'proposed',
+    votingEndDate: { $lte: now }
+  }).sort({ totalSpInvested: -1 }).lean();
+
+  if (roundChallenges.length === 0) throw new Error('No eligible challenge to resolve');
+
+  // The winner is the one with highest totalSpInvested in this round
+  const winner = roundChallenges[0];
+
   const liveEnd = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
 
   // Set winner as active
@@ -97,9 +124,9 @@ export async function resolveChallenge(resolvingChallengeId) {
     $set: { status: 'active', liveStartDate: now, liveEndDate: liveEnd }
   });
 
-  // Archive all other proposed challenges
+  // Archive all other proposed challenges whose voting has ended
   await Challenge.updateMany(
-    { status: 'proposed', _id: { $ne: winner._id } },
+    { status: 'proposed', _id: { $ne: winner._id }, votingEndDate: { $lte: now } },
     { $set: { status: 'archived' } }
   );
 
@@ -116,14 +143,15 @@ export async function resolveChallenge(resolvingChallengeId) {
 
 // Build the proposed challenges state for a student.
 async function buildProposedState(email) {
-  const now = new Date();
   const challenges = await Challenge.find({
-    status: 'proposed',
-    votingEndDate: { $gt: now }
+    status: 'proposed'
   }).sort({ votingEndDate: 1 }).lean();
 
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  const canonicalEmail = student ? student.email : email;
+
   const userVotesDocs = await ChallengeVote.find({
-    email,
+    email: canonicalEmail,
     status: 'active',
     challengeId: { $in: challenges.map(c => c._id) }
   }).lean();
@@ -133,7 +161,6 @@ async function buildProposedState(email) {
     userVotes[v.challengeId.toString()] = v.spInvested;
   }
 
-  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
   return { challenges, userVotes, totalSp: student ? student.totalSp : 0 };
 }
 
@@ -142,8 +169,11 @@ export async function buildActiveState(email) {
   const challenge = await Challenge.findOne({ status: 'active' }).lean();
   if (!challenge) return { challenge: null, enrolled: false };
 
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  const canonicalEmail = student ? student.email : email;
+
   const vote = await ChallengeVote.findOne({
-    email,
+    email: canonicalEmail,
     challengeId: challenge._id,
     status: 'active'
   }).lean();


### PR DESCRIPTION
# Upvote Challenge System

Adds a voting-based weekly challenge system to Spurti. Students spend SP to vote on proposed challenges. The challenge with the most SP wins and becomes active. Only voters of the winning challenge are eligible to participate; on completion they receive their invested SP back multiplied by the challenge's `rewardMultiplier`.

## How it works

- Proposed challenges appear in a new **Challenges** tab in the student dashboard, each with a voting window, type (`attendance` / `poll_participation`), and reward multiplier.
- Students spend SP to vote. They can add more SP to an existing vote or withdraw (full refund) any time before voting closes.
- An admin resolves the round once voting ends. The challenge with the highest `totalSpInvested` transitions to `active` with a 7-day live window; all others are archived.
- Students who voted for the winning challenge are enrolled. On completion they earn `spInvested * rewardMultiplier` SP credited back via `challenge_reward` transactions.
- SP spent on losing challenges is forfeited. Withdrawals are only possible during the voting phase.

## Endpoints

| Method | Endpoint | Purpose |
|---|---|---|
| `GET` | `/api/challenges/proposed` | Open challenges + user's votes + SP balance |
| `GET` | `/api/challenges/active` | Currently active challenge + enrollment status |
| `POST` | `/api/challenges/:id/vote` | Cast or increment a vote (`{ spPoints: number }`) |
| `POST` | `/api/challenges/:id/withdraw` | Withdraw vote, refund SP |
| `POST` | `/api/admin/challenges/:id/resolve` | Resolve round — pick winner, activate, archive losers |

## Seed data

Run `node server/scripts/seedChallenges.js` to create 3 sample proposed challenges with 7-day voting windows (idempotent — skips if challenges already exist).