### PR TITLE
docs: rewrite FAQ_SP.md + refresh CONTEXT.md to current rubric

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,7 +1,7 @@
 # Spurti Project Context
 
 ## Overview
-Spurti is a student engagement tracking app for the VLED Summership program at IIT Ropar. It tracks student attendance, polls, chat participation, and awards SP (Spurti Points).
+Spurti is a student engagement tracking app for the VLED Summership program at IIT Ropar. It awards SP (Spurti Points) for attendance, poll correctness, peer teaching/learning (SPA), answering peer queries, and ViBe course commitments. (Chat-based SP is a legacy, now-dormant source.)
 
 ## Running
 - **Production:** `https://samagama.in/spurti/`
@@ -100,26 +100,58 @@ Samagama's only remaining job is feeding two mirrors (Zoom data + expanded
 the ledger, clearing anyone not in it). Rules are identical to the band/tier
 rubric below; only the data sources changed.
 
-## SP Calculation — band/tier rubric (current, 2026-06)
+## SP Calculation — band/tier rubric (current, 2026-08)
 
-Implemented in `pipeline/sp-rubric-build.js` (NOT in this repo's `server/scripts/`,
-which hold the retired CSV/±5 logic). See `pipeline/README.md` for detail.
+Implemented in **`pipeline/sp-rubric-build-mirror.cjs`** (the mirror rubric). The
+old live-API `pipeline/sp-rubric-build.js` and this repo's `server/scripts/`
+CSV/±5 logic are **retired**. All categories are recomputed from scratch on every
+run (wipe-and-rebuild) except `manual`/`peer_faq`, which are preserved. Live
+categories in `sptransactions`: **`initial`, `attendance`, `poll`, `spa`,
+`query`** (plus preserved `manual`). See `pipeline/README.md` for detail.
+
+Common tier ladder used by attendance & poll:
+`pct ≥ 90 → +10, 75–89 → +5, 50–74 → +3, < 50 → 0` (positive-only; never negative).
 
 - **Initial:** +100 to every *started intern* on their official start date.
   Future-start interns are zeroed; non-intern roster entries are set aside.
-- **Attendance (A):** presence clipped to the official window, `pct = clipped /
-  window`, then banded: **≥90% → +10, 75–89% → +5, 50–74% → +3, <50% → 0**.
-  - **Before 2026-07-16 (morning standup):** window `[09:05 IST, min(first-instance-end, 11:00 IST)]`.
-  - **From 2026-07-16 (standup moved to evening):** window `[20:05 IST, min(picked-mtg-end, 21:00 IST)]`
-    and the scored meeting is the mandatory meeting with the **largest overlap**
-    of that evening window (not just the earliest-starting one — the all-day
-    persistent room must not steal the slot). Cutover + times are constants at
-    the top of `sp-rubric-build-mirror.cjs`: `EVENING_CUTOVER`,
-    `EVENING_WSTART_IST`, `EVENING_WEND_IST`. Change these if the timing shifts again.
-- **Poll (B):** `pct = answered / totalQuestions`, same band ladder (10/5/3/0).
+- **Attendance (A):** banded via the tier ladder. Source depends on the date:
+  - **Before 2026-07-16 (morning standup):** Zoom presence clipped to
+    `[09:05 IST, min(first-instance-end, 11:00 IST)]`.
+  - **2026-07-16 … Day 63 (evening on Zoom):** Zoom presence clipped to
+    `[20:05 IST, min(picked-mtg-end, 21:00 IST)]`; the scored meeting is the
+    mandatory meeting with the **largest overlap** of that window (constants
+    `EVENING_CUTOVER`/`EVENING_WSTART_IST`/`EVENING_WEND_IST`).
+  - **From Day 64 / 2026-07-29 (evening on Spandan — HYBRID):** no Zoom room, so
+    attendance is derived from **Spandan poll correctness**:
+    `attendedMinutes = min(60, round(correct / pollsLaunched × 100))` (≈60% correct
+    = a full 60-min session), then the tier ladder on `minutes/60`. Special
+    no-poll nights (V-Talks, celebrations) fall back to Zoom presence in an
+    official `SPECIAL_WINDOW_IST` window. Constant: `ATT_HYBRID_CUTOVER`.
+    Minutes feed `attendancerecords` (the My-Journey 3,600-min goal) via
+    `sync-attendance-records.cjs` parsing the `present X of Y min (Z%)` reason.
+- **Poll (B):**
+  - **From 2026-07-16 (Spandan):** correctness **percentiled to the day's top
+    scorer** — `pct = pointsEarned / dayTopPoints × 100`, then the tier ladder.
+    Source: `spandan_polls` (mirrored from the Spandan Research API by
+    `spandan-poll-fetch.cjs`).
+  - **Before 2026-07-16:** `pct = answered / totalQuestions` from the frozen
+    `zoom_polls` mirror (participation), unchanged as history has it.
+- **SPA (peer teaching/learning):** from **validated** `act_spa_endorsements`
+  (status `approved`/`audit_passed`): **+5/learned question (cap 50)** and
+  **+8/peer taught (cap 30)**. A confirmed-fraud or failed-audit flag applies a
+  penalty (−50% / −20% of current SP). `category:'spa'`.
+- **Query answering:** **+5 per DISTINCT peer query answered** (from
+  `act_query_reviews.peer.submittedAnswerHistory`), self-answers excluded,
+  **capped at 200 SP/student**; answers with `peer.review.action` of
+  `rejected`/`marked_unworthy` earn nothing. `category:'query'`.
 - **Grace day 2026-06-06:** 1-min join = full attendance + full poll.
-- **Chat / discretionary:** admin-reviewed via ChatSPReview in the web app
-  (absolute or %-of-balance award). Currently dormant (`chatrecords` empty).
+- **Chat / discretionary:** legacy ChatSPReview flow; **dormant** (`chatrecords`
+  empty, no chat SP awarded).
+
+**Beyond the ledger (web app, not `sptransactions` categories):** ViBe **stake
+commitments** (bet SP on a course %-by-deadline; win/lose the stake), **My
+Journey** goals incl. the **3,600-min standup goal**, **Levels / Trophy Leagues /
+Legend** (derived by `sync-levels.cjs`), and the **SP trajectory** snapshot.
 
 > NOTE: session labels are now `Day N (DD Mon)` / `Orientation (15 May)`
 > (produced by the pipeline), NOT the old `"15 May Morning"` form still listed
@@ -190,7 +222,17 @@ Code: `getSamagamaUser` / `studentEmailFromRequest` in `server/server.js`.
 - `deltaMode` validator error: schema expects `'absolute' | 'percentage'`. Using `'percent'` (singular) causes validation failure. Fixed in code — only affects legacy transactions created before the fix (May 26 restart).
 - **Percentage SP support:** When a chat SP review is accepted with `% SP` (e.g. +10% SP), `deltaMode` is set to `'percentage'`, `deltaValue` holds the percent (e.g. 10), and `appliedDelta` is computed at accept time as `round(currentBalance * deltaValue / 100)`. This works correctly.
 
-## Current DB State (2026-06-28, after mirror-rubric APPLY)
+## Current DB State (2026-08-04)
+Scored by `pipeline/sp-rubric-build-mirror.cjs` (`APPLY=1`), refreshed on the
+6-hourly `sp-refresh.sh` cron. Ballpark live figures:
+- students with `totalSp` > 0: **~3,843**
+- `sptransactions`: **~92,060** (categories: `initial`, `attendance`, `poll`,
+  `spa`, `query`)
+- sum of all `totalSp`: **~1,173,000**
+- Leaderboard #1: **Aman Jaiswal — 1,859 SP**
+- Integrity invariant still holds: per-student `sum(appliedDelta) == totalSp`.
+
+### (historical) 2026-06-28, after mirror-rubric APPLY
 Scored by `pipeline/sp-rubric-build-mirror.cjs` (`APPLY=1`), covering Day-by-day
 mandatory sessions 15 May → 27 Jun (36 qualifying sessions; 26 Jun was a holiday).
 - students with totalSp > 0: **3,062**

--- a/FAQ_SP.md
+++ b/FAQ_SP.md
@@ -1,928 +1,258 @@
 # Spurti Points (SP) FAQ
 
-## Section 1: Overview And Purpose
+> **Last updated: 2026-08-04.** This FAQ reflects the **current live rubric**
+> (`pipeline/sp-rubric-build-mirror.cjs`). SP rules may be revised as the
+> programme evolves — when they change, update this file so students and the
+> AI bot both answer from the latest rule. The in-app **FAQ tab** shows the same
+> content; keep the two in sync.
 
-### 1. What Is Spurti?
+## Section 1: Overview and Purpose
 
-Spurti is the student engagement and motivation system used for the VLED Summership/Internship programme. It tracks learning participation through Spurti Points, also called SP.
-
-Spurti is designed to help students see their learning energy, consistency, attendance, participation, and recovery over time. It is not a marks system. It is a motivation and engagement system.
-
-In simple words:
+### 1. What is Spurti?
+Spurti is the student engagement and motivation system for the VLED
+Summership/Internship programme at IIT Ropar. It tracks how consistently a
+student participates and expresses it as **Spurti Points (SP)**.
 
 - Marks show academic performance.
 - Attendance shows presence.
-- Spurti Points show learning engagement and consistency.
+- **Spurti Points show learning engagement and consistency.**
 
-Spurti helps students understand whether they are actively participating in the programme or slowly disconnecting from it.
+It is not a marks system and not a punishment system — it makes engagement
+visible early so students and mentors can respond before momentum is lost.
 
-### 2. What Does The Word "Spurti" Mean?
+### 2. What does "Spurti" mean?
+Spurti means energy, inspiration, and forward movement — the intent is to help
+students keep their learning energy through the whole programme.
 
-Spurti means energy, inspiration, inner motivation, and forward movement.
+### 3. What are the SP earning sources?
+There are **five live sources**, each recorded as its own category in the SP
+Bank:
 
-The name was chosen because the system is meant to help students maintain learning energy throughout the programme. Many students begin a course or internship with enthusiasm, but over time they may lose consistency. Spurti makes that process visible early so students and mentors can respond before it becomes a serious problem.
+1. **Attendance** — the daily standup.
+2. **Poll** — the session quizzes.
+3. **SPA** — peer teaching and learning endorsements.
+4. **Query** — answering other students' questions.
+5. **ViBe** — course commitments.
 
-### 3. Which Programme Is Spurti Used For?
+The system is **positive-first**: you gain SP for taking part, and most
+categories can never reduce your balance.
 
-Spurti is currently used for the VLED Summership/Internship programme at IIT Ropar.
+### 4. Is SP the same as marks?
+No. Marks measure performance on assessed tasks; SP measures engagement and
+consistency. A student can have high marks but low SP (strong work, weak
+participation), or modest marks but high SP (sincere, consistent participation).
 
-It tracks engagement in live sessions and programme activities using:
+## Section 2: Onboarding, Status, and Start Date
 
-- Attendance records
-- Poll participation
-- Chat participation
-- Manual SP awards or deductions when applicable
-- Student onboarding status
-- Student SP balance and leaderboard position
+### 5. How much SP does a student get initially?
+Every active intern receives an initial **+100 SP** on their official internship
+start date — a base "learning energy" balance everyone gets equally.
 
-### 4. Why Do We Need Spurti?
+### 6. What is the student lifecycle?
+`yet to onboard → active → excused`
 
-In most learning systems, students only see marks at the end of an exam, assignment, or course. By that time, it may already be too late to correct habits.
+- **yet to onboard:** exists in the system but not yet earning SP.
+- **active:** earns SP from participation.
+- **excused:** no longer part of active calculations; past SP history is
+  preserved and they are excluded from leaderboards and future scoring. If they
+  appear in a later roster they are reactivated.
 
-Spurti gives a live signal of student engagement. It helps answer questions like:
+### 7. From which date does my SP start counting?
+From your **official internship start date**. Sessions before that date do not
+create SP for you, and you are neither rewarded nor penalised for them.
 
-- Am I attending sessions regularly?
-- Am I participating in polls?
-- Am I interacting during sessions?
-- Am I improving or falling behind?
-- Am I maintaining consistency?
-- Do I need to recover my learning momentum?
+## Section 3: Attendance SP
 
-Spurti is not meant to punish students. It is meant to make learning behavior visible.
-
-### 5. What Are Spurti Points?
-
-Spurti Points, or SP, are the learning engagement points assigned to each student.
-
-Students earn SP for positive learning behaviors such as:
-
-- Joining and staying in live sessions
-- Attempting polls
-- Participating meaningfully
-- Responding to activities
-- Receiving manual appreciation or awards from instructors
-
-Students may lose SP for:
-
-- Low attendance
-- Missing polls
-- Not participating in required activities
-- Negative or problematic participation when reviewed
-
-SP is like a learning energy bank. Every student starts with an initial balance and then gains or loses SP based on participation.
-
-### 6. Is SP The Same As Marks?
-
-No. SP is not the same as marks.
-
-Marks measure academic performance. They usually answer: "How well did the student perform in an assessed task?"
-
-SP measures engagement behavior. It answers: "How consistently is the student participating in the learning process?"
-
-A student can have:
-
-- High marks but low SP if they perform well but do not participate consistently.
-- Lower marks but high SP if they are sincerely attending, attempting, participating, and improving.
-
-Both performance and engagement matter, but Spurti focuses on engagement.
-
-### 7. Is SP A Punishment System?
-
-No. Spurti should not be understood as a punishment system.
-
-SP deductions are signals. They show where participation was missing or incomplete. The purpose is to help students notice the issue early and recover.
-
-For example:
-
-- If attendance is low, SP decreases.
-- If polls are missed, SP decreases.
-- If participation improves, SP increases again.
-
-The system is meant to support recovery, not label students as failures.
-
-### 7A. Are The SP Rules Final?
-
-The SP rules described in this FAQ are the current working rules being used or planned for the programme. They are not necessarily final forever.
-
-For the time being, SP is awarded using the rules documented here. For example, poll SP currently uses:
+### 8. How is attendance SP calculated?
+For each standup, SP is based on the **share of the session's official
+time-window** you were present, awarded in **bands**:
 
 ```text
-+1 SP for each attempted poll question
--1 SP for each missed poll question
+≥ 90% of the window  → +10 SP
+75 – 89%             → +5 SP
+50 – 74%             → +3 SP
+< 50%                → 0 SP
 ```
 
-However, the programme team may revise SP rules if required. If a new rule is approved, this FAQ should be updated so that students and the AI bot both answer from the latest documented rule.
+**Attendance never subtracts SP** — the lowest outcome is 0. Example for a
+60-minute window: ~54 min or more → +10, ~45 min → +5, ~30 min → +3.
 
-Students should treat this FAQ as the current source of explanation, but they should also understand that SP rules may be improved as the programme evolves.
+### 9. How does attendance work on the evening quiz standups?
+From **Day 64 (29 Jul 2026)** the evening standups run as a live quiz on the
+**Spandan** classroom, which has no separate join/leave time. So attendance for
+those sessions is measured from **how many launched poll questions you answer
+correctly**:
 
-## Section 2: Onboarding, Status, And Start Date
+- Answering about **60% of the questions correctly = a full 60-minute session**
+  (top band).
+- It scales down proportionally, then the same **10/5/3/0** bands apply.
 
-### 8. How Much SP Does A Student Get Initially?
+You cannot idle in the background and still get credit — genuine engagement with
+the quiz is what earns attendance now.
 
-Every active student receives an initial credit of:
+### 10. What about special sessions (V-Talks, celebrations)?
+Sessions without a Spandan quiz (guest talks, celebrations) fall back to
+**presence within the session's official window** on Zoom, banded the same way.
+
+## Section 4: Poll SP
+
+### 11. How is poll SP calculated?
+Poll SP rewards **correctness relative to the day's top scorer**: your poll
+score as a percentage of the highest scorer that day, then banded **10/5/3/0**.
+Simply clicking answers is not enough — accuracy matters, and the bar flexes
+with how hard that day's quiz was. Poll SP is **never negative**.
+
+## Section 5: SPA (peer teaching and learning)
+
+### 12. What are SPA points?
+SPA rewards learning from and teaching peers, from **validated** endorsements
+only:
 
 ```text
-+100 SP
+Learn a question (validated):  +5 SP each, capped at 50 SP  (up to 10 questions)
+Teach a peer     (validated):  +8 SP each, capped at 30 SP
 ```
 
-This is given on the student's official internship start date.
+Unvalidated or flagged endorsements do not count.
 
-This initial SP is like a starting learning energy balance. It represents the trust and opportunity given to every student at the beginning of the programme.
+### 13. Is there any penalty in SPA?
+Yes — integrity is enforced. If **fraud is confirmed** or an **audit is failed**,
+a penalty is applied to your SP. Being genuine is the only way to keep SPA SP.
 
-### 9. Do All Students Get 100 SP Immediately?
+## Section 6: Query answering SP
 
-Only active students receive the initial 100 SP.
+### 14. How do I earn SP for answering queries?
+When you give a real, useful answer to another student's question, you earn
+**+5 SP per distinct query**, up to a **maximum of 200 SP** from this source.
 
-Students who are not yet onboarded do not receive SP until they become active.
+- Answering your **own** question does not count.
+- Answers the admins **reject** or mark **unworthy** earn nothing.
 
-The student lifecycle is:
+The goal is genuine peer help — quality and effort, not volume. Shallow or
+copied answers to many queries will not build SP.
 
-```text
-yet to onboard -> active -> excused
-```
+## Section 7: ViBe course commitments
 
-Meaning:
+### 15. What are ViBe commitments?
+ViBe lets you make a commitment on your own learning: you **stake some SP** on
+reaching a target completion percentage in a course by a deadline you choose.
 
-- `yet to onboard`: Student exists in the system but has not started earning SP.
-- `active`: Student can earn and lose SP.
-- `excused`: Student is no longer part of current active calculations and does not receive new SP changes.
+- Hit the goal in time → you **win SP**.
+- Miss it → you **lose the staked amount**.
 
-### 10. From Which Date Does My SP Start Counting?
+It is optional — a motivation tool that puts "skin in the game" behind a goal
+you set for yourself.
 
-Your SP starts counting from your official internship start date.
+## Section 8: My Journey and the 3,600-minute goal
 
-Sessions before your internship start date should not affect your SP.
+### 16. What is My Journey?
+My Journey brings your progress across the four tracks — **Standups, ViBe, SPA,
+Projects** — into one view, with an optional target date per track to pace
+yourself.
 
-Example:
+### 17. What is the 3,600-minute standup goal?
+The standup track's goal is to reach **3,600 cumulative attended minutes**
+(≈ 60 sessions of ~60 minutes). The progress bar shows minutes achieved vs the
+3,600 required. Once you reach 3,600 the goal is marked **achieved** and no
+target date is needed — that track's attendance goal is complete.
 
-If your internship start date is 17 May 2026, then sessions on 15 May and 16 May should not create SP transactions for you.
+## Section 9: SP Bank, Transactions, and Ledger
 
-### 11. What Happens If I Join The Programme Late?
+### 18. What is the SP Bank?
+Your complete, transparent ledger. Every SP change is a line showing the date,
+category, reason, amount, and running balance afterwards.
 
-If you officially join late, your SP should start from your actual onboarding or internship start date.
+### 19. How should I read my SP ledger?
+Session by session, not just the final number. For each date check whether you
+got attendance SP, poll SP, and any SPA/query SP, read the reason text, and look
+at the balance after each change. Most "why is my SP this number?" questions are
+answered by reading the reasons line by line.
 
-You should not be penalized for sessions that happened before your official start date.
+### 20. Why did my SP change by a different amount than I expected?
+SP is computed **category by category and then added**, so a single day can
+combine attendance, poll, and SPA/query SP. Open the SP Bank and read each
+line's reason for that date — the per-category detail explains the total.
 
-However, after you become active, future sessions will count normally.
+## Section 10: Can SP go down?
 
-### 12. What Happens If A Student Is Excused?
+### 21. Can my SP decrease?
+For everyday activity, **no**. Attendance and polls only ever add SP (floor 0),
+so a low day simply earns less, never a deduction. SP decreases in only two
+cases:
 
-If a student is marked as excused:
+- You **lose a ViBe stake** you chose to make.
+- An **SPA integrity penalty** applies (confirmed fraud or failed audit).
 
-- They stop receiving new SP changes.
-- They are excluded from active cohort calculations.
-- Their previous SP history is preserved.
-- They are not treated as active for future attendance, poll, or chat calculations.
+Spurti is built to reward participation and recovery, not to punish an ordinary
+off day.
 
-This is useful when a student leaves, pauses, or is officially removed from the active cohort.
+## Section 11: Leaderboard and Levels
 
-## Section 3: Attendance SP Rules
+### 22. What are the leaderboard and levels?
+The leaderboard ranks active students by total SP; levels/leagues reflect your
+standing. Both are engagement signals — consistency and participation, not
+academic ability. Scores refresh periodically, so rankings move; focus on your
+own steady progress.
 
-### 13. How Are SP Awarded For Attendance?
+## Section 12: Corrections, Evidence, and Missing Records
 
-Attendance is evaluated for each session.
+### 23. Why is a session missing from my SP?
+Common reasons: it was before your start date, you were excused, the email you
+joined with doesn't match your record, or that day hasn't been processed yet.
+Check your SP Bank for that date first.
 
-The general rule is:
+### 24. Are SP updates immediate?
+No. Scores are **recomputed on a schedule (about every 6 hours)**, and some data
+must be processed first, so new activity can take time to appear. If a genuine
+change is still missing after about a day, raise a correction.
 
-```text
-If attendance is 75% or more: +5 SP
-If attendance is less than 75%: -5 SP
-```
+### 25. I joined with a different email — what do I do?
+Always join sessions and quizzes with your **registered programme email**, or
+your records may not link. If you already used another email, ask the team to
+add it as an **alternate email** on your record.
 
-Example:
-
-If a session is 120 minutes long:
-
-- 75% of 120 minutes = 90 minutes
-- If you attend 90 minutes or more, you get +5 SP.
-- If you attend less than 90 minutes, you get -5 SP.
-
-### 14. Is The Attendance Rule Always 75%?
-
-The general rule is 75%.
-
-However, a special session may have a different rule if the programme team defines it.
-
-For example, the 17 May Evening session had a fixed threshold of 50 minutes instead of the regular 75% calculation.
-
-Unless specifically announced or configured otherwise, assume that the threshold is 75%.
-
-### 15. What If I Join Late Or Leave Early?
-
-Your attendance is calculated using the actual minutes recorded in the session.
-
-If you join late or leave early, only your attended minutes are counted.
-
-Example:
-
-Session duration: 100 minutes  
-Required attendance at 75%: 75 minutes
-
-- Attended 90 minutes: +5 SP
-- Attended 75 minutes: +5 SP
-- Attended 60 minutes: -5 SP
-- Attended 0 minutes: -5 SP
-
-### 16. What If My Internet Disconnects?
-
-Spurti depends on the attendance data available from the session platform.
-
-If your internet disconnects and your attendance minutes become low, the system may mark you below the threshold.
-
-If you believe your attendance is incorrect, you should raise a request with evidence such as:
-
-- Session date
-- Session name
-- Email used to join
-- Approximate joining and leaving time
-- Screenshot or other proof, if available
-
-### 17. Which Email Is Used For Attendance?
-
-Attendance is usually matched using the email recorded in the session attendance file.
-
-You should join sessions using the same email that is registered in the programme system.
-
-If you join using a different email, your attendance may not match correctly.
-
-If you use an alternate email, you should inform the team early and ensure it is added to your record.
-
-### 18. What If I Joined With A Different Email?
-
-If you joined with a different email, your attendance may not automatically connect to your Spurti account.
-
-To request correction, provide:
-
-- Your registered email
-- The alternate email used
-- Session date and label
-- Approximate time attended
-- Any proof that the alternate email belongs to you
-
-The team can then check whether the alternate email appears in the attendance records.
-
-## Section 4: Poll SP Rules
-
-### 19. How Are SP Awarded For Polls?
-
-Poll SP is calculated question by question.
-
-The rule is:
-
-```text
-+1 SP for each poll question attempted
--1 SP for each poll question missed
-```
-
-The final poll SP is:
-
-```text
-attempted questions - missed questions
-```
-
-Example:
-
-If a poll has 10 questions:
-
-- Attempted 10, missed 0: +10 SP
-- Attempted 8, missed 2: +6 SP
-- Attempted 5, missed 5: 0 SP
-- Attempted 3, missed 7: -4 SP
-- Attempted 0, missed 10: -10 SP
-
-### 20. Why Can Poll SP Be Negative?
-
-Poll SP can be negative because missed questions also count.
-
-The idea is to encourage active participation during live sessions. If a student is present but does not attempt polls, the system treats that as incomplete participation.
-
-### 21. What If I Was Present But Did Not See The Poll?
-
-If you were present but missed the poll because of a technical issue, raise a request with details:
-
-- Session name
-- Time of issue
-- What happened
-- Whether others had the same problem
-- Screenshot, if available
-
-The team can review the case, but automatic SP is based on the poll records available.
-
-### 22. What If A Poll Was Not Conducted?
-
-If a session does not have a poll file or poll activity, poll SP may not be applied for that session.
-
-Only sessions with poll data generate poll-based SP.
-
-## Section 5: Chat SP Rules
-
-### 23. How Are SP Awarded For Chat Participation?
-
-Chat participation may be evaluated when a session has chat data.
-
-The current automated chat rule uses a simple sentiment method:
-
-- Positive or meaningful chat participation can receive +5 SP.
-- Negative chat sentiment can receive -5 SP.
-
-This is calculated per student per session when the student has sent chat messages.
-
-### 24. How Does Chat Sentiment Work?
-
-The current system uses a rule-based word list.
-
-Some positive words increase the chat score, such as:
-
-```text
-good, great, excellent, helpful, learned, interesting, clear,
-understood, thanks, motivated, useful, curious, practical
-```
-
-Some negative words reduce the chat score, such as:
-
-```text
-bad, poor, confused, issue, problem, not, failed, unable,
-difficult, boring, missed, wrong, error, stuck
-```
-
-The system then counts positive and negative messages.
-
-General decision:
-
-```text
-If positive messages are greater than or equal to negative messages: +5 SP
-If negative messages are greater than positive messages: -5 SP
-```
-
-### 25. Is Chat Sentiment Always Perfect?
-
-No. Chat sentiment is not perfect.
-
-It is currently rule-based and can misunderstand context.
-
-Example:
-
-```text
-"I was not confused after the explanation."
-```
-
-This is actually positive, but the words "not" and "confused" may be interpreted negatively by a simple word-based system.
-
-For this reason, some chat-related SP may require admin review or correction.
-
-### 26. Do Simple Messages Like "Hi" Or "Good Morning" Count?
-
-Simple greeting or filler messages may be treated as neutral.
-
-Examples:
-
-```text
-hi
-hello
-ok
-done
-good morning
-thank you
-```
-
-These may not always represent meaningful academic participation.
-
-Students should try to use chat for useful participation, questions, answers, reflections, and activity responses.
-
-### 27. Can Chat Give Extra SP Apart From Automatic Sentiment?
-
-Yes. Instructors may manually award SP based on chat responses or participation.
-
-For example, if a teacher appreciates a student's answer or activity response, they may award:
-
-```text
-+3 SP
-+5 SP
-+10 SP
-```
-
-Manual awards may go through a review process before being added to the SP ledger.
-
-### 28. Can Instructors Deduct SP Manually?
-
-Yes, manual deduction may also happen if required.
-
-Examples:
-
-- Incorrect conduct
-- Repeated disregard of instructions
-- Camera or participation-related penalties if announced
-- Specific instructor-reviewed cases
-
-Manual deductions should have a reason attached so that the student can understand why the SP changed.
-
-### 29. What Is A Manual SP Review?
-
-A manual SP review is an item that is detected or created for admin approval.
-
-For example, if a chat message says:
-
-```text
-Award +5 SP to Rahul
-```
-
-The system may create a review item. The admin then checks it and either:
-
-- Accepts it, which creates the SP transaction.
-- Rejects it, which means no SP change is applied.
-
-This prevents accidental or incorrect SP changes.
-
-## Section 6: ViBe Course SP Rules
-
-### 30. What Are The Main SP Categories?
-
-The main SP categories are:
-
-```text
-initial
-attendance
-poll
-chat
-ViBe course milestone
-manual award or manual deduction
-```
-
-Each SP change is recorded as a transaction.
-
-### 31. How Will ViBe Course Completion Affect SP?
-
-ViBe course completion may also generate SP based on milestone completion.
-
-Unlike attendance and polls, ViBe course SP is percentage-based. This means the SP change is calculated as a percentage of your current SP balance at the time the milestone is processed.
-
-The planned milestone rule is:
-
-```text
-25% course completion by deadline: +2.5% of current SP
-50% course completion by deadline: +5% of current SP
-75% course completion by deadline: +7.5% of current SP
-100% course completion by deadline: +10% of current SP
-```
-
-Example:
-
-If your current SP is 200 and you complete the 25% ViBe milestone before the deadline:
-
-```text
-2.5% of 200 = 5 SP
-New balance = 205 SP
-```
-
-### 32. What Happens If I Miss A ViBe Course Deadline?
-
-If a ViBe course milestone deadline is missed, a percentage deduction may be applied to your current SP.
-
-For example:
-
-```text
-Missed 50% course completion deadline: -5% of current SP
-```
-
-Example:
-
-If your current SP is 200 and you miss the 50% ViBe deadline:
-
-```text
-5% of 200 = 10 SP
-New balance = 190 SP
-```
-
-This deduction is applied because the required milestone was not completed within the given timeline.
-
-### 33. Can I Recover Missed ViBe Milestone SP Later?
-
-You can continue the course and earn future milestone SP, but the SP missed or deducted for an earlier deadline is not automatically restored.
-
-Example:
-
-```text
-Week 1: You complete 25% before the deadline.
-Result: +2.5% of current SP
-
-Week 2: You miss the 50% deadline.
-Result: -5% of current SP
-
-Week 3: You complete 75% before the deadline.
-Result: +7.5% of current SP
-```
-
-In this case, when you complete 75%, you receive the 75% milestone reward only. You do not also receive the 50% reward that was missed, and the earlier -5% deduction is not automatically reversed.
-
-The idea is that each ViBe milestone has its own timeline. Completing a later milestone helps you move forward, but it does not erase a missed earlier deadline unless the programme team explicitly announces a correction or recovery rule.
-
-### 34. Why Is ViBe SP Percentage-Based?
-
-ViBe SP is percentage-based because it rewards learning momentum relative to your current engagement level.
-
-If you have maintained a strong SP balance, your milestone reward becomes larger. If your balance is lower, the reward is smaller, but recovery is still possible through future milestones and participation.
-
-This makes consistency valuable over time.
-
-## Section 7: SP Bank, Transactions, And Ledger
-
-### 35. What Is An SP Transaction?
-
-An SP transaction is a record of one SP change.
-
-It usually contains:
-
-- Student email
-- Student ID
-- Category
-- Session label
-- SP change
-- Balance after the change
-- Reason
-- Date and time
-
-This creates a transparent SP Bank ledger.
-
-### 36. What Is The SP Bank?
-
-The SP Bank is your personal SP ledger.
-
-It shows:
-
-- Current SP balance
-- SP earned
-- SP deducted
-- Session-wise transactions
-- Reasons for each change
-- Attendance, poll, and participation records where available
-
-It helps you understand how your SP changed over time.
-
-### 37. Why Did My SP Decrease Even Though I Attended?
-
-Possible reasons:
-
-- You attended less than the required threshold.
-- You missed some or all poll questions.
-- Your chat participation was scored negatively.
-- You missed a ViBe course milestone deadline.
-- A manual deduction was applied.
-- You joined using an email that did not match your registered account.
-
-Attendance alone is not the only source of SP. Polls and chat can also affect your balance.
-
-### 38. Why Did My SP Increase Even Though I Missed Some Attendance?
-
-This can happen because SP is calculated category-wise.
-
-Example:
-
-- Attendance: -5 SP
-- Poll: +10 SP
-- Chat/manual award: +5 SP
-
-Net effect:
-
-```text
--5 + 10 + 5 = +10 SP
-```
-
-So your total SP may increase even if one category was negative.
-
-### 39. Why Did I Get Negative SP For A Session?
-
-You may get negative SP if:
-
-- Attendance was below threshold.
-- Polls were missed.
-- Chat sentiment was negative.
-- A ViBe course milestone deadline was missed.
-- A manual penalty was approved.
-
-Check the transaction reason in your SP Bank to know the exact cause.
-
-## Section 8: Leaderboard, Red Zone, And Recovery
-
-### 40. What Is The Leaderboard?
-
-The leaderboard ranks active students based on SP.
-
-It reflects engagement and consistency, not marks.
-
-A higher SP balance usually means the student has been more consistent in attendance, polls, and participation.
-
-### 41. Does A Higher SP Mean I Am Academically Better?
-
-Not necessarily.
-
-High SP means strong engagement and participation. It does not automatically mean higher academic mastery.
-
-Similarly, low SP does not mean a student is incapable. It may mean the student missed sessions, polls, or participation opportunities.
-
-### 42. What Is The Red Zone?
-
-The Red Zone is a warning concept used in the broader Spurti design.
-
-It means a student's SP has dropped below a safe level or expected engagement level for a period of time.
-
-The purpose is not punishment. The purpose is early intervention.
-
-If a student enters the Red Zone, mentors or teachers may reach out to understand the issue and help the student recover.
-
-### 43. Can I Recover Lost SP?
-
-Yes. Spurti is designed so that recovery is possible.
-
-You can recover by:
-
-- Attending future sessions properly
-- Attempting polls
-- Participating meaningfully
-- Completing future ViBe milestones within the given timeline
-- Completing required activities
-- Responding to mentor guidance
-- Taking part in announced SP opportunities
-
-One bad session should not define your entire journey.
-
-### 44. Can My SP Go Below Zero?
-
-The current active Summership system tracks total SP as transactions are added.
-
-The broader Spurti design includes ideas such as minimum SP limits and recovery mechanisms. For the active programme, students should focus on maintaining and improving their SP through participation.
-
-If a balance appears incorrect or unusually low, students should request a review.
-
-## Section 9: Corrections, Evidence, And Missing Records
-
-### 45. What If My SP Balance Looks Wrong?
-
-If your SP balance looks wrong, first check your SP Bank transaction history.
-
-Look for:
-
-- Attendance transaction
-- Poll transaction
-- Chat transaction
-- ViBe course milestone transaction
-- Manual award or deduction
-- Session label
-- Reason text
-- Balance after transaction
-
-If you still think there is an error, raise a correction request.
-
-### 46. How Do I Request An SP Correction?
-
-When requesting a correction, provide complete details.
-
-Use this format:
+### 26. How do I request an SP correction?
+Provide enough detail to verify it:
 
 ```text
 Name:
 Registered email:
-Alternate email, if any:
+Alternate email (if any):
 Session date:
 Session label:
-Issue category: Attendance / Poll / Chat / ViBe / Manual SP / Other
+Category: Attendance / Poll / SPA / Query / ViBe / Other
 What is wrong:
 What you expected:
-Evidence, if any:
+Evidence (screenshot, join/leave time, course-progress proof):
 ```
 
-Incomplete requests are harder to verify.
-
-### 47. What Evidence Helps In SP Correction?
-
-Useful evidence includes:
-
-- Screenshot of Zoom attendance or session presence
-- Screenshot of poll participation
-- Screenshot or proof of ViBe course progress
-- Chat screenshot
-- Email used to join the session
-- Approximate join and leave time
-- Any message from instructor or mentor
-- Clear explanation of the issue
-
-The team checks system records first, so specific dates and session labels are very important.
-
-### 48. Why Is My Alternate Email Important?
-
-If you joined sessions with another email, the attendance file may record that alternate email instead of your registered email.
-
-If the alternate email is not linked to your account, Spurti may not know that both emails belong to the same student.
-
-Always use the registered email whenever possible.
-
-### 49. Can I Use Multiple Emails?
-
-Avoid using multiple emails.
-
-Use the same registered email for:
-
-- Joining sessions
-- Poll participation
-- Programme communication
-- Spurti access
-
-If you must use another email, inform the team and get it added as an alternate email.
-
-### 50. Why Am I Not Able To Search My SP Directly?
-
-In production, direct student search may be disabled for privacy and security.
-
-Students should normally open Spurti from the Samagama dashboard or official programme link.
-
-This ensures that students see only their own SP details.
-
-### 51. How Should I Read My SP Ledger?
-
-Read your ledger session by session.
-
-For each session, check:
-
-- Did I get attendance SP?
-- Did I get poll SP?
-- Did I get chat SP?
-- Did I get ViBe course milestone SP?
-- Was there a manual award or deduction?
-- What was my balance after that transaction?
-
-Do not look only at the final number. The ledger tells the story of how your SP changed.
-
-### 52. Why Are Some Sessions Missing From My SP?
-
-Possible reasons:
-
-- The session happened before your internship start date.
-- You were not active at that time.
-- You were marked excused.
-- That session did not have a particular data source, such as poll or chat.
-- The session has not yet been ingested into the system.
-- Your email did not match the attendance or poll records.
-
-### 53. Why Is My ViBe Course Milestone Missing From My SP?
-
-Possible reasons:
-
-- The milestone deadline has not yet arrived.
-- Your course progress was not recorded before the deadline.
-- The ViBe progress data has not yet been processed.
-- You completed the milestone after the deadline.
-- Your ViBe account/email does not match your registered programme email.
-- The milestone is still under review.
-
-If you believe your ViBe progress is missing, raise a correction request with your course progress proof and the email used on ViBe.
-
-### 54. What If A Session Happened Before My Onboarding?
-
-Sessions before your official internship start date should not count for SP.
-
-You should not receive rewards or penalties for those sessions.
-
-### 55. Are SP Updates Immediate?
-
-Not always.
-
-Some SP updates depend on data processing after the session:
-
-- Attendance files need to be uploaded and processed.
-- Poll files need to be uploaded and processed.
-- Chat files may need review.
-- ViBe course progress may need to be checked against milestone deadlines.
-- Manual awards or deductions may need admin approval.
-
-So your SP may update after some delay.
-
-### 56. Can SP Be Changed Later?
-
-Yes. SP may be corrected later if:
-
-- Attendance data was mismatched.
-- Wrong email was used.
-- A poll record was missing.
-- ViBe course progress was not matched correctly.
-- A manual review was accepted or rejected.
-- A transaction was found to be incorrect.
-
-Corrections should be based on evidence and system records.
-
-## Section 10: Automatic And Manual SP
-
-### 57. What Is The Difference Between Automatic And Manual SP?
-
-Automatic SP is calculated from available data:
-
-- Attendance minutes
-- Poll attempts
-- Chat sentiment
-- ViBe course milestone progress, when configured
-
-Manual SP is given or deducted by an instructor/admin after review.
-
-Examples of manual SP:
-
-- Bonus for a very good answer
-- Bonus for helping others
-- Deduction for specific rule violation
-- Correction after verifying an issue
-
-## Section 11: Good Practices For Students
-
-### 58. What Are Good Practices To Maintain SP?
-
-Good practices:
-
-- Join sessions with your registered email.
-- Join on time.
-- Stay until the end.
-- Attempt all polls.
-- Use chat meaningfully.
-- Complete ViBe course milestones before their deadlines.
-- Ask questions when confused.
-- Respond to activities.
-- Avoid spam or irrelevant messages.
-- Check your SP ledger regularly.
-- Raise issues quickly with full details.
-
-### 59. What Should I Avoid?
-
-Avoid:
-
-- Joining with different emails without informing the team.
-- Joining very late or leaving early.
-- Ignoring polls.
-- Missing ViBe course milestone deadlines.
-- Sending only filler messages repeatedly.
-- Spamming chat.
-- Assuming attendance is counted without checking.
-- Raising vague complaints without session details.
-
-### 60. If I Ask "I Am Confused", Will I Lose SP?
-
-The current rule-based chat sentiment can sometimes misunderstand negative words like "confused" or "stuck".
-
-Students should not stop asking questions because of this. Asking questions is part of learning.
-
-If a genuine learning question is incorrectly treated as negative, it can be reviewed.
-
-To reduce misunderstanding, write clearly:
-
-```text
-I am confused about the assignment step. Can you explain the submission format?
-```
-
-This is better than only writing:
-
-```text
-confused
-```
-
-### 61. Is It Better To Stay Silent In Chat?
-
-No. Meaningful participation is better than silence.
-
-Use chat for:
-
-- Answers
-- Questions
-- Reflections
-- Poll-related discussion
-- Activity responses
-- Constructive feedback
-
-Avoid spam or repeated filler messages.
-
-## Section 12: Meaning, Future Features, And Summary
-
-### 62. Can SP Be Used Like Money?
-
-SP is not real money.
-
-It is a learning motivation currency inside the programme.
-
-Depending on programme rules, SP may be used for rankings, recognition, achievements, redemption, recovery signals, or other academic engagement features.
-
-### 63. What Are Achievements Or Badges?
-
-The broader Spurti design includes badges, streaks, achievements, red zone recovery, analytics, and other motivation features.
-
-These may be introduced gradually as the system evolves.
-
-### 64. What Is The Main Message Of Spurti?
-
-The main message is:
-
-```text
-Your learning effort matters.
-Your consistency matters.
-Your participation matters.
-Your recovery matters.
-```
-
-Spurti tries to make these things visible.
-
-### 65. One-Line Summary
-
-Spurti is a motivation and engagement system for the VLED Summership/Internship programme that uses SP to make student attendance, participation, ViBe course progress, consistency, and recovery visible throughout the learning journey.
+The team checks system records first, so accurate dates and labels matter.
+
+## Section 13: Automatic vs Manual SP
+
+### 27. What is the difference between automatic and manual SP?
+**Automatic SP** is computed from data — attendance, polls, SPA endorsements,
+query answers, and ViBe outcomes. **Manual SP** is any award/adjustment an
+admin makes after review (rare; used for corrections). Manual awards are
+recorded in the ledger with a reason.
+
+## Section 14: Good Practices
+
+### 28. What are good practices to maintain SP?
+- Join with your registered email, on time, and stay for the session.
+- Attempt the quizzes and answer carefully — correctness matters.
+- Help peers genuinely (SPA and queries).
+- Complete ViBe commitments you make before their deadline.
+- Check your SP Bank regularly and raise issues quickly with full details.
+
+### 29. Why can't I search my SP directly?
+For privacy, direct student search is disabled in production. Open Spurti from
+your **Samagama dashboard** — you will only ever see your own record.
+
+## Section 15: Summary
+
+### 30. One-line summary
+Spurti is a positive-first engagement system for the VLED Summership: it turns
+attendance, poll correctness, peer teaching (SPA), query answering, and ViBe
+course commitments into visible Spurti Points so students can see and sustain
+their learning momentum.


### PR DESCRIPTION
Brings the two docs in line with the live rubric: FAQ_SP.md fully rewritten (banded attendance, Spandan poll correctness, SPA, query answering + 200 cap, ViBe commitments, 3600-min goal, positive-only), and CONTEXT.md corrected (scorer ref, poll scoring, hybrid attendance, spa/query categories, refreshed DB-state snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)