### PR TITLE
fix(student): label future-start students as 'yet to onboard' (refined from #93)

### DIFF
--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -493,7 +493,14 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   for (const e of await Tx.distinct('email')) if (!keep.has(e)) staleSet.add(e);
   const staleEmails = [...staleSet];
   let zdel = 0; for (let i = 0; i < staleEmails.length; i += 500) { const r = await Tx.deleteMany({ email: { $in: staleEmails.slice(i, i + 500) } }); zdel += r.deletedCount; }
-  for (let i = 0; i < staleEmails.length; i += 1000) await Students.bulkWrite(staleEmails.slice(i, i + 1000).map((email) => ({ updateOne: { filter: { email }, update: { $set: { totalSp: 0 } } } })), { ordered: false });
-  console.log(`RECONCILED -> ${staleEmails.length} students not in new ledger cleared (incl ${zeroOut.length} future-start; ghost txns deleted ${zdel}, totalSp=0)`);
+  const zeroOutSet = new Set(zeroOut);
+  const staleBulk = staleEmails.map((email) => {
+    if (zeroOutSet.has(email)) {
+      return { updateOne: { filter: { email }, update: { $set: { totalSp: 0, status: 'yet to onboard' } } } };
+    }
+    return { updateOne: { filter: { email }, update: { $set: { totalSp: 0 } } } };
+  });
+  for (let i = 0; i < staleBulk.length; i += 1000) await Students.bulkWrite(staleBulk.slice(i, i + 1000), { ordered: false });
+  console.log(`RECONCILED -> ${staleEmails.length} students not in new ledger cleared (incl ${zeroOut.length} future-start set to 'yet to onboard'; ghost txns deleted ${zdel}, totalSp=0)`);
   await conn.close();
 })().catch((e) => { console.error('FATAL', e.message); process.exit(1); });

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -6,7 +6,7 @@ const studentSchema = new mongoose.Schema({
   alternateEmail: { type: String, lowercase: true, trim: true, default: '', index: true },
   internshipStartDate: { type: Date, required: true, index: true },
   internshipEndDate: { type: Date, default: null },
-  status: { type: String, enum: ['active', 'excused'], default: 'active', index: true },
+  status: { type: String, enum: ['active', 'excused', 'yet to onboard'], default: 'active', index: true },
   excusedAt: { type: Date, default: null },
   excusedReason: { type: String, default: '' },
   totalSp: { type: Number, default: 100, index: true },

--- a/server/scripts/addStudents.js
+++ b/server/scripts/addStudents.js
@@ -135,7 +135,8 @@ async function run() {
       existing.alternateEmail = row.alternateEmail || existing.alternateEmail;
       existing.internshipStartDate = row.internshipStartDate || existing.internshipStartDate;
       existing.internshipEndDate = row.internshipEndDate || existing.internshipEndDate;
-      existing.status = 'active';
+      const existingStart = existing.internshipStartDate ? new Date(existing.internshipStartDate) : null;
+      existing.status = (existingStart && existingStart > new Date()) ? 'yet to onboard' : 'active';
       existing.excusedAt = null;
       existing.excusedReason = '';
       await existing.save();
@@ -143,13 +144,14 @@ async function run() {
       continue;
     }
 
+    const start = row.internshipStartDate ? new Date(row.internshipStartDate) : null;
     const student = await Student.create({
       name: row.name || row.email,
       email: row.email,
       alternateEmail: row.alternateEmail,
       internshipStartDate: row.internshipStartDate,
       internshipEndDate: row.internshipEndDate,
-      status: 'active',
+      status: (start && start > new Date()) ? 'yet to onboard' : 'active',
       excusedAt: null,
       excusedReason: '',
       totalSp: 100

--- a/server/scripts/syncStudents.js
+++ b/server/scripts/syncStudents.js
@@ -72,7 +72,8 @@ async function run() {
       existing.internshipStartDate = row.internshipStartDate || existing.internshipStartDate;
       existing.internshipEndDate = row.internshipEndDate || existing.internshipEndDate;
       if (existing.status === 'excused') stats.reactivated++;
-      existing.status = 'active';
+      const existingStart = existing.internshipStartDate ? new Date(existing.internshipStartDate) : null;
+      existing.status = (existingStart && existingStart > new Date()) ? 'yet to onboard' : 'active';
       existing.excusedAt = null;
       existing.excusedReason = '';
       await existing.save();
@@ -81,13 +82,14 @@ async function run() {
       continue;
     }
 
+    const start = row.internshipStartDate ? new Date(row.internshipStartDate) : null;
     const student = await Student.create({
       name: row.name || row.email,
       email: normalizeEmail(row.email),
       alternateEmail: normalizeEmail(row.alternateEmail),
       internshipStartDate: row.internshipStartDate,
       internshipEndDate: row.internshipEndDate,
-      status: 'active',
+      status: (start && start > new Date()) ? 'yet to onboard' : 'active',
       excusedAt: null,
       excusedReason: '',
       totalSp: 100


### PR DESCRIPTION
Refined version of #93 — same intent (label future-start students with a third status value), but the PR as filed conflicts with current `main` and contains a behaviour change that can silently un-excuse admin-marked students. This PR rebases the changes onto the current `main`, drops the retired-file edit, and fixes the reconcile to preserve status for stale non-future students.

## What's kept from #93

- `server/models/Student.js` — add `'yet to onboard'` to the `status` enum so the value can actually be saved. Previously Mongoose would reject it; that is why `/api/admin/stats`' `yetToOnboard` count and `/api/admin/analytics`' status breakdown were stuck at 0.
- `server/scripts/addStudents.js`, `server/scripts/syncStudents.js` — set `'yet to onboard'` when the row's `internshipStartDate` is in the future, else `'active'`. Matches the original PR.

## What's fixed vs #93

- `pipeline/sp-rubric-build-mirror.cjs` reconcile — instead of forcing `status: 'active'/'excused'` for every stale student, **only** set `status: 'yet to onboard'` for `zeroOutSet` (future-start) students. For every other stale student, only `totalSp: 0` is written; their existing `status` (including admin-set `excused`) is preserved. The original PR's blanket overwrite could silently un-excuse students whose `excused` status was set in the DB but not reflected in this run's `excusedSet` (built from the candidates mirror).

## What's dropped from #93

- `pipeline/sp-rubric-build.js` — that file is retired per `CONTEXT.md` (the live-API rubric that was replaced by `sp-rubric-build-mirror.cjs` on 2026-06-28). Editing a retired file was noise; this PR removes that edit entirely. The same logic lives in the mirror rubric above.

## Why #93 couldn't merge as-is

- Rebased onto the current `main`, it conflicts with #122's preserve-manual-awards changes in the retired `sp-rubric-build.js`.
- The mirror-rubric reconcile change has the status-overwrite risk above.

## Verified

- `node --check` passes on all modified `.cjs`/`.js` files.
- Merges into current `origin/main` with **zero conflicts**.
- No touches to retired files.

Closes #93 (superseded by this PR).
Updated to 3 logical commits (model enum / roster scripts / mirror reconcile). No retired-file changes included. Clean merge into main verified.
