### PR TITLE
fix(admin): 'yet to onboard' status param + fetch headers for stats and student lists

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1254,7 +1254,7 @@ function AdminView({ admin, auth, onBack }) {
 
   useEffect(() => { loadLeaderboard(50); fetchStats(); }, []);
   const fetchStats = async () => {
-    const r = await fetch(`${API}/admin/stats`, headers);
+    const r = await fetch(`${API}/admin/stats`, { headers });
     if (r.ok) setStats(await r.json());
   };
   useEffect(() => {
@@ -1438,7 +1438,7 @@ function Chart({ title, rows, max }) {
 
 
 function AllStudentsPanel({ stats, onStudent, auth }) {
-  const [activeTab, setActiveTab] = useState('yetToOnboard');
+  const [activeTab, setActiveTab] = useState('yet to onboard');
   const [list, setList] = useState([]);
   const [loading, setLoading] = useState(false);
   const headers = adminHeaders(auth);
@@ -1446,7 +1446,7 @@ function AllStudentsPanel({ stats, onStudent, auth }) {
   const loadList = async (status) => {
     setLoading(true);
     try {
-      const res = await fetch(`${API}/admin/students-by-status?status=${status}&limit=200`, headers);
+      const res = await fetch(`${API}/admin/students-by-status?status=${status}&limit=200`, { headers });
       if (res.ok) setList(await res.json());
     } finally {
       setLoading(false);
@@ -1461,7 +1461,7 @@ function AllStudentsPanel({ stats, onStudent, auth }) {
         <h2>All Students</h2>
       </div>
       <div className="tab-bar">
-        <button className={activeTab === 'yetToOnboard' ? 'active' : ''} onClick={() => { setActiveTab('yetToOnboard'); }}>Yet to Onboard ({stats?.yetToOnboard ?? 0})</button>
+        <button className={activeTab === 'yet to onboard' ? 'active' : ''} onClick={() => { setActiveTab('yet to onboard'); }}>Yet to Onboard ({stats?.yetToOnboard ?? 0})</button>
         <button className={activeTab === 'active' ? 'active' : ''} onClick={() => { setActiveTab('active'); }}>Active ({stats?.activeStudents ?? 0})</button>
         <button className={activeTab === 'excused' ? 'active' : ''} onClick={() => { setActiveTab('excused'); }}>Excused ({stats?.excusedStudents ?? 0})</button>
       </div>


### PR DESCRIPTION
## Summary

Fixes two Medium admin-panel bugs, both in `client/src/main.jsx`.

## Bug 5 — "Yet to Onboard" list always empty (client/server param mismatch)

`AllStudentsPanel` sent `?status=yetToOnboard` (camelCase) but the server filters on the canonical `'yet to onboard'` (`server/server.js:551`), so `Student.find({ status: 'yetToOnboard' })` matched nothing → the tab always showed "No students in this category."

**Fix:** the tab value now uses the canonical `'yet to onboard'` in the state, the fetch, and the button-active check (3 edits, `main.jsx:1441/1449/1464`).

## Bug 6 — `/admin/stats` never loads (headers passed as fetch `init`)

`fetch(url, headers)` passes the headers object as the **request init**, not as `init.headers` — so the auth headers (`X-Admin-Email`/`X-Admin-Token`) are never sent and the adminGuard 403s every call, leaving the stats card permanently empty.

**Fix:** `fetch(`${API}/admin/stats`, { headers })` (`main.jsx:1257`). **Bonus:** the same latent bug existed in `AllStudentsPanel.loadList` (`main.jsx:1449`) — the "Yet to Onboard"/"Active"/"Excused" lists would also 403 — fixed there too.

## Verification
- `npm run build` in `client/` passes (30 modules, no errors).
- Other admin fetches already used the correct `{ headers }` form (`main.jsx:1235-1251`) — these were the only two bare `, headers)` calls.
- 1 file changed (+4 / −4).
