### PR TITLE
fix(security): search never returns full profile without email ownership proof

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -391,13 +391,12 @@ api.get('/search', async (req, res) => {
   const q = String(req.query.q || '').trim();
   if (q.length < 2) return res.json({ exact: false, matches: [] });
 
-  if (q.includes('@')) {
-    const email = normalizeEmail(q);
-    const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
-    if (student?.status === 'excused') return res.json(excusedPayload(student));
-    if (student) return res.json({ exact: true, profile: await studentPayload(student) });
-  }
-
+  // Search NEVER returns the full profile — only masked public rows. The caller
+  // must pick a record and prove email ownership via POST /confirm to unlock the
+  // full personal payload (transactions, poll responses, attendance, alt email).
+  // Previously an exact-email query short-circuited to studentPayload() with zero
+  // ownership check, leaking any student's private record to anyone who knew the
+  // email. (Regressed fix — see PR for the search-data-leak issue.)
   const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const matches = await Student.find({
     $or: [


### PR DESCRIPTION
## Summary

Fixes High Bug 1: `GET /api/search?q=<exact-email>` returned the **full personal profile unauthenticated**.

## Problem

`server/server.js` had a short-circuit in `/search`:

```js
if (q.includes('@')) {
  const email = normalizeEmail(q);
  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
  if (student?.status === 'excused') return res.json(excusedPayload(student));
  if (student) return res.json({ exact: true, profile: await studentPayload(student) });
}
```

An exact-email query skipped the ownership check entirely and returned `studentPayload()` — **every SP transaction with reasons/dates, poll records including raw responses, attendance history, primary + alternate email** — to anyone who knew or guessed a student's email. The `/confirm` endpoint (which at least requires typing a matching email) was bypassed. `ALLOW_STUDENT_SEARCH` defaults to `true`.

## Fix

`/search` now **never** returns the full profile. The exact-email branch is removed; every query returns only masked public rows (`publicStudent` — name + masked emails + totalSp). The caller must select a record and prove email ownership via `POST /confirm`, which keeps the existing email-match check (`403` if the typed email doesn't match primary/alternate).

This matches the intended search flow: the client already renders the match list and confirm step (`client/src/main.jsx:250-266`); the now-dead `data.exact`/`data.excused` branches in the client's `search()` are harmless leftovers (server no longer returns those fields from `/search`).

## Behavior preserved
- Name/email search still lists matches (masked).
- Legit students still unlock their own record — via `/confirm`, same as before.
- Excused students still get `excusedPayload` — but only after email confirmation.

## Verification
- `node --check server/server.js` passes.
- `studentPayload`/`excusedPayload` still used by `/me` and `/confirm` — no orphaned helpers.
- 1 file changed (+6 / −7).
