### PR TITLE
fix(sp): sort ledger by dateTime, not sessionDatetime

### DIFF
--- a/server/services/sp.js
+++ b/server/services/sp.js
@@ -101,7 +101,7 @@ export function withSp(studentDoc) {
  */
 export async function withSpFromTxns(studentDoc) {
   const raw = typeof studentDoc.toObject === 'function' ? studentDoc.toObject() : studentDoc;
-  const txns = await SPTransaction.find({ email: raw.email.toLowerCase() }).sort({ sessionDatetime: 1 }).lean();
+  const txns = await SPTransaction.find({ email: raw.email.toLowerCase() }).sort({ dateTime: 1, createdAt: 1 }).lean();
   return withSp({ ...raw, _txns: txns });
 }
 


### PR DESCRIPTION
Problem
`withSpFromTxns` in `server/services/sp.js` sorts by `sessionDatetime`, which does not exist in the SPTransaction schema (`dateTime` + `createdAt`). The sort is a no-op; the transaction ledger can come back in arbitrary order.

Fix
Change `.sort({ sessionDatetime: 1 })` to `.sort({ dateTime: 1, createdAt: 1 })`, matching the sort used by `studentPayload`.

Verification
- `node --check server/services/sp.js` passes.
- Rebuilds cleanly into `main`; 1 file changed (+1 / -1).
