### PR TITLE
My Journey phase-goals (self-set target dates + pace)

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -681,50 +681,89 @@ const toInput = d => d ? new Date(d).toISOString().slice(0, 10) : '';
 // The unified phase-by-phase progress + SP tab. Four phases: Standups, ViBe, SPA,
 // Projects. Standups & ViBe show real SP; SPA & Projects are placeholders until the
 // Samagama data (and their SP rule) land. Goal *staking* lives in the Commitments tab.
+const NEXT_NUDGE = { standup: 'Next up: push your ViBe courses.', vibe: 'Next up: keep your SPA pace.', spa: 'Next up: ship your first project PR.', project: 'On track across the board — keep it up!' };
+
+// Goal block that lives ON a phase card: set a target date (none/missed) → pace bar
+// once active → "reached" when done. Unit-aware (min for standups, % for ViBe). A GOAL
+// is a self-set target (no SP) — distinct from a COMMITMENT (staking SP, the Stake link).
+function PhaseGoal({ phaseKey, field, goal, targetText, form, setForm, onSave }) {
+  const isPct = goal.unit === '%';
+  const metric = isPct ? `${goal.progressPct}% done` : `${goal.current}/${goal.target} ${goal.unit} (${goal.progressPct}%)`;
+  const paceLeft = isPct
+    ? `${goal.remainingPct}% to go · ~${goal.perDay ?? '—'}%/day to stay on track`
+    : `${goal.remaining} ${goal.unit} to go · ~${goal.perDay ?? '—'} ${goal.unit}/${goal.perDayUnit || 'day'} to stay on track`;
+
+  if (goal.status === 'achieved') {
+    return <div className="jr-goal"><span className="jr-goal-label done">🎯 Goal reached 🎉</span><span className="jr-goal-foot">{NEXT_NUDGE[phaseKey]}</span></div>;
+  }
+  if (goal.status === 'active') {
+    return (
+      <div className="jr-goal">
+        {goal.pending ? (
+          <span className="jr-goal-meta">🎯 Goal: by {fmtDate(goal.targetDate)} · {goal.daysLeft}d left · progress soon</span>
+        ) : (
+          <>
+            <span className="jr-goal-meta">🎯 Goal: {metric} · by {fmtDate(goal.targetDate)} · {goal.daysLeft}d left</span>
+            <div className="jr-progress"><i style={{ width: `${goal.progressPct}%` }} /></div>
+            <span className="jr-goal-foot">{paceLeft}</span>
+          </>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="jr-goal">
+      <span className={`jr-goal-label ${goal.status === 'missed' ? 'miss' : ''}`}>
+        🎯 {goal.status === 'missed' ? `Goal missed — set a new date to ${targetText}` : `Set a target date to ${targetText}`}
+      </span>
+      <div className="jr-goal-row">
+        <input type="date" min={goal.minDate || undefined} max={goal.maxDate || undefined} value={form[field] ?? ''} onChange={e => setForm({ ...form, [field]: e.target.value })} />
+        <button className="secondary" disabled={!form[field]} onClick={() => onSave(field, form[field])}>Set goal</button>
+      </div>
+      {goal.minDate && <span className="jr-goal-hint">Earliest realistic: {fmtDate(goal.minDate)}{goal.paceHint ? ` · ${goal.paceHint}` : ''}</span>}
+    </div>
+  );
+}
+
 function MyJourney({ student, setTab }) {
   const email = student.email;
   const [data, setData] = useState(null);
-  const [plan, setPlan] = useState({ vibeBy: '', spaBy: '', projectBy: '' });
-  const [savedMsg, setSavedMsg] = useState(false);
+  const [form, setForm] = useState({});
+  const [showTraj, setShowTraj] = useState(false);
+  const [err, setErr] = useState(null);
 
   const load = async () => {
     const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
-    const j = await r.json();
-    setData(j);
-    if (j.plan) setPlan({ vibeBy: toInput(j.plan.vibeBy), spaBy: toInput(j.plan.spaBy), projectBy: toInput(j.plan.projectBy) });
+    setData(await r.json());
   };
   useEffect(() => { load(); }, [email]);
-
-  const savePlan = async () => {
-    const r = await fetch(`${API}/journey/plan`, {
-      method: 'PUT', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, ...plan })
-    });
-    if (r.ok) { setData(await r.json()); setSavedMsg(true); setTimeout(() => setSavedMsg(false), 2000); }
-  };
 
   if (!data) return <section className="panel">Loading your journey…</section>;
   if (!data.eligible) return <section className="panel empty">My Journey isn’t available for your cohort yet.</section>;
 
-  const { standups, vibe, spa, projects } = data;
-  const spaPct = spa.total ? Math.round(spa.solved / spa.total * 100) : 0;
+  const { standups, vibe, goals } = data;
+
+  const saveTarget = async (field, value) => {
+    const r = await fetch(`${API}/journey/plan`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, [field]: value })
+    });
+    const j = await r.json();
+    if (!r.ok) { setErr(j.error); return; }
+    setErr(null); setData(j);
+  };
+  const gp = { form, setForm, onSave: saveTarget };
 
   return (
     <div className="jr">
-      <section className="panel jr-plan">
-        <h2>My internship plan</h2>
-        <p className="muted">Four phases to your Summership. Set the dates you’re aiming for — your cards below track you against them. (SP is staked separately in the <b>Commitments</b> tab.)</p>
-        <div className="jr-plan-row">
-          <label>Finish ViBe by<input type="date" value={plan.vibeBy} onChange={e => setPlan({ ...plan, vibeBy: e.target.value })} /></label>
-          <label>Solve all 53 SPA by<input type="date" value={plan.spaBy} onChange={e => setPlan({ ...plan, spaBy: e.target.value })} /></label>
-          <label>First project PR by<input type="date" value={plan.projectBy} onChange={e => setPlan({ ...plan, projectBy: e.target.value })} /></label>
-          <button className="primary" onClick={savePlan}>Save plan</button>
-          {savedMsg && <span className="jr-saved">✓ Saved</span>}
-        </div>
+      <section className="panel jr-intro">
+        <h2>My Journey</h2>
+        <p className="muted"><b>🎯 Goal</b> = your own finish-date target; it tracks your pace, no SP. &nbsp;<b>🎲 Commitment</b> = stake SP on a bet — the <b>Stake SP</b> link.</p>
+        {err && <p className="error">{err}</p>}
       </section>
 
       <div className="jr-grid">
-        {/* Phase 1 — Standups */}
+        {/* Standups — continuous, no completion goal; commitment only */}
         <section className="jr-card phase-standups">
           <div className="jr-head"><span className="jr-n">1</span><h3>Standups</h3><span className="jr-sp">+{standups.sp} SP</span></div>
           <p className="jr-sub">Zoom attendance + Spandan polls</p>
@@ -737,12 +776,14 @@ function MyJourney({ student, setTab }) {
             <span className="jr-pill">Attendance +{standups.spAttendance}</span>
             <span className="jr-pill">Polls +{standups.spPolls}</span>
           </div>
+          <PhaseGoal phaseKey="standup" field="standupBy" goal={goals.standup} targetText="reach 3,600 Zoom minutes" {...gp} />
+          <div className="jr-cardfoot"><button className="jr-stake" onClick={() => setTab('vibe')}>🎲 Stake SP →</button></div>
         </section>
 
-        {/* Phase 2 — ViBe */}
+        {/* ViBe — goal + commitment */}
         <section className="jr-card phase-vibe">
           <div className="jr-head"><span className="jr-n">2</span><h3>ViBe courses</h3><span className={`jr-sp ${vibe.sp < 0 ? 'neg' : ''}`}>{vibe.sp >= 0 ? '+' : ''}{vibe.sp} SP</span></div>
-          <p className="jr-sub">{vibe.clearedCount}/{vibe.totalCourses} courses complete · plan: by {fmtDate(data.plan.vibeBy)}</p>
+          <p className="jr-sub">{vibe.clearedCount}/{vibe.totalCourses} courses complete</p>
           <div className="jr-dots">
             {vibe.ladder.map(l => (
               <div key={l.key} className={`jr-dot ${l.cleared ? 'done' : (vibe.current && vibe.current.key === l.key ? 'current' : '')}`} title={l.name}>
@@ -750,40 +791,35 @@ function MyJourney({ student, setTab }) {
               </div>
             ))}
           </div>
-          <div className="jr-splits">
-            {vibe.current
-              ? <span className="jr-pill">Now: {vibe.current.name} — {vibe.current.pct}%</span>
-              : <span className="jr-pill">All courses complete 🎉</span>}
-            {vibe.activeCommitment && <span className="jr-pill amber">Active commitment: +{vibe.activeCommitment.goalPct}%</span>}
-            <button className="jr-link" onClick={() => setTab('vibe')}>Set a commitment →</button>
-          </div>
+          {vibe.activeCommitment && <div className="jr-splits"><span className="jr-pill amber">🎲 Active commitment: +{vibe.activeCommitment.goalPct}%</span></div>}
+          <PhaseGoal phaseKey="vibe" field="vibeBy" goal={goals.vibe} targetText="finish all your ViBe courses" {...gp} />
+          <div className="jr-cardfoot"><button className="jr-stake" onClick={() => setTab('vibe')}>🎲 Stake SP →</button></div>
         </section>
 
-        {/* Phase 3 — SPA (data + SP rule pending Samagama) */}
+        {/* SPA — goal (date) works now; progress data + commitment coming soon */}
         <section className="jr-card phase-spa">
-          <div className="jr-head"><span className="jr-n">3</span><h3>SPA — Matrix Mystics</h3><span className="jr-soon">Coming soon</span></div>
-          <p className="jr-sub">53-problem set · plan: by {fmtDate(data.plan.spaBy)}</p>
-          {spa.pending
-            ? <p className="cm-soon">Your Matrix Mystics progress and SP will appear here soon — we’re wiring up the data.</p>
-            : <>
-                <div className="jr-big"><strong>{spa.solved}</strong><span>/ {spa.total} solved</span></div>
-                <div className="jr-progress"><i style={{ width: `${spaPct}%` }} /></div>
-                <div className="jr-splits"><span className="jr-pill">{spa.spaPoints} SPA points</span></div>
-              </>}
+          <div className="jr-head"><span className="jr-n">3</span><h3>SPA — Matrix Mystics</h3><span className="jr-soon">Data soon</span></div>
+          <p className="jr-sub">53-problem set · progress data coming soon</p>
+          <PhaseGoal phaseKey="spa" field="spaBy" goal={goals.spa} targetText="solve all 53 problems" {...gp} />
         </section>
 
-        {/* Phase 4 — Projects (data + SP rule pending Samagama) */}
+        {/* Projects — goal (date) works now; progress data coming soon */}
         <section className="jr-card phase-project">
-          <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-soon">Coming soon</span></div>
-          <p className="jr-sub">Pull requests · plan: by {fmtDate(data.plan.projectBy)}</p>
-          {projects.pending
-            ? <p className="cm-soon">Your project PRs and SP will appear here soon — we’re wiring up the data.</p>
-            : <div className="jr-stats">
-                <div><strong>{projects.prsRaised}</strong><span>PRs raised</span></div>
-                <div><strong>{projects.prsMerged}</strong><span>PRs merged</span></div>
-              </div>}
+          <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-soon">Data soon</span></div>
+          <p className="jr-sub">Pull requests · progress data coming soon</p>
+          <PhaseGoal phaseKey="project" field="projectBy" goal={goals.project} targetText="raise your first PR" {...gp} />
         </section>
       </div>
+
+      <section className="panel jr-trajlink">
+        <div>
+          <h2>Your SP trajectory</h2>
+          <p className="muted">Your Spurti Points over time vs the cohort and your group.</p>
+        </div>
+        <button className="secondary" onClick={() => setShowTraj(true)}>View trajectory ↗</button>
+      </section>
+
+      {showTraj && <TrajectoryModal student={student} onClose={() => setShowTraj(false)} />}
     </div>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -223,7 +223,7 @@ input {
 @media (max-width: 720px) { .level-tiles { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 .pulse-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: 1fr 2fr;
   gap: 12px;
   margin-bottom: 18px;
 }
@@ -263,6 +263,32 @@ input {
 .traj-axis { fill: var(--muted); font-size: 11px; }
 .traj-axis-title { fill: var(--muted); font-size: 12px; font-weight: 700; }
 .traj-foot { margin-top: 10px; font-size: 12px; }
+
+/* ---- My Journey: goal setup + pace bars --------------------------------- */
+.jr-goalset { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; padding: 10px 0; border-top: 1px solid var(--line); }
+.jr-goalset:first-of-type { border-top: none; padding-top: 4px; }
+.jr-goalset label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; font-weight: 700; color: var(--muted); }
+.jr-goalset input { min-height: 36px; padding: 0 8px; border: 1px solid var(--line); border-radius: 8px; }
+.jr-missed { color: var(--red); font-size: 12px; font-weight: 800; }
+.jr-progress i.done { background: var(--green); }
+.jr-pill.green { background: #e9f7ee; color: var(--green); }
+.jr-trajlink { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.jr-trajlink h2 { margin: 0; }
+.jr-intro h2 { margin-bottom: 4px; }
+.jr-card { display: flex; flex-direction: column; }
+.jr-goal { margin-top: 12px; padding-top: 12px; border-top: 1px dashed var(--line); }
+.jr-goal-label { display: block; font-size: 12.5px; font-weight: 800; color: var(--muted); margin-bottom: 6px; }
+.jr-goal-label.done { color: var(--green); }
+.jr-goal-label.miss { color: var(--red); }
+.jr-goal-meta { display: block; font-size: 13px; font-weight: 800; color: var(--text); margin-bottom: 6px; }
+.jr-goal-foot { display: block; font-size: 12px; color: var(--muted); margin-top: 6px; }
+.jr-goal-row { display: flex; gap: 8px; align-items: center; }
+.jr-goal-row input { flex: 1; min-height: 34px; padding: 0 8px; border: 1px solid var(--line); border-radius: 8px; }
+.jr-goal-row button { min-height: 34px; white-space: nowrap; }
+.jr-cardfoot { margin-top: auto; padding-top: 12px; display: flex; justify-content: flex-end; }
+.jr-stake { background: none; border: 1px solid var(--primary); color: var(--primary); border-radius: 999px; padding: 6px 12px; font-weight: 800; font-size: 12px; cursor: pointer; }
+.jr-stake:hover { background: var(--primary); color: #fff; }
+.jr-goal-hint { display: block; font-size: 11.5px; color: var(--muted); margin-top: 6px; }
 .compare-list { display: grid; gap: 8px; }
 .compare-list b { font-size: 14px; }
 .badge-row { display: flex; flex-wrap: wrap; gap: 8px; }

--- a/server/models/JourneyPlan.js
+++ b/server/models/JourneyPlan.js
@@ -5,6 +5,7 @@ import mongoose from 'mongoose';
 // a planned date can later award a completion bonus. One plan per student.
 const journeyPlanSchema = new mongoose.Schema({
   email: { type: String, lowercase: true, trim: true, required: true, unique: true, index: true },
+  standupBy: { type: Date, default: null },   // reach 3600 cumulative Zoom minutes by
   vibeBy: { type: Date, default: null },      // finish all 3 ViBe courses by
   spaBy: { type: Date, default: null },       // solve all 53 SPA problems by
   projectBy: { type: Date, default: null }    // first / target project PR by

--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -15,6 +15,7 @@ import JourneyProgress from '../models/JourneyProgress.js';
 import { buildVibeState } from './vibe.js';
 
 export const SPA_TOTAL = 53;
+export const STANDUP_MINUTES_TARGET = 3600;   // cumulative Zoom minutes (~120 min/week)
 
 export async function buildJourneyState(student) {
   const email = student.email;
@@ -70,26 +71,110 @@ export async function buildJourneyState(student) {
 
   const plan = await JourneyPlan.findOne({ email }).lean();
 
+  // Per-phase goal status + pace toward the student's target date. ViBe has live
+  // completion %; SPA/Projects are pending (date countdown only until Samagama data).
+  const vibeOverall = Math.round(vibe.ladder.reduce((a, l) => a + l.pct, 0) / (vibe.ladder.length || 1));
+  const goals = {
+    standup: phaseGoal({ targetDate: plan?.standupBy, current: standups.zoomMinutes, target: STANDUP_MINUTES_TARGET, unit: 'min', daysPerWeek: STANDUP_DAYS_PER_WEEK }),
+    vibe: phaseGoal({ targetDate: plan?.vibeBy, current: vibeOverall, target: 100, unit: '%' }),
+    spa: phaseGoal({ targetDate: plan?.spaBy, pending: true }),
+    project: phaseGoal({ targetDate: plan?.projectBy, pending: true })
+  };
+  // Attach realistic date bounds so a target can't be set too soon (superficial) or
+  // too far out (delayed). Standups is pace-capped at ~60 min per working day.
+  const endDate = student.internshipEndDate || null;
+  for (const [key, g] of Object.entries(goals)) Object.assign(g, goalBounds(key, g, endDate));
+
   return {
     eligible: true,
     name: student.name,
     totalSp: student.totalSp || 0,
     plan: {
+      standupBy: plan?.standupBy || null,
       vibeBy: plan?.vibeBy || null,
       spaBy: plan?.spaBy || null,
       projectBy: plan?.projectBy || null
     },
+    goals,
     phaseSp: { standups: standups.sp, vibe: vibe.sp, spa: spa.sp, projects: projects.sp },
     standups, vibe, spa, projects
   };
 }
 
-// Upsert the student's self-declared plan dates. Only the three date fields are set.
-export async function saveJourneyPlan(email, { vibeBy, spaBy, projectBy }) {
+const DAY_MS = 86400000;
+const startOfToday = () => { const d = new Date(); d.setHours(0, 0, 0, 0); return d; };
+const addDays = (d, n) => { const x = new Date(d); x.setDate(x.getDate() + n); return x; };
+// Local date-only string (yyyy-mm-dd) — matches how <input type="date"> works and
+// avoids UTC/local off-by-one between the picker min/max and server validation.
+const ymd = d => { const x = new Date(d); return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, '0')}-${String(x.getDate()).padStart(2, '0')}`; };
+export const STANDUP_MIN_PER_DAY = 60;      // one 60-min standup per working day
+export const STANDUP_DAYS_PER_WEEK = 6;     // 6 working days per week
+
+// Realistic [minDate, maxDate] for a goal. Standups are pace-capped (can't beat
+// 60 min/working-day over 6 working days/week); other phases just need a small buffer
+// so it isn't "tomorrow". Upper bound = internship end if known, else 60 days past min.
+function goalBounds(key, goal, endDate) {
+  const today = startOfToday();
+  let minDate;
+  if (key === 'standup' && goal.remaining > 0) {
+    const workDays = Math.ceil(goal.remaining / STANDUP_MIN_PER_DAY);
+    minDate = addDays(today, Math.ceil((workDays * 7) / STANDUP_DAYS_PER_WEEK));   // working → calendar days
+  } else {
+    minDate = addDays(today, key === 'project' ? 3 : 7);
+  }
+  const end = endDate ? new Date(endDate) : null;
+  const maxDate = end && end.getTime() > minDate.getTime() ? end : addDays(minDate, 60);
+  return { minDate: ymd(minDate), maxDate: ymd(maxDate), paceHint: key === 'standup' ? '≈60 min per working day' : null };
+}
+
+// Goal status + pace for one phase. `current`/`target` are in `unit` (e.g. min, %).
+// none | active | achieved | missed. pending = progress data not available yet.
+function phaseGoal({ targetDate, current = null, target = null, unit = '%', pending = false, daysPerWeek = null }) {
+  const t = targetDate ? new Date(targetDate) : null;
+  const today = startOfToday();
+  const known = !pending && current != null && target != null;
+  const complete = known && current >= target;
+  let status = 'none';
+  if (t) {
+    if (complete) status = 'achieved';
+    else if (t.getTime() < today.getTime()) status = 'missed';
+    else status = 'active';
+  }
+  const daysLeft = t ? Math.max(0, Math.round((t.getTime() - today.getTime()) / DAY_MS)) : null;
+  const progressPct = known ? Math.min(100, Math.round((current / target) * 100)) : null;
+  const remaining = known ? Math.max(0, target - current) : null;
+  // Pace to stay on track. For a phase with working days (standups), pace is per
+  // WORKING day over the working days left; otherwise per calendar day.
+  let perDay = null, perDayUnit = 'day';
+  if (status === 'active' && remaining != null && daysLeft > 0) {
+    if (daysPerWeek) {
+      const workDaysLeft = Math.max(1, Math.round((daysLeft * daysPerWeek) / 7));
+      perDay = Math.ceil(remaining / workDaysLeft);
+      perDayUnit = 'working day';
+    } else {
+      perDay = Math.ceil(remaining / daysLeft);
+    }
+  }
+  return {
+    targetDate: t, hasTarget: !!t, status, unit,
+    current: known ? current : null, target: known ? target : null,
+    progressPct, remaining, remainingPct: progressPct == null ? null : Math.max(0, 100 - progressPct),
+    daysLeft, perDay, perDayUnit, pending: !!pending
+  };
+}
+
+// Upsert the plan dates — but LOCK a phase once its target is set and still in the
+// future (a commitment device: no moving the goalpost). A phase only becomes settable
+// again when its date has passed (missed). Only fields present in `incoming` are touched.
+export async function saveJourneyPlan(email, incoming = {}) {
+  const existing = await JourneyPlan.findOne({ email }).lean();
+  const today = startOfToday();
   const set = {};
-  const parse = d => (d ? new Date(d) : null);
-  set.vibeBy = parse(vibeBy);
-  set.spaBy = parse(spaBy);
-  set.projectBy = parse(projectBy);
-  await JourneyPlan.updateOne({ email }, { $set: set }, { upsert: true });
+  for (const f of ['standupBy', 'vibeBy', 'spaBy', 'projectBy']) {
+    const cur = existing?.[f] ? new Date(existing[f]) : null;
+    const locked = cur && cur.getTime() >= today.getTime();   // active future target → locked
+    if (locked) continue;
+    if (Object.prototype.hasOwnProperty.call(incoming, f)) set[f] = incoming[f] ? new Date(incoming[f]) : null;
+  }
+  if (Object.keys(set).length) await JourneyPlan.updateOne({ email }, { $set: set }, { upsert: true });
 }


### PR DESCRIPTION
Per-phase finish-date goals with pace tracking + goal-locking. Server phaseGoal/goalBounds + standupBy; client PhaseGoal/MyJourney. Verified live (set->active pace, cleanup ok). Also fixes pulse-grid for the cleaned 2-card pulse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)