### PR TITLE
feat: Add Student-Facing SP Simulator for Future SP Projection

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -290,12 +290,14 @@ function StudentView({ profile, onBack }) {
         ['journey','My Journey'],
         ...(student.eligibleForVibeGoals ? [['vibe','Commitments']] : []),
         ['spa','SPA Points'],
+        ['simulator','SP Simulator'],
         ['leaderboard','Leaderboard'],
         ['faq','FAQ']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
       {tab === 'journey' && <MyJourney student={student} goToCommitment={goToCommitment} canCommit={student.eligibleForVibeGoals} />}
       {tab === 'vibe' && student.eligibleForVibeGoals && <Commitments student={student} initialPhase={commitPhase} />}
       {tab === 'spa' && <SpaModule student={student} />}
+      {tab === 'simulator' && <SpSimulator student={student} />}
       {tab === 'leaderboard' && <LeaderboardPanel student={student} />}
       {tab === 'faq' && <FaqTab />}
     </main>
@@ -743,6 +745,136 @@ function Leaderboard({ rows }) {
   );
 }
 
+
+const SIMULATOR_OPTIONS = [
+  ['attendance', 'Attendance'],
+  ['reflection', 'Reflection'],
+  ['poll', 'Poll'],
+  ['commitment', 'Commitment']
+];
+
+function SpSimulator({ student }) {
+  const exampleRows = useMemo(() => ([
+    { type: 'attendance', count: 5 },
+    { type: 'reflection', count: 2 },
+    { type: 'poll', count: 4 },
+    { type: 'commitment', count: 3 }
+  ]), []);
+  const [rows, setRows] = useState(exampleRows);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const runSimulation = async (nextRows = rows) => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch(`${API}/sp/simulate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          studentId: student._id,
+          activities: nextRows.map(row => ({ type: row.type, count: Number(row.count) }))
+        })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Simulation failed');
+      setResult(data);
+    } catch (err) {
+      setResult(null);
+      setError(err?.message || 'Simulation failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    runSimulation(exampleRows);
+  }, []);
+
+  const updateRow = (index, patch) => {
+    setRows(prev => prev.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  };
+
+  const addRow = () => setRows(prev => [...prev, { type: 'attendance', count: 1 }]);
+  const removeRow = (index) => setRows(prev => prev.filter((_, i) => i !== index));
+  const resetExample = () => {
+    setRows(exampleRows);
+    runSimulation(exampleRows);
+  };
+
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <div>
+          <h2>SP Simulator</h2>
+          <p className="muted">Try future activities to preview your SP, level, and breakdown. This does not write anything to the database.</p>
+        </div>
+        <div className="bank-controls simulator-actions">
+          <button className="secondary" onClick={resetExample}>Reset example</button>
+          <button className="primary" onClick={() => runSimulation()}>Simulate</button>
+        </div>
+      </div>
+
+      <div className="simulator-shell">
+        <div className="simulator-grid">
+          {rows.map((row, index) => (
+            <div key={`${row.type}-${index}`} className="simulator-row">
+              <label>
+                Activity
+                <select value={row.type} onChange={e => updateRow(index, { type: e.target.value })}>
+                  {SIMULATOR_OPTIONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+                </select>
+              </label>
+              <label>
+                Count
+                <input type="number" min="0" step="1" value={row.count} onChange={e => updateRow(index, { count: e.target.value })} />
+              </label>
+              <button className="secondary" onClick={() => removeRow(index)} disabled={rows.length === 1}>Remove</button>
+            </div>
+          ))}
+        </div>
+
+        <button className="secondary" onClick={addRow}>Add activity</button>
+
+        {error && <p className="error" style={{ marginTop: 12 }}>{error}</p>}
+        {loading && <p className="muted" style={{ marginTop: 12 }}>Calculating prediction…</p>}
+
+        {result && (
+          <div className="simulator-results">
+            <div className="metric-grid small">
+              <div className="metric"><span>Current SP</span><strong>{result.currentSP}</strong></div>
+              <div className="metric"><span>Predicted SP</span><strong>{result.predictedSP}</strong></div>
+              <div className="metric"><span>Gain</span><strong>{result.gain}</strong></div>
+              <div className="metric"><span>Predicted Level</span><strong>L{result.predictedLevel}</strong></div>
+            </div>
+
+            <div className="badge-row">
+              <em>Current level L{result.currentLevel}</em>
+              <em>Current league {result.currentTrophyLeague}</em>
+              <em>Predicted league {result.predictedTrophyLeague}</em>
+              <em>{result.predictedLegendBadgeUnlocked ? 'Legend badge unlocked' : 'Legend badge locked'}</em>
+            </div>
+
+            <h3>Breakdown</h3>
+            <table className="table">
+              <thead><tr><th>Activity</th><th>Count</th><th>SP</th></tr></thead>
+              <tbody>
+                {result.breakdown.map(item => (
+                  <tr key={`${item.activity}-${item.count}`}>
+                    <td>{item.activity}</td>
+                    <td>{item.count}</td>
+                    <td>+{item.sp}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
 const fmtDate = d => d ? new Date(d).toLocaleDateString(undefined, { day: 'numeric', month: 'short' }) : '—';
 const toInput = d => d ? new Date(d).toISOString().slice(0, 10) : '';
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -439,6 +439,29 @@ input {
   color: var(--muted);
 }
 .live-summary strong { font-size: 38px; color: var(--primary); }
+.simulator-shell { display: grid; gap: 14px; }
+.simulator-grid { display: grid; gap: 10px; }
+.simulator-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.2fr) minmax(120px, 0.7fr) auto;
+  gap: 10px;
+  align-items: end;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfdff;
+  padding: 12px;
+}
+.simulator-row label {
+  display: grid;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 800;
+}
+.simulator-row select { min-height: 40px; border: 1px solid var(--line); border-radius: 8px; padding: 0 10px; background: #fff; }
+.simulator-row input { min-height: 40px; }
+.simulator-actions { flex-wrap: wrap; justify-content: flex-end; }
+.simulator-results { display: grid; gap: 12px; margin-top: 4px; }
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
@@ -503,6 +526,9 @@ input {
   .bank-row {
     grid-template-columns: 1fr;
   }
+  .simulator-row { grid-template-columns: 1fr; }
+  .simulator-actions { justify-content: stretch; }
+  .simulator-actions .primary, .simulator-actions .secondary { width: 100%; }
   .search-row { grid-template-columns: 1fr; }
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,7 @@ import { isVibeEligible, buildVibeState, validateBet, settleBetDemo, applySpDelt
 import { buildStandupState, placeStandup, settleStandupDemo } from './services/standup.js';
 import { buildJourneyState, saveJourneyPlan } from './services/journey.js';
 import { buildSpaState } from './services/spa.js';
+import { simulateSp } from './services/spSimulator.js';
 import { buildTrajectoryState } from './services/trajectory.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -278,6 +279,17 @@ function adminGuard(req, res, next) {
 }
 
 api.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+api.post('/sp/simulate', async (req, res) => {
+  try {
+    const result = await simulateSp(req.body || {});
+    res.json(result);
+  } catch (error) {
+    const status = Number(error?.status) || 500;
+    const message = error?.message || 'Internal Server Error';
+    res.status(status).json({ error: message });
+  }
+});
 
 api.get('/config', (_req, res) => res.json({
   allowStudentSearch: ALLOW_STUDENT_SEARCH,

--- a/server/services/spSimulator.js
+++ b/server/services/spSimulator.js
@@ -1,0 +1,113 @@
+import mongoose from 'mongoose';
+
+import Student from '../models/Student.js';
+import { leagueBand, levelFor, legendBadge } from './levels.js';
+
+export const SP_RULES = Object.freeze({
+  attendance: 20,
+  reflection: 10,
+  poll: 5,
+  commitment: 15
+});
+
+class SimulatorError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.name = 'SimulatorError';
+    this.status = status;
+  }
+}
+
+function fail(status, message) {
+  throw new SimulatorError(status, message);
+}
+
+function normalizeActivityType(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function toFiniteNumber(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function validateActivities(activities) {
+  if (!Array.isArray(activities)) fail(400, 'activities must be an array');
+
+  return activities.map((activity, index) => {
+    if (!activity || typeof activity !== 'object' || Array.isArray(activity)) {
+      fail(400, `activities[${index}] must be an object`);
+    }
+
+    const type = normalizeActivityType(activity.type);
+    if (!type) fail(400, `activities[${index}].type is required`);
+    if (!(type in SP_RULES)) fail(400, `unknown activity type: ${type}`);
+
+    const count = toFiniteNumber(activity.count);
+    if (count === null) fail(400, `activities[${index}].count must be a finite number`);
+    if (count < 0) fail(400, `activities[${index}].count must be greater than or equal to 0`);
+
+    return { type, count };
+  });
+}
+
+function currentLevelSnapshot(student) {
+  const currentSP = Number(student.totalSp ?? 0) || 0;
+  const currentHighest = Math.max(Number(student.highestSpEver ?? 0) || 0, currentSP);
+  const currentLevel = levelFor(currentHighest);
+
+  return {
+    currentSP,
+    currentHighest,
+    currentLevel,
+    currentTrophyLeague: leagueBand(currentSP),
+    currentLegendBadgeUnlocked: legendBadge(currentHighest)
+  };
+}
+
+export async function simulateSp(payload = {}) {
+  const { studentId, activities } = payload;
+
+  if (!studentId || typeof studentId !== 'string') {
+    fail(400, 'studentId is required');
+  }
+  if (!mongoose.isValidObjectId(studentId)) {
+    fail(400, 'studentId is invalid');
+  }
+
+  const student = await Student.findById(studentId).lean();
+  if (!student) fail(404, 'Student not found');
+
+  const normalizedActivities = validateActivities(activities);
+  const current = currentLevelSnapshot(student);
+
+  const breakdown = normalizedActivities.map(({ type, count }) => ({
+    activity: type,
+    count,
+    sp: count * SP_RULES[type]
+  }));
+
+  const gain = breakdown.reduce((sum, item) => sum + item.sp, 0);
+  const predictedSP = current.currentSP + gain;
+  const predictedHighest = Math.max(current.currentHighest, predictedSP);
+
+  return {
+    studentId: String(student._id),
+    currentSP: current.currentSP,
+    predictedSP,
+    gain,
+    currentLevel: current.currentLevel,
+    predictedLevel: levelFor(predictedHighest),
+    currentTrophyLeague: current.currentTrophyLeague,
+    predictedTrophyLeague: leagueBand(predictedSP),
+    currentLegendBadgeUnlocked: current.currentLegendBadgeUnlocked,
+    predictedLegendBadgeUnlocked: legendBadge(predictedHighest),
+    breakdown
+  };
+}
+
+export { SimulatorError };


### PR DESCRIPTION
## Overview

This PR introduces a new **SP Simulator** feature that enables students to estimate their future Spurti Points based on planned activities without affecting any existing data. The simulator provides a projected SP total, predicted level, trophy league, and a detailed activity-wise breakdown, helping students understand the impact of their participation before actually completing activities.

The implementation is entirely **read-only** and performs all calculations in memory.

## Read-Only Behavior

The simulator **does not modify application data**.

Specifically, it does **not**:

* Create SP transactions
* Update student records
* Modify leaderboards
* Update analytics or snapshots
* Modify attendance or journey data
* Perform any database writes

The endpoint is intended solely for previewing future outcomes.


* Verified that the simulation endpoint returns the expected JSON response for valid requests.

## Files Modified/ Added

* `server/server.js`
* `server/services/spSimulator.js` 
* `client/src/main.jsx`
* `client/src/styles.css`

## Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/96028563-f608-46d3-bbec-895cfd769418" />
