### PR TITLE
feat(leaderboard): weekly + category + cohort boards (cached)

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -296,7 +296,7 @@ function StudentView({ profile, onBack }) {
       {tab === 'journey' && <MyJourney student={student} goToCommitment={goToCommitment} canCommit={student.eligibleForVibeGoals} />}
       {tab === 'vibe' && student.eligibleForVibeGoals && <Commitments student={student} initialPhase={commitPhase} />}
       {tab === 'spa' && <SpaModule student={student} />}
-      {tab === 'leaderboard' && <LeaderboardTabs overall={profile.leaderboard} group={profile.groupLeaderboard} groupLabel={student.leaderboardGroupLabel} />}
+      {tab === 'leaderboard' && <LeaderboardPanel student={student} />}
       {tab === 'faq' && <FaqTab />}
     </main>
   );
@@ -418,28 +418,66 @@ function LevelStatus({ student }) {
   );
 }
 
-function LeaderboardTabs({ overall = [], group = [], groupLabel }) {
-  const [type, setType] = useState('overall');
-  const rows = type === 'overall' ? overall : group;
+// Curated leaderboard presets → each maps to a cached board (window/category/scope).
+const LB_PRESETS = [
+  { key: 'week-total',        label: 'This Week',                          window: 'week', category: 'total',      scope: 'all' },
+  { key: 'week-total-cohort', label: 'This Week — My Cohort',             window: 'week', category: 'total',      scope: 'cohort' },
+  { key: 'all-total',         label: 'All-Time',                          window: 'all',  category: 'total',      scope: 'all' },
+  { key: 'all-total-cohort',  label: 'All-Time — My Cohort',             window: 'all',  category: 'total',      scope: 'cohort' },
+  { key: 'week-attendance',   label: '🏅 Best Attendance — This Week',    window: 'week', category: 'attendance', scope: 'all' },
+  { key: 'all-attendance',    label: '🏅 Best Attendance — All-Time',     window: 'all',  category: 'attendance', scope: 'all' },
+  { key: 'week-poll',         label: '🎯 Poll Champions — This Week',      window: 'week', category: 'poll',       scope: 'all' },
+  { key: 'all-poll',          label: '🎯 Poll Champions — All-Time',       window: 'all',  category: 'poll',       scope: 'all' },
+  { key: 'week-spa',          label: '🧑‍🏫 Top SPA — This Week',           window: 'week', category: 'spa',        scope: 'all' },
+  { key: 'all-spa',           label: '🧑‍🏫 Top SPA — All-Time',            window: 'all',  category: 'spa',        scope: 'all' },
+  { key: 'week-query',        label: '💬 Top Query Answerers — This Week', window: 'week', category: 'query',      scope: 'all' },
+  { key: 'all-query',         label: '💬 Top Query Answerers — All-Time',  window: 'all',  category: 'query',      scope: 'all' },
+];
+
+function LeaderboardPanel({ student }) {
+  const [presetKey, setPresetKey] = useState('week-total');
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const preset = LB_PRESETS.find(p => p.key === presetKey);
+  useEffect(() => {
+    let live = true;
+    setLoading(true);
+    fetch(`${API}/leaderboard/board?window=${preset.window}&category=${preset.category}&scope=${preset.scope}&email=${encodeURIComponent(student.email)}`)
+      .then(r => r.json())
+      .then(d => { if (live) { setData(d); setLoading(false); } })
+      .catch(() => { if (live) setLoading(false); });
+    return () => { live = false; };
+  }, [presetKey, student.email]);
+  const rows = data?.rows || [];
+  const me = data?.me || null;
+  const meOutside = me && !rows.some(r => r.studentId === student._id);
   return (
     <section className="panel">
       <div className="panel-head">
         <h2>Leaderboard</h2>
-        <select value={type} onChange={e => setType(e.target.value)}>
-          <option value="overall">Overall Leaderboard</option>
-          <option value="my_onboarding_group">My Onboarding Group</option>
+        <select value={presetKey} onChange={e => setPresetKey(e.target.value)}>
+          {LB_PRESETS.map(p => <option key={p.key} value={p.key}>{p.label}</option>)}
         </select>
       </div>
-      {type === 'my_onboarding_group' && groupLabel &&
-        <p className="muted">Showing students onboarded in your group: {groupLabel}</p>}
-      <table className="table">
-        <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>Level</th><th>SP</th></tr></thead>
-        <tbody>{rows.map(row => (
-          <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}>
-            <td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.level}</td><td>{row.totalSp}</td>
-          </tr>
-        ))}</tbody>
-      </table>
+      {preset.window === 'week' && data?.weekLabel && <p className="muted lb-week">Week of {data.weekLabel} · resets Monday</p>}
+      {loading ? <p className="muted">Loading…</p> : rows.length === 0 ? <p className="muted">No entries yet.</p> : (
+        <>
+          <table className="table lb-table">
+            <thead><tr><th>Rank</th><th>Name</th><th>Level</th><th>SP</th></tr></thead>
+            <tbody>{rows.map(r => (
+              <tr key={r.studentId} className={r.studentId === student._id ? 'current-student' : ''}>
+                <td>{r.rank}</td><td>{r.name}</td><td>L{r.level}</td><td>{r.sp}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+          {me && (
+            <div className="lb-me">
+              You: <b>#{me.rank}</b> · {me.sp} SP
+              {meOutside && <span className="muted"> — {preset.window === 'week' ? 'earn more this week to climb' : 'keep going to climb'}</span>}
+            </div>
+          )}
+        </>
+      )}
     </section>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -699,3 +699,8 @@ input {
 .faq-caret { font-size: 18px; font-weight: 800; line-height: 1; color: var(--muted); flex: 0 0 auto; }
 .faq-item.open .faq-caret { color: var(--primary); }
 .faq-a { margin: 0; padding: 0 14px 14px; font-size: 13px; line-height: 1.55; color: var(--muted); }
+
+/* Weekly / category leaderboard */
+.lb-week { font-size: 12.5px; margin: 0 0 10px; }
+.lb-me { margin-top: 12px; padding: 10px 12px; border-radius: 8px; background: var(--bg); border: 1px solid var(--line); font-size: 13.5px; font-weight: 700; }
+.lb-me .muted { font-weight: 500; }

--- a/server/models/LeaderboardSnapshot.js
+++ b/server/models/LeaderboardSnapshot.js
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose';
+
+// One document per leaderboard "board" (window × category × scope). Rebuilt each
+// sp-refresh by services/leaderboards.js. Rows hold the FULL sorted list so the
+// API can return the top N AND locate the requesting student's own rank. No email
+// is stored — student-facing boards show name + level only.
+const rowSchema = new mongoose.Schema({
+  studentId: { type: String, required: true },
+  name: { type: String, required: true },
+  sp: { type: Number, default: 0 },
+  level: { type: Number, default: 0 },
+  rank: { type: Number, required: true }
+}, { _id: false });
+
+const leaderboardSnapshotSchema = new mongoose.Schema({
+  boardKey: { type: String, required: true, unique: true, index: true }, // e.g. week:total:all, all:query:all, week:total:group:<g>
+  window: { type: String, enum: ['week', 'all'], required: true },
+  category: { type: String, enum: ['total', 'attendance', 'poll', 'spa', 'query'], required: true },
+  scope: { type: String, enum: ['all', 'group'], required: true },
+  group: { type: String, default: null },
+  weekStart: { type: Date, default: null },
+  weekLabel: { type: String, default: '' },
+  builtAt: { type: Date, default: Date.now },
+  rows: { type: [rowSchema], default: [] }
+}, { timestamps: true });
+
+export default mongoose.model('LeaderboardSnapshot', leaderboardSnapshotSchema);

--- a/server/scripts/buildLeaderboards.js
+++ b/server/scripts/buildLeaderboards.js
@@ -1,0 +1,15 @@
+// Recompute the cached weekly/all-time/category/cohort leaderboard boards and
+// store them as LeaderboardSnapshot docs. Wire into sp-refresh (after sync-levels).
+//   node server/scripts/buildLeaderboards.js
+import mongoose from 'mongoose';
+import { MONGO_URI } from '../config.js';
+import { computeAndStoreLeaderboards } from '../services/leaderboards.js';
+
+async function main() {
+  await mongoose.connect(MONGO_URI);
+  const r = await computeAndStoreLeaderboards();
+  console.log('leaderboards rebuilt:', r);
+  await mongoose.disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ import AttendanceRecord from './models/AttendanceRecord.js';
 import PollRecord from './models/PollRecord.js';
 import SPTransaction from './models/SPTransaction.js';
 import SessionEvent from './models/SessionEvent.js';
+import LeaderboardSnapshot from './models/LeaderboardSnapshot.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import Commitment from './models/Commitment.js';
 import { isVibeEligible, buildVibeState, validateBet, settleBetDemo, applySpDelta, courseByKey } from './services/vibe.js';
@@ -435,6 +436,28 @@ api.get('/leaderboard', async (req, res) => {
     level: levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0)),
     trophyLeague: leagueBand(s.totalSp)
   })));
+});
+
+// Cached weekly/all-time/category/cohort boards (built by buildLeaderboards.js).
+// window=week|all, category=total|attendance|poll|spa|query, scope=all|cohort.
+// Returns the top 50 + the requesting student's own rank/SP (even if outside it).
+api.get('/leaderboard/board', async (req, res) => {
+  const student = await vibeStudent(req);
+  const window = ['week', 'all'].includes(req.query.window) ? req.query.window : 'week';
+  const category = ['total', 'attendance', 'poll', 'spa', 'query'].includes(req.query.category) ? req.query.category : 'total';
+  // Cohort scope only exists for the 'total' board; category boards are global.
+  const wantCohort = req.query.scope === 'cohort' && category === 'total' && student?.leaderboardGroup;
+  const boardKey = wantCohort ? `${window}:total:group:${student.leaderboardGroup}` : `${window}:${category}:all`;
+  const board = await LeaderboardSnapshot.findOne({ boardKey }).lean();
+  if (!board) return res.json({ window, category, scope: wantCohort ? 'cohort' : 'all', weekLabel: '', builtAt: null, rows: [], me: null });
+  const meId = student ? String(student._id) : null;
+  const meRow = meId ? board.rows.find((r) => r.studentId === meId) : null;
+  res.json({
+    window: board.window, category: board.category, scope: wantCohort ? 'cohort' : 'all',
+    weekLabel: board.weekLabel, builtAt: board.builtAt, total: board.rows.length,
+    rows: board.rows.slice(0, 50),
+    me: meRow ? { rank: meRow.rank, sp: meRow.sp } : null
+  });
 });
 
 api.post('/ping', async (req, res) => {

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -1,0 +1,97 @@
+import Student from '../models/Student.js';
+import SPTransaction from '../models/SPTransaction.js';
+import LeaderboardSnapshot from '../models/LeaderboardSnapshot.js';
+import { levelFor } from './levels.js';
+
+// Category boards beyond the "total" board. Combined SPA (learn + teach) is one
+// category. `total` = sum of all categories in the window.
+const CATS = ['attendance', 'poll', 'spa', 'query'];
+const IST_MS = 5.5 * 3600 * 1000;
+const MON = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Most recent Monday 00:00 IST, returned as the real UTC instant.
+function weekStartIST(now) {
+  const ist = new Date(now.getTime() + IST_MS);
+  const daysSinceMon = (ist.getUTCDay() + 6) % 7; // Mon->0 ... Sun->6
+  const monMidnightIst = Date.UTC(ist.getUTCFullYear(), ist.getUTCMonth(), ist.getUTCDate() - daysSinceMon);
+  return new Date(monMidnightIst - IST_MS);
+}
+function weekLabel(weekStartUtc) {
+  const s = new Date(weekStartUtc.getTime() + IST_MS);
+  const e = new Date(s.getTime() + 6 * 86400000);
+  return s.getUTCMonth() === e.getUTCMonth()
+    ? `${MON[s.getUTCMonth()]} ${s.getUTCDate()}–${e.getUTCDate()}`
+    : `${MON[s.getUTCMonth()]} ${s.getUTCDate()} – ${MON[e.getUTCMonth()]} ${e.getUTCDate()}`;
+}
+
+// Sum appliedDelta per (student, category) over a match window.
+async function sumByStudentCat(match) {
+  const rows = await SPTransaction.aggregate([
+    { $match: match },
+    { $group: { _id: { sid: '$studentId', cat: '$category' }, sp: { $sum: '$appliedDelta' } } }
+  ]);
+  const m = new Map(); // sid -> { total, cat:{} }
+  for (const r of rows) {
+    const sid = r._id.sid ? String(r._id.sid) : null;
+    if (!sid) continue;
+    let o = m.get(sid); if (!o) { o = { total: 0, cat: {} }; m.set(sid, o); }
+    o.cat[r._id.cat] = (o.cat[r._id.cat] || 0) + r.sp;
+    o.total += r.sp;
+  }
+  return m;
+}
+
+export async function computeAndStoreLeaderboards() {
+  const now = new Date();
+  const weekStart = weekStartIST(now);
+  const label = weekLabel(weekStart);
+
+  const students = await Student.find(
+    { status: { $ne: 'excused' } },
+    { name: 1, totalSp: 1, highestSpEver: 1, leaderboardGroup: 1 }
+  ).lean();
+
+  const weekMap = await sumByStudentCat({ dateTime: { $gte: weekStart } });
+  const allMap = await sumByStudentCat({});
+
+  const levelOf = (s) => levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0));
+  const build = (subset, valueOf) => subset
+    .map((s) => ({ studentId: String(s._id), name: s.name || '', level: levelOf(s), sp: Math.round(valueOf(String(s._id))) }))
+    .sort((a, b) => b.sp - a.sp || a.name.localeCompare(b.name))
+    .map((r, i) => ({ ...r, rank: i + 1 }));
+
+  const wTotal = (sid) => (weekMap.get(sid)?.total) || 0;
+  const wCat = (cat) => (sid) => (weekMap.get(sid)?.cat[cat]) || 0;
+  const aCat = (cat) => (sid) => (allMap.get(sid)?.cat[cat]) || 0;
+  const byId = new Map(students.map((s) => [String(s._id), s]));
+  const aTotal = (sid) => Number(byId.get(sid)?.totalSp) || 0;
+
+  const boards = [];
+  const push = (window, category, scope, group, rows) => boards.push({
+    boardKey: scope === 'group' ? `${window}:${category}:group:${group}` : `${window}:${category}:${scope}`,
+    window, category, scope, group: group || null, weekStart, weekLabel: label, builtAt: now, rows
+  });
+
+  // Total boards (global)
+  push('week', 'total', 'all', null, build(students, wTotal));
+  push('all', 'total', 'all', null, build(students, aTotal));
+  // Category boards (global), weekly + all-time
+  for (const cat of CATS) {
+    push('week', cat, 'all', null, build(students, wCat(cat)));
+    push('all', cat, 'all', null, build(students, aCat(cat)));
+  }
+  // Total boards per onboarding group (weekly + all-time)
+  const groups = [...new Set(students.map((s) => s.leaderboardGroup).filter(Boolean))];
+  for (const g of groups) {
+    const subset = students.filter((s) => s.leaderboardGroup === g);
+    push('week', 'total', 'group', g, build(subset, wTotal));
+    push('all', 'total', 'group', g, build(subset, aTotal));
+  }
+
+  // Persist: upsert each board; drop any stale group boards no longer present.
+  const keys = new Set(boards.map((b) => b.boardKey));
+  await Promise.all(boards.map((b) => LeaderboardSnapshot.updateOne({ boardKey: b.boardKey }, { $set: b }, { upsert: true })));
+  await LeaderboardSnapshot.deleteMany({ boardKey: { $nin: [...keys] } });
+
+  return { boards: boards.length, groups: groups.length, weekStart, weekLabel: label, students: students.length };
+}


### PR DESCRIPTION
Weekly-reset headline board + cohort/all-time/category boards from a cached snapshot (rebuilt each sp-refresh). Always shows the student's own rank even outside the top 50; no email on student boards. Built & deployed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)