### PR TITLE
fix(server): global error middleware + ObjectId guards against CastError remote crash

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -114,6 +114,24 @@ const app = express();
 const api = express.Router();
 const liveViewers = new Map();
 
+// Express 4 does NOT forward rejections from async route handlers to the error
+// middleware — an unhandled rejection crashes the Node process (remote DoS; e.g.
+// a CastError from a malformed ObjectId in /confirm). Wrap every handler so sync
+// throws AND async rejections reach the single error handler registered below.
+for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+  const original = api[method].bind(api);
+  api[method] = (path, ...handlers) => original(path, ...handlers.map(handler => {
+    const wrapped = (req, res, next) => {
+      try {
+        return Promise.resolve(handler(req, res, next)).catch(next);
+      } catch (err) {
+        return next(err);
+      }
+    };
+    return wrapped;
+  }));
+}
+
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
 
@@ -413,6 +431,7 @@ api.get('/search', async (req, res) => {
 api.post('/confirm', async (req, res) => {
   if (!ALLOW_STUDENT_SEARCH) return res.status(403).json({ error: 'Student search is disabled. Please login from Samagama to view your Spurti Points.' });
   const { studentId, email } = req.body || {};
+  if (!mongoose.isValidObjectId(studentId)) return res.status(404).json({ error: 'Student not found' });
   const typed = normalizeEmail(email);
   const student = await Student.findById(studentId).lean();
   if (!student) return res.status(404).json({ error: 'Student not found' });
@@ -602,6 +621,7 @@ api.get('/admin/attendance', adminGuard, async (_req, res) => {
 });
 
 api.get('/admin/student/:id', adminGuard, async (req, res) => {
+  if (!mongoose.isValidObjectId(req.params.id)) return res.status(404).json({ error: 'Student not found' });
   const student = await Student.findById(req.params.id).lean();
   if (!student) return res.status(404).json({ error: 'Student not found' });
   res.json(await studentPayload(student));
@@ -767,6 +787,19 @@ if (fs.existsSync(clientDist)) {
 } else {
   app.get('*', (_req, res) => res.status(404).send('Build the client first with npm run build.'));
 }
+
+// Global error handler — last middleware. Catches sync throws, async rejections
+// (forwarded via next(err) by the route wrapper above) and body-parser errors
+// (invalid JSON, oversized payload). Returns a clean JSON error instead of the
+// Express default HTML stack trace, and never crashes the process.
+app.use((err, _req, res, _next) => {
+  if (err?.type === 'entity.parse.failed') return res.status(400).json({ error: 'Invalid JSON body' });
+  if (err?.type === 'entity.too.large') return res.status(413).json({ error: 'Request body too large' });
+  if (err?.name === 'CastError') return res.status(400).json({ error: 'Invalid identifier' });
+  if (err?.name === 'ValidationError') return res.status(400).json({ error: 'Invalid input', details: err.message });
+  console.error('[error]', err?.stack || err);
+  res.status(err?.statusCode || 500).json({ error: err?.message || 'Internal server error' });
+});
 
 mongoose.connect(MONGO_URI).then(() => {
   app.listen(PORT, () => console.log(`Spurti app running at http://localhost:${PORT}/`));


### PR DESCRIPTION
## Summary

Fixes High Bug 2: **no Express error middleware + `/confirm` CastError = remote crash** (unauthenticated DoS).

## Problem

Two compounding issues:

1. **No error-handling middleware.** The app had zero `app.use((err, req, res, next) => ...)` handlers, so unhandled errors fell through to Express's default HTML error page (leaks stack traces, wrong content-type for an API).

2. **Async rejections crashed the process.** Express 4 does **not** forward rejected promises from async route handlers to any error middleware. A single crafted request — e.g. `POST /confirm` with `studentId: "not-an-objectid"` → `mongoose CastError` from `Student.findById(studentId)` at `server/server.js:417` — became an **unhandled promise rejection**, killing the Node process. Since `/confirm` is unauthenticated, any remote client could crash the server on demand (DoS). The same cast hazard existed at `GET /admin/student/:id` (`findById(req.params.id)`).

## Fix (3 parts)

1. **Wrap every `api.*` route handler** (`server/server.js:117-131`) so sync throws **and** async rejections are forwarded via `next(err)`:
   ```js
   const wrapped = (req, res, next) => {
     try { return Promise.resolve(handler(req, res, next)).catch(next); }
     catch (err) { return next(err); }
   };
   ```
   Applied to `get/post/put/patch/delete` on the router — covers every existing handler and any future one registered through the router. Middlewares like `adminGuard` pass through the wrapper harmlessly (they're synchronous and return normally).

2. **Global error middleware** (`server/server.js:791-801`), registered last, maps errors to clean JSON:
   - malformed JSON body → `400 Invalid JSON body`
   - oversized body → `413 Request body too large`
   - Mongoose `CastError` → `400 Invalid identifier`
   - `ValidationError` → `400 Invalid input` (with message)
   - anything else → `500` (logged server-side, message surfaced) — never the HTML stack-trace page.

3. **Early ObjectId validation** at both `findById` sites so the cast never happens for a bad id — `/confirm` (`server.js:434`) and `/admin/student/:id` (`server.js:624`) now return a clean `404 Student not found` via `mongoose.isValidObjectId(...)`.

## Behavior preserved
- All 200-path responses identical — the wrapper only intercepts failures.
- Admin routes still gated by `adminGuard` (unchanged).
- Invalid JSON/oversized bodies now get a JSON error instead of a crash/HTML.

## Verification
- `node --check server/server.js` passes.
- Only 1 file changed (+33), no client impact.
- Every handler is auto-wrapped via the router monkey-patch, so there is no route we missed.
