### PR TITLE
fix(journey): always show standup progress + block goal on achieved phase

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -695,6 +695,12 @@ function PhaseGoal({ phaseKey, field, goal, targetText, form, setForm, onSave })
   }
   return (
     <div className="jr-goal">
+      {!goal.pending && goal.progressPct != null && (
+        <>
+          <span className="jr-goal-meta">{metric}</span>
+          <div className="jr-progress"><i style={{ width: `${goal.progressPct}%` }} /></div>
+        </>
+      )}
       <span className={`jr-goal-label ${goal.status === 'missed' ? 'miss' : ''}`}>
         🎯 {goal.status === 'missed' ? `Goal missed — set a new date to ${targetText}` : `Set a target date to ${targetText}`}
       </span>

--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -137,11 +137,10 @@ function phaseGoal({ targetDate, current = null, target = null, unit = '%', pend
   const known = !pending && current != null && target != null;
   const complete = known && current >= target;
   let status = 'none';
-  if (t) {
-    if (complete) status = 'achieved';
-    else if (t.getTime() < today.getTime()) status = 'missed';
-    else status = 'active';
-  }
+  // Already at/over target -> 'achieved' even if no target date was ever set, so
+  // the client hides the goal-setting UI (can't set a goal on a done phase).
+  if (complete) status = 'achieved';
+  else if (t) status = t.getTime() < today.getTime() ? 'missed' : 'active';
   const daysLeft = t ? Math.max(0, Math.round((t.getTime() - today.getTime()) / DAY_MS)) : null;
   const progressPct = known ? Math.min(100, Math.round((current / target) * 100)) : null;
   const remaining = known ? Math.max(0, target - current) : null;
@@ -171,11 +170,18 @@ function phaseGoal({ targetDate, current = null, target = null, unit = '%', pend
 export async function saveJourneyPlan(email, incoming = {}) {
   const existing = await JourneyPlan.findOne({ email }).lean();
   const today = startOfToday();
+  // Can't set a standup goal once the 3600-min target is already met (achieved).
+  let standupDone = false;
+  if (incoming.standupBy) {
+    const att = await AttendanceRecord.find({ email }).lean();
+    standupDone = att.reduce((a, r) => a + (r.attendedMinutes || 0), 0) >= STANDUP_MINUTES_TARGET;
+  }
   const set = {};
   for (const f of ['standupBy', 'vibeBy', 'spaBy', 'projectBy']) {
     const cur = existing?.[f] ? new Date(existing[f]) : null;
     const locked = cur && cur.getTime() >= today.getTime();   // active future target → locked
     if (locked) continue;
+    if (f === 'standupBy' && standupDone) continue;           // already achieved → not settable
     if (Object.prototype.hasOwnProperty.call(incoming, f)) set[f] = incoming[f] ? new Date(incoming[f]) : null;
   }
   if (Object.keys(set).length) await JourneyPlan.updateOne({ email }, { $set: set }, { upsert: true });


### PR DESCRIPTION
## Summary
Fixes two My-Journey standup-goal gaps (both deployed & verified live):

1. **Progress always visible** — the `X/3600 min (Y%)` bar rendered only after a goal was set; now shows in the default/missed states too.
2. **Can't set a goal on an achieved phase** — a phase was only `achieved` if a date was set, so the 598 students already at ≥3600 min could still set a goal. Now `achieved` whenever `current ≥ target` regardless of a set date (client hides the picker), plus a `saveJourneyPlan` guard rejecting `standupBy` once the target is met.

Server `journey.js` + client `main.jsx`; client rebuilt & PM2 restarted on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)