### PR TITLE
Fix bug 2: remove retired HMAC auth references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,10 @@
 PORT=5290
 MONGO_URI=mongodb://127.0.0.1:27017/analysis_summership
 ALLOW_STUDENT_SEARCH=true
-SPURTI_AUTH_SECRET=local-dev-only-change-this
-SPURTI_COOKIE_SECURE=false
+# SAMAGAMA_AUTH_URL is the internal endpoint Samagama validates the student's
+# chatengine_token cookie against. Default is the same-host Samagama; override
+# only if Spurti is deployed separately.
+SAMAGAMA_AUTH_URL=http://127.0.0.1:5001/api/auth/me
 
 # --- Mandatory survey pop-up (perception triangulation) ---
 # Leave SURVEY_ENABLED unset/0 to keep the modal off entirely.

--- a/.env.ssh.example
+++ b/.env.ssh.example
@@ -2,5 +2,6 @@
 PORT=5003
 MONGO_URI=mongodb://127.0.0.1:27017/sakshi_spurti
 ALLOW_STUDENT_SEARCH=false
-SPURTI_AUTH_SECRET=replace-with-the-same-secret-used-by-samagama
-SPURTI_COOKIE_SECURE=true
+# Spurti lives at samagama.in/spurti and validates students by forwarding their
+# chatengine_token cookie to Samagama's internal /api/auth/me endpoint.
+SAMAGAMA_AUTH_URL=http://127.0.0.1:5001/api/auth/me

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ Spurti is a student engagement tracking app for the VLED Summership program at I
 - **Frontend:** React + Vite (client/), served as static SPA
 - **Backend:** Express.js (server/server.js)
 - **Database:** MongoDB with Mongoose
-- **Auth:** Cookie-based (`spurti_student`), HMAC-signed token via `/spurti/auth?token=`
+- **Auth:** Cookie-based (`chatengine_token`), forwarded to Samagama's `/api/auth/me` for verification
 - **Nginx proxy:** `/spurti` → `127.0.0.1:5003`
 
 ## Database Schema

--- a/HOW_TO_USE.md
+++ b/HOW_TO_USE.md
@@ -61,7 +61,7 @@ On production, direct student search should stay disabled:
 ALLOW_STUDENT_SEARCH=false
 ```
 
-Students should enter Spurti from Samagama using a signed link to `/spurti/auth?token=...`. Samagama and Spurti must share the same `SPURTI_AUTH_SECRET`.
+Students enter Spurti from their Samagama dashboard. Spurti lives at `samagama.in/spurti` (same origin), so the browser already carries the `chatengine_token` cookie that Samagama validates — Spurti forwards it to Samagama's internal `/api/auth/me` endpoint (`SAMAGAMA_AUTH_URL`) to confirm the session. No token in the URL, no shared secret, no login page.
 
 ## Folder Structure
 

--- a/VLED_SP_BUTTON_IMPLEMENTATION.md
+++ b/VLED_SP_BUTTON_IMPLEMENTATION.md
@@ -1,5 +1,19 @@
 # Adding "My Spurti" Button to Samagama Dashboard
 
+> **⚠️ DEPRECATED (2026-06-29)** — This HMAC-based auth handoff has been **retired**.
+> Samagama deleted the shared `SPURTI_AUTH_SECRET`, so the flow below verifies
+> against an empty secret and 401s every student. **Do not reintroduce.**
+>
+> **Current auth (live since 2026-06-29):** Spurti lives at `samagama.in/spurti`
+> (same origin as Samagama), so the browser already carries the student's
+> `chatengine_token` cookie. Spurti forwards that cookie to Samagama's internal
+> `/api/auth/me` endpoint (`SAMAGAMA_AUTH_URL`, default
+> `http://127.0.0.1:5001/api/auth/me`) to validate the session. No token in the
+> URL, no shared secret, no login page. See `CONTEXT.md` §Auth and `HOW_TO_USE.md`
+> for the current flow.
+>
+> This file is preserved as historical context for the HMAC implementation only.
+
 ## Overview
 
 This document describes what needs to be done to add a "My Spurti →" button in the Samagama student dashboard. When clicked, the button redirects the logged-in student to their Spurti (Summership SP) dashboard without requiring them to log in again.


### PR DESCRIPTION
Clean up stale references to the retired HMAC auth (SPURTI_AUTH_SECRET / spurti_student / /spurti/auth) from env templates and docs after Samagama deleted the shared secret on 2026-06-29.