### PR TITLE
fix(sp): poll SP reads appliedDelta; authenticate /ping telemetry

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1224,7 +1224,7 @@ function AdminView({ admin, auth, onBack }) {
     if (!auth?.email) return;
     const doPing = (page) => fetch(`${API}/ping`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...adminHeaders(auth) },
       body: JSON.stringify({ email: auth.email, name: auth.email, page })
     }).catch(() => {});
     doPing('admin-analytics');

--- a/server/server.js
+++ b/server/server.js
@@ -464,6 +464,22 @@ api.post('/ping', async (req, res) => {
   const { email, name, page } = req.body || {};
   const normalized = normalizeEmail(email);
   if (!normalized || !name || !page) return res.status(400).json({ error: 'email, name, page required' });
+  // Identity check: page-view telemetry must match the authenticated caller, or
+  // anyone could spoof analytics and inject fake entries into the admin
+  // live-viewer panel. Admin pings need admin credentials; student pings must
+  // resolve to the same record as the session email (primary or alternate).
+  const isAdminPing = page.startsWith('admin');
+  let identityOk = false;
+  if (isAdminPing) {
+    identityOk = isAdmin(req);
+  } else {
+    const authedEmail = await studentEmailFromRequest(req);
+    if (authedEmail) {
+      const student = await Student.findOne({ $or: [{ email: authedEmail }, { alternateEmail: authedEmail }] }).lean();
+      identityOk = student && (student.email === normalized || student.alternateEmail === normalized);
+    }
+  }
+  if (!identityOk) return res.status(403).json({ error: 'Forbidden' });
   // Telemetry is best-effort: an unknown page value (e.g. a new admin sub-page
   // not yet in the enum) must never crash the request or leak an unhandled
   // rejection. Drop the write and carry on.

--- a/server/services/sp.js
+++ b/server/services/sp.js
@@ -62,7 +62,7 @@ export function withSp(studentDoc) {
 
   // Poll SP from transaction log
   const pollTxns = (raw._txns || []).filter(t => t.category === 'poll');
-  const pollSp = pollTxns.reduce((sum, t) => sum + Number(t.delta || 0), 0);
+  const pollSp = pollTxns.reduce((sum, t) => sum + Number(t.appliedDelta || 0), 0);
 
   const activitySp = 0;
 


### PR DESCRIPTION
## Summary

Two small, independent fixes from the tracked bug list: one **high-severity** data-display bug and one **low-severity** authentication gap in telemetry.

---

### 1. [High] Poll SP always displayed as 0 — wrong field name in `withSp()`

**File:** `server/services/sp.js`

`withSp()` computed poll SP from `Number(t.delta || 0)` on the poll transactions. The `SPTransaction` schema has **no `delta` field** — the awarded points live in `appliedDelta` (`deltaValue` holds the raw configured value; `appliedDelta` is the actually-applied amount). As a result `t.delta` was always `undefined`, so **every student's Poll SP displayed as 0** in the dashboard's SP breakdown, even though the ledger correctly stored positive poll transactions.

**Fix:** read the real field:

```diff
-  const pollSp = pollTxns.reduce((sum, t) => sum + Number(t.delta || 0), 0);
+  const pollSp = pollTxns.reduce((sum, t) => sum + Number(t.appliedDelta || 0), 0);
```

`sptransactions` is the single source of truth for SP (per CONTEXT.md), so `appliedDelta` is exactly the right field — it mirrors what the ledger summed for `totalSp`. This is a pure display fix; no ledger values are changed.

**Verification:** `node --check server/services/sp.js` passes.

---

### 2. [Low] `/ping` accepted unauthenticated, spoofable telemetry

**Files:** `server/server.js`, `client/src/main.jsx`

`POST /ping` accepted any `{ email, name, page }` from the request body with **no identity verification**. Anyone could POST arbitrary pings and:

- Inject fake `page_view` rows into `sessionevents` (polluting `/admin/analytics` usage stats), and
- Insert spoofed entries into the in-memory `liveViewers` map (shown in `/admin/active` — the admin "who's viewing now" panel), including pretending to be `record` / admin pages.

**Fix (`server/server.js`):** add an identity check before recording anything. The requested `email` must resolve to the same student record as the authenticated session (`chatengine_token` → Samagama `/api/auth/me`), accepting the primary or alternate email. Admin pages (`page.startsWith('admin')`) additionally require admin credentials (`isAdmin` — env-only `ADMIN_EMAIL`/`ADMIN_TOKEN` headers). Anything else gets a `403 Forbidden`.

**Fix (`client/src/main.jsx`):** the admin dashboard's ping (`AdminView`) now sends its `X-Admin-Email` / `X-Admin-Token` headers so admin page views still pass the new check. The student ping already sent the session cookie, so it continues to work unchanged.

**Behavior preserved:** valid student pings (30s heartbeat on the record page) and valid admin pings both succeed exactly as before; spoofed/unauthorized pings are rejected.

**Verification:** `node --check server/server.js` passes.

---

## Files changed

| File | Change |
| --- | --- |
| `server/services/sp.js` | Poll SP reads `appliedDelta` (was non-existent `delta`) |
| `server/server.js` | `/ping` now authenticates the caller before logging/telemetry |
| `client/src/main.jsx` | Admin ping sends admin auth headers |

## Testing

- `node --check` on both changed server files.
- Manual review of the `/ping` auth flow against the existing `/me` session flow (`studentEmailFromRequest`) and the `isAdmin` guard.
- No DB writes, migrations, or schema changes. No behavior change to any other endpoint.

## Notes

- No backend/database impact: this touches only the display computation and request authentication.
- Branch: `bugs-fixed-new`, one commit on top of `main` (`d710ef5`).
