### PR TITLE
fix(low): spa/query analytics totals, modernize dead ledger modules, align rank tie-break, guard null Top-50

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -560,7 +560,7 @@ function StudentPulse({ profile }) {
         <div className="pulse-card progress-card">
           <span>Standing</span>
           <strong>Rank {student.rank}</strong>
-          <p>{cohort.pointsToTop50 === 0 ? 'You are in the Top 50.' : `${cohort.pointsToTop50} SP to enter Top 50.`}</p>
+          <p>{cohort.pointsToTop50 == null || cohort.pointsToTop50 === 0 ? 'You are in the Top 50.' : `${cohort.pointsToTop50} SP to enter Top 50.`}</p>
           <div className="compare-list">
             <b>Cohort avg: {cohort.averageSp}</b>
             <b>Top 50: {cohort.top50Cutoff ?? '—'}</b>

--- a/server/server.js
+++ b/server/server.js
@@ -696,7 +696,7 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
     };
   });
 
-  const categoryTotals = ['initial', 'attendance', 'poll', 'manual'].map(category => {
+  const categoryTotals = ['initial', 'attendance', 'poll', 'spa', 'query', 'manual'].map(category => {
     const rows = activeTransactions.filter(t => t.category === category);
     return {
       category,

--- a/server/services/analyticsService.js
+++ b/server/services/analyticsService.js
@@ -83,7 +83,7 @@ export async function computeSnapshot() {
   const deltaMap = {};
   for (const t of activeRecentTx) {
     const key = t.email.toLowerCase();
-    deltaMap[key] = (deltaMap[key] || 0) + (t.delta || 0);
+    deltaMap[key] = (deltaMap[key] || 0) + (t.appliedDelta || 0);
   }
   const emailToName = {};
   for (const s of activeStudents) {

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -57,7 +57,12 @@ export async function computeAndStoreLeaderboards() {
   const levelOf = (s) => levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0));
   const build = (subset, valueOf) => subset
     .map((s) => ({ studentId: String(s._id), name: s.name || '', level: levelOf(s), sp: Math.round(valueOf(String(s._id))) }))
-    .sort((a, b) => b.sp - a.sp || a.name.localeCompare(b.name))
+    // Tie-break on name uses the SAME binary (code-point) ordering the live
+    // leaderboard query applies (`name: 1` / `name: { $lt: ... }` in server.js),
+    // NOT localeCompare — otherwise a snapshot rank can disagree with the
+    // student-facing "Rank X of Y". (`a.name < b.name` in JS matches Mongo's
+    // string ordering for the practical character set.)
+    .sort((a, b) => b.sp - a.sp || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
     .map((r, i) => ({ ...r, rank: i + 1 }));
 
   const wTotal = (sid) => (weekMap.get(sid)?.total) || 0;

--- a/server/services/spLedger.js
+++ b/server/services/spLedger.js
@@ -8,7 +8,7 @@ import Student from '../models/Student.js';
 import SPTransaction from '../models/SPTransaction.js';
 
 /**
- * Get full ledger (all transactions) for a student, ordered by sessionDatetime.
+ * Get full ledger (all transactions) for a student, ordered by dateTime.
  * Returns running balance at each step.
  */
 export async function getLedger(email) {
@@ -16,20 +16,20 @@ export async function getLedger(email) {
   if (!student) return null;
 
   const transactions = await SPTransaction.find({ email: email.toLowerCase() })
-    .sort({ sessionDatetime: 1 })
+    .sort({ dateTime: 1, createdAt: 1 })
     .lean();
 
   let runningBalance = 0;
   const ledger = transactions.map(t => {
-    runningBalance += Number(t.delta || 0);
+    runningBalance += Number(t.appliedDelta || 0);
     return {
       category: t.category,
       sessionLabel: t.sessionLabel,
-      sessionDatetime: t.sessionDatetime,
-      delta: t.delta,
+      dateTime: t.dateTime,
+      delta: t.appliedDelta,
       reason: t.reason,
       balanceAfter: runningBalance,
-      recordedAt: t.recordedAt
+      createdAt: t.createdAt
     };
   });
 
@@ -73,8 +73,7 @@ export async function getAllStudentsSummary() {
   return students.map(s => ({
     email: s.email,
     name: s.name,
-    totalSp: s.totalSp,
-    hasAttendance: s.sessions && Object.values(s.sessions).some(v => v > 0)
+    totalSp: s.totalSp
   }));
 }
 
@@ -82,24 +81,23 @@ export async function getAllStudentsSummary() {
  * Append a new transaction and update Student.totalSp atomically.
  * Use this when new data arrives (attendance, chat, poll, activity).
  */
-export async function appendTransaction(email, category, sessionLabel, sessionDatetime, delta, reason, ingestedFrom) {
-  const sessionDt = sessionDatetime instanceof Date ? sessionDatetime : new Date(sessionDatetime);
+export async function appendTransaction(email, category, sessionLabel, dateTime, deltaValue, reason) {
+  const sessionDt = dateTime instanceof Date ? dateTime : new Date(dateTime);
 
   const [txn] = await SPTransaction.create([{
     email: email.toLowerCase(),
     category,
     sessionLabel,
-    sessionDatetime: sessionDt,
-    delta,
-    reason,
-    recordedAt: new Date(),
-    ingestedFrom
+    dateTime: sessionDt,
+    deltaValue,
+    appliedDelta: deltaValue,
+    reason
   }]);
 
   // Atomic update of student totalSp
   await Student.updateOne(
     { email: email.toLowerCase() },
-    { $inc: { totalSp: delta } }
+    { $inc: { totalSp: deltaValue } }
   );
 
   return txn;


### PR DESCRIPTION
## Summary

Fixes four Low-priority bugs in one focused PR.

## Bug 13 — `/admin/analytics` categoryTotals omits `spa` + `query`
`server/server.js:699` iterated `['initial','attendance','poll','manual']` only, so the SP analytics panel never showed SPA or query totals even though both are live categories. **Fix:** added `'spa'` and `'query'`.

## Bug 14 — dead modules use retired fields
`server/services/spLedger.js` and `server/services/analyticsService.js` are not imported anywhere but were written against retired schema fields (`sessionDatetime`, `delta`, `recordedAt`, `ingestedFrom`, `s.sessions`), so they'd be broken if ever wired up. **Fix:** modernized to the current schema:
- `sessionDatetime` → `dateTime` (with `createdAt` tie-break on sort)
- `delta` → `appliedDelta` (creates now set both `deltaValue` + `appliedDelta`)
- `recordedAt`/`ingestedFrom` → `createdAt` (timestamps)
- dropped `hasAttendance` from `getAllStudentsSummary` (used the long-removed `s.sessions` map)

## Bug 16 — leaderboard rank tie-break inconsistency
The student-facing rank uses Mongo's **binary (code-point)** string comparison (`server.js:184` `name: { $lt: ... }`), but the cached-board builder used `localeCompare`, which orders names differently (case/punctuation) — so a snapshot board could disagree with the live "Rank X of Y". **Fix:** `server/services/leaderboards.js:60` now tie-breaks with the same binary ordering (`a.name < b.name`), matching the live query.

## Bug 18 — literal `"null SP to enter Top 50."` for small cohorts
`client/src/main.jsx:563` rendered `cohort.pointsToTop50` without a null guard. When there are fewer than 50 active students, `pointsToTop50` is `null` (`server.js:260`), producing "null SP to enter Top 50." **Fix:** treat `null` as "You are in the Top 50." (you're automatically in the Top 50 when fewer than 50 exist).

## Verification
- `node --check` passes on all 4 server files.
- `npm run build` passes in `client/`.
- 5 files changed (+23 / −20), no lockfile churn.
