### PR TITLE
fix(pipeline): preserve manual/peer_faq SP during reconcile for students outside the new ledger

### DIFF
--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -481,19 +481,35 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     update: { $set: { ...s, activity: 'Activity 1: Linear Algebra', updatedAt: new Date() }, $setOnInsert: { createdAt: new Date() } }, upsert: true } }));
   for (let i = 0; i < spaOps.length; i += 1000) await Spa.bulkWrite(spaOps.slice(i, i + 1000), { ordered: false });
   console.log(`SPA -> spaprogresses upserted ${spaOps.length}`);
-  // RECONCILE: the new ledger is the COMPLETE source of truth — all current SP is
-  // rubric-generated (initial/attendance/poll only; no admin/discretionary txns
-  // exist). Any student NOT in the new ledger must be cleared so the leaderboard
-  // shows ONLY the new ledger with no stale ghosts. This covers: future-start
-  // attendees (zeroOut), rejected applicants, duplicate person-records now
-  // consolidated under a canonical email, and no-longer-qualifying students.
+  // RECONCILE: the new ledger is the COMPLETE source of truth for rubric SP
+  // (initial/attendance/poll/spa/query). Any student NOT in the new ledger must
+  // be cleared so the leaderboard shows ONLY the new ledger with no stale ghosts.
+  // This covers: future-start attendees (zeroOut), rejected applicants, duplicate
+  // person-records now consolidated under a canonical email, and no-longer-
+  // qualifying students. CRITICAL: the PRESERVED categories ('manual'/'peer_faq')
+  // are admin-granted and NOT recomputable, so they survive even for students
+  // outside the new ledger — we delete only non-preserved rows and set totalSp to
+  // the student's surviving preserved balance (0 if they have none).
   const keep = new Set(finalBal.keys());
   const staleSet = new Set();
   for (const s of await Students.find({ totalSp: { $ne: 0 } }, { projection: { email: 1 } }).toArray()) if (!keep.has(s.email)) staleSet.add(s.email);
   for (const e of await Tx.distinct('email')) if (!keep.has(e)) staleSet.add(e);
   const staleEmails = [...staleSet];
-  let zdel = 0; for (let i = 0; i < staleEmails.length; i += 500) { const r = await Tx.deleteMany({ email: { $in: staleEmails.slice(i, i + 500) } }); zdel += r.deletedCount; }
-  for (let i = 0; i < staleEmails.length; i += 1000) await Students.bulkWrite(staleEmails.slice(i, i + 1000).map((email) => ({ updateOne: { filter: { email }, update: { $set: { totalSp: 0 } } } })), { ordered: false });
-  console.log(`RECONCILED -> ${staleEmails.length} students not in new ledger cleared (incl ${zeroOut.length} future-start; ghost txns deleted ${zdel}, totalSp=0)`);
+  let zdel = 0;
+  for (let i = 0; i < staleEmails.length; i += 500) {
+    const chunk = staleEmails.slice(i, i + 500);
+    const r = await Tx.deleteMany({ email: { $in: chunk }, category: { $nin: PRESERVED_CATS } });
+    zdel += r.deletedCount;
+  }
+  // Preserved balance per stale student = sum of their surviving manual/peer_faq deltas.
+  const stalePreserved = new Map();
+  for (const t of await Tx.find({ email: { $in: staleEmails }, category: { $in: PRESERVED_CATS } }, { projection: { email: 1, appliedDelta: 1 } }).toArray()) {
+    stalePreserved.set(t.email, (stalePreserved.get(t.email) || 0) + (Number(t.appliedDelta) || 0));
+  }
+  for (let i = 0; i < staleEmails.length; i += 1000) {
+    const chunk = staleEmails.slice(i, i + 1000);
+    await Students.bulkWrite(chunk.map((email) => ({ updateOne: { filter: { email }, update: { $set: { totalSp: stalePreserved.get(email) || 0 } } } })), { ordered: false });
+  }
+  console.log(`RECONCILED -> ${staleEmails.length} students not in new ledger cleared (incl ${zeroOut.length} future-start; non-preserved txns deleted ${zdel}, ${stalePreserved.size} kept preserved SP)`);
   await conn.close();
 })().catch((e) => { console.error('FATAL', e.message); process.exit(1); });


### PR DESCRIPTION
## Summary

Fixes High Bug 3: **pipeline reconcile deletes `manual`/`peer_faq` for students not in the new ledger**.

## Problem

The rebuild step 3e (`pipeline/sp-rubric-build-mirror.cjs:353-364`) reads all existing `manual`/`peer_faq` transactions into `preservedByCanon` so "commitment/admin SP survives the rebuild." But preservation only works for students who end up in the new ledger — the **reconcile** step (`:490-497`) was:

1. Collecting every email NOT in the new ledger (`future-start`, rejected, duplicate-consolidated, no-longer-qualifying, or briefly missing from a stale mirror) → `staleSet`.
2. `Tx.deleteMany({ email: { $in: staleEmails } })` — deleting **every** transaction, `manual`/`peer_faq` included.
3. Setting `totalSp = 0` for those students.

So real admin-granted SP (manual corrections, ViBe/standup commitment stakes, peer_faq awards) was **silently and permanently wiped** for any student outside the ledger — exactly the category step 3e was designed to protect. Worst case, a bad/empty mirror sync (bug #10) would erase a whole cohort's manual SP and no re-run could restore it.

## Fix

The reconcile now respects `PRESERVED_CATS`:

```js
// delete only non-preserved rows
await Tx.deleteMany({ email: { $in: chunk }, category: { $nin: PRESERVED_CATS } });
```

Then it recomputes each stale student's `totalSp` from their **surviving** `manual`/`peer_faq` deltas (`sum(appliedDelta)`), so a student outside the ledger keeps whatever admin-granted SP they earned; only rubric-generated ghost rows (`initial/attendance/poll/spa/query`) and totalSp are cleared. Students with no preserved rows still get `totalSp = 0` exactly as before.

## Behavior preserved
- Rubric SP for out-of-ledger students is still cleared (leaderboard has no stale ghosts).
- Stale students with zero preserved SP → `totalSp = 0` (unchanged).
- The normal ledger path (students IN the ledger) is untouched — step 4 still folds their preserved rows in at `:430`.

## Verification
- `node --check pipeline/sp-rubric-build-mirror.cjs` passes.
- 1 file changed (+25 / −9).
- Dry-run logic (`!APPLY`) untouched — this only changes the APPLY reconcile path.
