### PR TITLE
fix(pipeline): guard against negative attendance window (wEnd <= wStart)

### DIFF
--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -202,6 +202,12 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
       first = mandatory.sort((a, b) => new Date(a.startTime) - new Date(b.startTime))[0];
       wStart = utcFromISTDate(date, '09:05');
       wEnd = WINDOW_END_OVERRIDE_IST[date] ? utcFromISTDate(date, WINDOW_END_OVERRIDE_IST[date]) : Math.min(new Date(first.endTime).getTime(), utcFromISTDate(date, '11:00'));
+      // The official window must actually exist: a meeting that ENDED before the
+      // 09:05 window opens (wEnd <= wStart) would otherwise yield a NEGATIVE
+      // winMin in the scoring loop, which turns the 10/5/3/0 attendance tier into
+      // +10 for EVERY attendee (negative/negative percentage). Skip the session
+      // entirely — nobody can be present in a window that never opened.
+      if (wEnd <= wStart) continue;
     }
     sessions.push({ date, uuid: first._id, topic: first.topic, wStart, wEnd, label: dayLabel(first.topic) });
   }
@@ -250,6 +256,7 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
 
   for (const s of sessions) {
     const winMin = Math.round((s.wEnd - s.wStart) / 60000);
+    if (winMin <= 0) continue; // defensive: a degenerate/negative window must never score attendance
     // attendance via zoom_attendance mirror (firstJoin/lastLeave), clipped to window
     const segByEmail = new Map();
     for (const p of await sak.collection('zoom_attendance').find({ meetingUuid: s.uuid }).toArray()) {


### PR DESCRIPTION
## Summary

Fixes Bug 4: **pipeline negative attendance window** — a session whose scoring window never opens (meeting ends before the window start) would credit +10 SP to *every* attendee.

## Problem

In `pipeline/sp-rubric-build-mirror.cjs`, each session's attendance window is `[wStart, wEnd]`, and the scoring loop computes:

```js
const winMin = Math.round((s.wEnd - s.wStart) / 60000);   // line 252
```

If a meeting ends **before** the window opens (`wEnd < wStart`), `winMin` goes **negative**, and the per-attendee percentage becomes `negative/negative = +100%` (`:270`) → **everyone who joined gets the full +10 attendance tier** for a session nobody could have attended inside the window.

- The **evening path** (current standups, 8–9 PM → window `20:05–21:00` IST) already guarded: it picks the max-overlap meeting and skips the session when `scored.ov <= 0` (`:198`).
- The **historical morning path** (pre-2026-07-16 sessions, window `09:05–11:00` IST — still re-scored on every rebuild) had **no such guard**. This fix closes that hole.

## Fix (2 layers)

1. **Session-build guard** (`:206-208`): skip the morning session entirely when `wEnd <= wStart` — a meeting that ended before the window opened produces no attendance and no poll rows.
2. **Defensive scoring guard** (`:259`): `if (winMin <= 0) continue;` at the top of the per-session loop, so no window path (morning, evening, special/override) can ever yield a negative window and mint SP.

## Behavior preserved
- Normal sessions (window ≥ 1 min) score exactly as before — including current 8–9 PM evening standups (unaffected; they already had the overlap guard, and the defensive guard can't skip them since overlap > 0 guarantees `wEnd > wStart`).
- Degenerate-window sessions now score **nothing** instead of +10-for-everyone.

## Verification
- `node --check pipeline/sp-rubric-build-mirror.cjs` passes.
- 1 file changed (+7, −0).
