### PR TITLE
SPA → SP: award Spurti Points for the peer-teaching activity

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -288,13 +288,97 @@ function StudentView({ profile, onBack }) {
       <StudentPulse profile={profile} badges={badges} nextActions={nextActions} />
       <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'], ['polls','Polls'],
         ...(student.eligibleForVibeGoals ? [['journey','My Journey'], ['vibe','Commitments']] : []),
+        ['spa','SPA Points'],
         ['leaderboard','Leaderboard']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'polls' && <Polls polls={profile.polls} />}
       {tab === 'journey' && student.eligibleForVibeGoals && <MyJourney student={student} setTab={setTab} />}
       {tab === 'vibe' && student.eligibleForVibeGoals && <Commitments student={student} />}
+      {tab === 'spa' && <SpaModule student={student} />}
       {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
     </main>
+  );
+}
+
+// SPA → SP (display only). SP is scored + credited by the pipeline rubric
+// (+5 per validated question learned, +8 per validated peer taught, capped 50/30,
+// minus a one-time audit/fraud penalty) and lands in the SP Bank automatically.
+// This tab just reads the rubric's `spaprogresses` summary. Universal across cohorts.
+function SpaModule({ student }) {
+  const email = student.email;
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      const r = await fetch(`${API}/spa/state?email=${encodeURIComponent(email)}`);
+      setData(await r.json());
+    })();
+  }, [email]);
+
+  if (!data) return <section className="panel">Loading your SPA points…</section>;
+  if (!data.hasActivity) return (
+    <section className="panel empty">
+      <h2>SPA — Peer Teaching Points</h2>
+      <p className="muted">No validated SPA endorsements on record yet for <b>{data.activity}</b>. Learn a question and get endorsed, or endorse a peer — SP lands in your SP Bank automatically as each is validated.</p>
+    </section>
+  );
+
+  const { learn, teach, penalty, creditedSp, maxSp, config } = data;
+
+  return (
+    <div className="jr">
+      <section className="panel jr-intro">
+        <h2>SPA — Peer Teaching Points</h2>
+        <p className="muted">For <b>{data.activity}</b>, SP is credited to your <b>SP Bank automatically</b> as each endorsement is validated — <b>+{config.learnUnit} SP</b> per question you learn, <b>+{config.teachUnit} SP</b> per peer you teach. No claiming needed.</p>
+      </section>
+
+      <div className="jr-grid">
+        {/* Track A — Learning */}
+        <section className="jr-card phase-spa">
+          <div className="jr-head"><span className="jr-n">A</span><h3>Learning</h3><span className="jr-sp">+{learn.sp} SP</span></div>
+          <p className="jr-sub">Questions you were validly endorsed on</p>
+          <div className="jr-stats">
+            <div><strong>{learn.validated}</strong><span>validated</span></div>
+            <div><strong>{learn.credited}</strong><span>credited</span></div>
+            <div><strong>×{learn.unit}</strong><span>SP each</span></div>
+          </div>
+          {learn.validated > learn.cap && <div className="jr-splits"><span className="jr-pill amber">Capped at {learn.cap} — extra {learn.validated - learn.cap} not counted</span></div>}
+        </section>
+
+        {/* Track B — Teaching */}
+        <section className="jr-card phase-vibe">
+          <div className="jr-head"><span className="jr-n">B</span><h3>Teaching</h3><span className="jr-sp">+{teach.sp} SP</span></div>
+          <p className="jr-sub">Peers you validly endorsed</p>
+          <div className="jr-stats">
+            <div><strong>{teach.validated}</strong><span>validated</span></div>
+            <div><strong>{teach.credited}</strong><span>credited</span></div>
+            <div><strong>×{teach.unit}</strong><span>SP each</span></div>
+          </div>
+          {teach.validated > teach.cap && <div className="jr-splits"><span className="jr-pill amber">Capped at {teach.cap} — extra {teach.validated - teach.cap} not counted</span></div>}
+        </section>
+      </div>
+
+      <section className="panel">
+        <div className="panel-head"><h2>SPA SP summary</h2></div>
+        <table className="table">
+          <tbody>
+            <tr><td>Learning (Track A) — {learn.credited} × {config.learnUnit}</td><td style={{ textAlign: 'right' }}>+{learn.sp} SP</td></tr>
+            <tr><td>Teaching (Track B) — {teach.credited} × {config.teachUnit}</td><td style={{ textAlign: 'right' }}>+{teach.sp} SP</td></tr>
+            <tr><td><b>Total credited to SP Bank</b> <span className="muted">(max {maxSp})</span></td><td style={{ textAlign: 'right' }}><b>+{creditedSp} SP</b></td></tr>
+            {penalty.done && penalty.applied > 0 && (
+              <tr className="error">
+                <td>{penalty.fraud ? '⚠️ Fraud penalty' : '⚠️ Audit-failure penalty'} — −{Math.round(penalty.rate * 100)}% of current SP{penalty.at ? ` on ${new Date(penalty.at).toLocaleDateString()}` : ''}</td>
+                <td style={{ textAlign: 'right' }}>−{penalty.applied} SP</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+        <p className="muted" style={{ marginTop: 12 }}>
+          ✅ Auto-credited to your SP Bank — current balance <b>{data.totalSp} SP</b>.
+          {penalty.done && penalty.applied > 0 ? ' An integrity penalty was applied (see the debit row in your SP Bank).' : ''}
+        </p>
+      </section>
+    </div>
   );
 }
 

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -85,6 +85,18 @@ const STAFF = new Set([
   'sudarshansudarshan@gmail.com', 'sudarshan@iitrpr.ac.in', 'rajankrsna@gmail.com',
 ]);
 
+// ── SPA → SP (peer-teaching endorsement points; Pattern A: rubric-recomputed) ──
+// SP for the SPA activity, scored here alongside attendance/poll so it is
+// regenerated every rebuild (wipe-safe by construction — no preserved category).
+// Only VALIDATED endorsements count (status approved|audit_passed); the raw
+// act_spa_transactions.deltaSPA ledger is a runaway compounding value and is
+// never used. Two capped tracks + a one-time integrity penalty on current SP.
+// Source: act_spa_endorsements + act_spa_transactions (mirrored 6-hourly).
+const SPA_LEARN_UNIT = 5, SPA_LEARN_CAP = 50;   // +5 SP / validated question learned, cap 50 → max 250
+const SPA_TEACH_UNIT = 8, SPA_TEACH_CAP = 30;   // +8 SP / validated peer taught,     cap 30 → max 240
+const SPA_FRAUD_RATE = 0.5, SPA_AUDIT_RATE = 0.2;
+const SPA_GOOD = ['approved', 'audit_passed'];
+
 const isMandatory = (t) => /stand|orientation/i.test(t) && !/breakout|weekend|nptel|special|support|non[- ]?mandatory/i.test(t);
 const tier = (pct) => { pct = Math.min(100, pct); return pct >= 90 ? 10 : pct >= 75 ? 5 : pct >= 50 ? 3 : 0; };
 const dstr = (d) => { if (!d) return null; const x = new Date(d); return isNaN(x) ? null : x.toISOString().slice(0, 10); };
@@ -219,8 +231,35 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   // Spandan poll days with no mandatory evening session still earn poll SP (label from the Day number).
   for (const [, sp] of spandanByDate) scoreSpandanPoll(sp, 'Day ' + sp.dayNumber);
 
+  // 3b. SPA → per-canon validated learn/teach events (dated) + integrity flags.
+  //     emailToCanon is fully built by now, so we can fold aliases correctly.
+  const spaByCanon = new Map(); // canon -> { learn:[YYYY-MM-DD...], teach:[...] }
+  const spaFlag = new Map();    // canon -> { auditFail?, fraud? }
+  const canonOf = (e) => { const k = String(e || '').toLowerCase().trim(); return emailToCanon.get(k) || k; };
+  const touchSpa = (c) => { let o = spaByCanon.get(c); if (!o) { o = { learn: [], teach: [] }; spaByCanon.set(c, o); } return o; };
+  for (const en of await sak.collection('act_spa_endorsements').find(
+        { status: { $in: SPA_GOOD } },
+        { projection: { learnerEmail: 1, teacherEmail: 1, approvedAt: 1, updatedAt: 1, createdAt: 1 } }).toArray()) {
+    const d = dstr(en.approvedAt) || dstr(en.updatedAt) || dstr(en.createdAt); if (!d) continue;
+    if (en.learnerEmail) touchSpa(canonOf(en.learnerEmail)).learn.push(d);
+    if (en.teacherEmail) touchSpa(canonOf(en.teacherEmail)).teach.push(d);
+  }
+  // Genuine fraud = net teacher_fraud_penalty + fraud_penalty_reversal < 0, with
+  // operator "Testing" rows excluded (they are demote-feature tests, all reversed).
+  for (const f of await sak.collection('act_spa_transactions').aggregate([
+        { $match: { transactionType: { $in: ['teacher_fraud_penalty', 'fraud_penalty_reversal'] }, reason: { $not: /testing/i } } },
+        { $group: { _id: { $toLower: '$email' }, net: { $sum: '$deltaSPA' } } }]).toArray()) {
+    if (f.net < 0) { const c = canonOf(f._id); spaFlag.set(c, { ...(spaFlag.get(c) || {}), fraud: true }); }
+  }
+  for (const a of await sak.collection('act_spa_transactions').aggregate([
+        { $match: { transactionType: { $in: ['audit_failure_learner_penalty', 'audit_failure_teacher_penalty'] } } },
+        { $group: { _id: { $toLower: '$email' } } }]).toArray()) {
+    const c = canonOf(a._id); spaFlag.set(c, { ...(spaFlag.get(c) || {}), auditFail: true });
+  }
+
   // 4. assemble ledger, ROSTER-DRIVEN union: base 100 to every started intern.
   const ledger = []; const setAside = []; const finalBal = new Map(); const zeroOut = []; const nameByCanon = new Map();
+  const spaSummary = []; // per-canon SPA breakdown for the web-app SPA tab (spaprogresses)
   const candidates = new Map(); // identity email -> { start, emails:[..], name }
   // (a) confirmed candidates interns (incl. those who never attended). Start comes
   //     from the person's OWN record (internStart), not an alias-polluted lookup.
@@ -241,9 +280,32 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     const best = new Map();
     for (const e of info.emails) { const o = students.get(e); if (!o) continue; if (info.name === cand && o.name && !o.name.includes('@')) info.name = o.name; for (const r of o.rows) { if (r.date < info.start) continue; const k = r.date + '|' + r.cat; const cur = best.get(k); if (!cur || r.delta > cur.delta) best.set(k, r); } }
     const rows = [{ date: info.start, order: 0, cat: 'initial', delta: 100, reason: `Base Spurti Points (100) credited on internship start date ${info.start}.` }, ...best.values()];
+    // SPA rows (Pattern A): one consolidated 'spa' row per day, cumulative caps
+    // across days. These bypass the (date|cat) best-dedup by being pushed directly.
+    const spa = spaByCanon.get(cand); const flags = spaFlag.get(cand) || {};
+    let spaLearnUsed = 0, spaTeachUsed = 0;
+    if (spa) {
+      const byDay = new Map(); // date -> { learn, teach }
+      for (const d of spa.learn.slice().sort()) { if (spaLearnUsed >= SPA_LEARN_CAP) break; spaLearnUsed++; const o = byDay.get(d) || { learn: 0, teach: 0 }; o.learn++; byDay.set(d, o); }
+      for (const d of spa.teach.slice().sort()) { if (spaTeachUsed >= SPA_TEACH_CAP) break; spaTeachUsed++; const o = byDay.get(d) || { learn: 0, teach: 0 }; o.teach++; byDay.set(d, o); }
+      for (const [d, o] of byDay) {
+        const delta = o.learn * SPA_LEARN_UNIT + o.teach * SPA_TEACH_UNIT; if (!delta) continue;
+        const parts = []; if (o.learn) parts.push(`${o.learn} learned`); if (o.teach) parts.push(`${o.teach} taught`);
+        rows.push({ date: d, order: 3, cat: 'spa', delta, reason: `SPA (${ddmon(d)}): ${parts.join(' + ')} (validated) -> +${delta} SP.` });
+      }
+    }
+    // Integrity penalty: one-time -% of current total SP (fraud takes precedence).
+    const penRate = flags.fraud ? SPA_FRAUD_RATE : (flags.auditFail ? SPA_AUDIT_RATE : 0);
+    let spaPenalty = 0;
+    if (penRate > 0) {
+      spaPenalty = Math.round(rows.reduce((a, r) => a + r.delta, 0) * penRate);
+      if (spaPenalty > 0) rows.push({ date: TODAY, order: 9, cat: 'spa', delta: -spaPenalty,
+        reason: `SPA (${ddmon(TODAY)}): ${flags.fraud ? 'fraud' : 'audit-failure'} penalty -${Math.round(penRate * 100)}% of current SP -> -${spaPenalty} SP.` });
+    }
     rows.sort((a, b) => a.date < b.date ? -1 : a.date > b.date ? 1 : a.order - b.order);
     let bal = 0; for (const r of rows) { bal += r.delta; ledger.push({ email: cand, name: info.name, ...r, balanceAfter: bal }); }
     finalBal.set(cand, bal); nameByCanon.set(cand, info.name);
+    if (spa || penRate > 0) spaSummary.push({ email: cand, learnValidated: spa ? spa.learn.length : 0, teachValidated: spa ? spa.teach.length : 0, learnCredited: spaLearnUsed, teachCredited: spaTeachUsed, auditFail: !!flags.auditFail, fraud: !!flags.fraud, penaltyApplied: spaPenalty });
   }
   for (const [e, o] of students) { if (STAFF.has(e) || matched.has(e) || emailToCanon.has(e)) continue; setAside.push({ email: e, name: o.name, rows: o.rows.length }); }
 
@@ -287,6 +349,12 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   const docs = ledger.map((r) => { const idx = r.reason.indexOf(': '); return { email: r.email, studentId: idMap.get(r.email), category: r.cat, sessionLabel: r.cat === 'initial' ? '' : (idx > 0 ? r.reason.slice(0, idx) : ''), deltaMode: 'absolute', deltaValue: r.delta, appliedDelta: r.delta, balanceAfter: r.balanceAfter, reason: r.reason, dateTime: new Date(r.date + (r.cat === 'initial' ? 'T00:00:00.000Z' : 'T09:00:00.000Z')), createdAt: new Date(), updatedAt: new Date() }; });
   let ins = 0; for (let i = 0; i < docs.length; i += 2000) { await Tx.insertMany(docs.slice(i, i + 2000), { ordered: false }); ins += Math.min(2000, docs.length - i); }
   console.log(`APPLIED -> students upserted ${sBulk.length}, old txns deleted ${del}, new txns inserted ${ins}`);
+  // SPA summary for the web-app SPA tab (display only; SP itself is in the ledger above).
+  const Spa = sak.collection('spaprogresses');
+  const spaOps = spaSummary.map((s) => ({ updateOne: { filter: { email: s.email },
+    update: { $set: { ...s, activity: 'Activity 1: Linear Algebra', updatedAt: new Date() }, $setOnInsert: { createdAt: new Date() } }, upsert: true } }));
+  for (let i = 0; i < spaOps.length; i += 1000) await Spa.bulkWrite(spaOps.slice(i, i + 1000), { ordered: false });
+  console.log(`SPA -> spaprogresses upserted ${spaOps.length}`);
   // RECONCILE: the new ledger is the COMPLETE source of truth — all current SP is
   // rubric-generated (initial/attendance/poll only; no admin/discretionary txns
   // exist). Any student NOT in the new ledger must be cleared so the leaderboard

--- a/server/models/SPTransaction.js
+++ b/server/models/SPTransaction.js
@@ -6,7 +6,7 @@ const spTransactionSchema = new mongoose.Schema({
   category: {
     type: String,
     required: true,
-    enum: ['initial', 'attendance', 'poll', 'manual', 'peer_faq'],
+    enum: ['initial', 'attendance', 'poll', 'manual', 'peer_faq', 'spa'],
     index: true
   },
   sessionLabel: { type: String, default: '', index: true },

--- a/server/models/SpaProgress.js
+++ b/server/models/SpaProgress.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+// Per-student SPA (peer-teaching endorsement) progress for the SPA→SP module.
+// Locally seeded with DUMMY values; in production these counts come from the
+// `act_spa_*` collections in `sakshi_spurti`:
+//   learnValidated = # endorsements RECEIVED with status in {approved, audit_passed}
+//   teachValidated = # endorsements GIVEN     with status in {approved, audit_passed}
+//   auditFail      = has a genuine audit_failure_* penalty (viva-failed on review)
+//   fraud          = genuine fraud AFTER netting teacher_fraud_penalty vs
+//                    fraud_penalty_reversal (test/reversed rows are NOT fraud)
+//
+// SP is credited AUTOMATICALLY as activity arrives — +5 per validated question
+// learned, +8 per validated peer taught — via syncSpaSp(). The *Credited fields
+// are watermarks of how many events have already been posted to the SP ledger,
+// so re-syncs only post the delta (idempotent). No student "claim" step.
+const spaProgressSchema = new mongoose.Schema({
+  email: { type: String, lowercase: true, trim: true, required: true, unique: true, index: true },
+  activity: { type: String, default: 'Activity 1: Linear Algebra' },
+  learnValidated: { type: Number, default: 0 },     // good endorsements received (from mirror)
+  teachValidated: { type: Number, default: 0 },     // good endorsements given (from mirror)
+  learnCredited: { type: Number, default: 0 },       // learns already posted to the ledger
+  teachCredited: { type: Number, default: 0 },       // teaches already posted to the ledger
+  auditFail: { type: Boolean, default: false },      // → one-time -20% of current SP
+  fraud: { type: Boolean, default: false },          // → one-time -50% of current SP
+  auditPenaltyApplied: { type: Boolean, default: false },
+  fraudPenaltyApplied: { type: Boolean, default: false },
+  penaltyApplied: { type: Number, default: 0 },      // total SP removed by integrity penalties
+  penaltyAt: { type: Date, default: null }
+}, { timestamps: true });
+
+export default mongoose.model('SpaProgress', spaProgressSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -17,6 +17,7 @@ import Commitment from './models/Commitment.js';
 import { isVibeEligible, buildVibeState, validateBet, settleBetDemo, applySpDelta, courseByKey } from './services/vibe.js';
 import { buildStandupState, placeStandup, settleStandupDemo } from './services/standup.js';
 import { buildJourneyState, saveJourneyPlan } from './services/journey.js';
+import { buildSpaState } from './services/spa.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -361,6 +362,15 @@ api.post('/vibe/bet/:id/settle', async (req, res) => {
   await settleBetDemo(bet, result);
   const fresh = await Student.findOne({ email: student.email }).lean();
   res.json(await buildVibeState(fresh));
+});
+
+// ---- SPA → SP (peer-teaching endorsement points; ALL cohorts) ----------------
+// DISPLAY ONLY: SP is scored + credited by the pipeline rubric; this just reads
+// the `spaprogresses` summary + student total. Universal, no cohort gate.
+api.get('/spa/state', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  res.json(await buildSpaState(student));
 });
 
 // ---- Standup commitments (weekly, attendance-only; keep-the-stake) -----------

--- a/server/services/spa.js
+++ b/server/services/spa.js
@@ -1,0 +1,61 @@
+// SPA → SP module logic (peer-teaching endorsement activity) — DISPLAY layer.
+// The SP itself is scored + credited by the pipeline rubric
+// (pipeline/sp-rubric-build-mirror.cjs, Pattern A): +5 per validated question
+// learned, +8 per validated peer taught (capped 50/30), minus a one-time
+// audit/fraud penalty. The rubric writes the `spaprogresses` summary this reads.
+// The web app NEVER writes SP — it only renders what the rubric produced.
+// Universal: applies to ALL cohorts (15-May onward).
+import Student from '../models/Student.js';
+import SpaProgress from '../models/SpaProgress.js';
+
+export function isSpaEligible() { return true; } // SPA SP is a universal feature.
+
+// LOCKED scheme (see memory: spa-sp-award-scheme).
+export const CONFIG = {
+  learnUnit: 5,  learnCap: 50,   // +5 SP per validated question learned, cap 50  → max 250
+  teachUnit: 8,  teachCap: 30,   // +8 SP per validated endorsement given, cap 30 → max 240
+  fraudRate: 0.5,                // genuine fraud  → -50% of current SP (one-time)
+  auditRate: 0.2                 // audit failure  → -20% of current SP (one-time)
+};
+export const MAX_SPA_SP = CONFIG.learnUnit * CONFIG.learnCap + CONFIG.teachUnit * CONFIG.teachCap; // 490
+
+// Pure computation of the SP breakdown from a SpaProgress row (display).
+export function computeSpaSp(prog) {
+  const learnCounted = Math.min(prog.learnValidated || 0, CONFIG.learnCap);
+  const teachCounted = Math.min(prog.teachValidated || 0, CONFIG.teachCap);
+  return {
+    learn: { validated: prog.learnValidated || 0, counted: learnCounted, credited: prog.learnCredited || 0,
+             cap: CONFIG.learnCap, unit: CONFIG.learnUnit, sp: learnCounted * CONFIG.learnUnit },
+    teach: { validated: prog.teachValidated || 0, counted: teachCounted, credited: prog.teachCredited || 0,
+             cap: CONFIG.teachCap, unit: CONFIG.teachUnit, sp: teachCounted * CONFIG.teachUnit },
+    grossSp: learnCounted * CONFIG.learnUnit + teachCounted * CONFIG.teachUnit,
+    penalty: { fraud: !!prog.fraud, auditFail: !!prog.auditFail,
+               rate: prog.fraud ? CONFIG.fraudRate : (prog.auditFail ? CONFIG.auditRate : 0),
+               applied: prog.penaltyApplied || 0, at: prog.penaltyAt || null,
+               done: (prog.penaltyApplied || 0) > 0 }
+  };
+}
+
+// Build the student-facing SPA state. DISPLAY ONLY — the SP itself is scored and
+// credited by the pipeline rubric (sp-rubric-build-mirror.cjs, Pattern A), which
+// also writes the `spaprogresses` summary this reads. The web app never writes SP.
+export async function buildSpaState(student) {
+  const prog = await SpaProgress.findOne({ email: student.email }).lean();
+  const stu = await Student.findOne({ email: student.email }).lean();
+  if (!prog) {
+    return { eligible: true, name: student.name, totalSp: stu?.totalSp || 0,
+      activity: 'Activity 1: Linear Algebra', hasActivity: false, config: CONFIG, maxSp: MAX_SPA_SP };
+  }
+  const calc = computeSpaSp(prog);
+  return {
+    eligible: true,
+    name: student.name,
+    totalSp: stu?.totalSp || 0,
+    activity: prog.activity,
+    hasActivity: (prog.learnValidated || 0) + (prog.teachValidated || 0) > 0,
+    ...calc,
+    creditedSp: calc.learn.credited * CONFIG.learnUnit + calc.teach.credited * CONFIG.teachUnit,
+    maxSp: MAX_SPA_SP,
+    config: CONFIG
+  };
+}


### PR DESCRIPTION
Scores the SPA peer-teaching endorsement activity into Spurti Points (Pattern A — rubric-recomputed, wipe-safe like Spandan polls).

## What it does
- **Scorer** (`pipeline/sp-rubric-build-mirror.cjs`): reads `act_spa_*` (validated learn/teach, dated) + integrity flags (audit-fail; fraud netted of reversals, Testing rows dropped). Emits one consolidated `category:'spa'` ledger row per student per day — **+5 SP/validated question learned, +8 SP/validated peer taught**, caps 50/30; a one-time **-20% (audit) / -50% (fraud)** penalty folded into the balance. Upserts a `spaprogresses` summary. Regenerated every rescore, so no PRESERVED_CATS needed.
- **Web app (display only)**: `/api/spa/state` + **SPA Points** tab reading `spaprogresses`. The app never writes SP.
- `SPTransaction`: allow category `spa`.

## Live result (already deployed)
935 earners, **+167,913 SP**, 26 audit-fail penalties, 0 fraud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)