### PR TITLE
Guarantee unique verify codes, settle podium awards, and make sharing measurable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -229,7 +229,6 @@ OFF, so the feature ships dark):
 | `ACHIEVEMENTS_ENABLED=1` | tab visible to the whole cohort. **Also** turns on tie-aware "1224" ranking in the leaderboard build and the minting of podium cards — with it off, the build ranks 1,2,3… exactly as before and awards nothing. |
 | `ACHIEVEMENTS_EMAILS=a@b.com,…` | named accounts see the tab while it is otherwise off (preview on live data) |
 | `ACHIEVEMENTS_SHARING=1` | Share/Download buttons, and the `share/card` + `share/track` endpoints. Requires the tab to be visible; never the other way round |
-| `ACHIEVEMENTS_ALLTIME=1` | mints **all-time** podium cards. Separate switch, default off — see below. Flip it **once, at programme end** |
 | `VERIFY_VIEW_LOG=0` | turns OFF verify-page view logging (defaults ON). The one switch here that defaults on, because the log is what makes reach measurable at all |
 
 **When podium cards are awarded.** Weekly cards come from the **last completed
@@ -240,14 +239,27 @@ replacing the previous holder — up to 28 students could each hold a permanent,
 independently verifiable "1st place, week of X" card for the same board. A
 finished week cannot move, so awarding from it yields one set of winners.
 
-All-time boards have the same failure and **no completed period to award from** —
-they only settle when the programme does. Hence `ACHIEVEMENTS_ALLTIME`, off by
-default. Flipping it mints one settled set from the standings **at that moment**
-and closes those titles for good, so flip it at the end; doing it early freezes
-whoever happens to be ahead. Both paths are backed by a settled-placing guard:
-once a placing has any holder it is closed, which still allows ties (awarded
-together in one batch) but stops a later challenger claiming the same title —
-including after a backdated transaction shifts a past week's standings.
+A settled-placing guard backs this up: once a placing has any holder it is
+closed. Ties still work, since they are awarded together in one batch, but a
+later challenger cannot claim a title already issued — including after a
+backdated transaction shifts a past week's standings.
+
+**All-time boards are not awarded as podiums at all.** They never settle while
+the programme runs, so an unqualified "1st place, All-time" would go to every
+successive leader in turn. Instead the top spot is a **dated reign**, recorded in
+`boardreign` (`board`, `studentId`, `from`, `to`, `peakSp`, `awarded`): "top of
+the Overall board, 15 Jul – 12 Aug 2026" is true of each holder, the spans do not
+overlap, and nobody's card is revoked when they are overtaken.
+
+- **1st only.** "Reigning champion" is a real idea; "was second for a while" is
+  not, and the places below the top shuffle constantly.
+- **A reign earns a card after 7 days.** The build runs four times a day and the
+  lead can change between runs early in a cohort, so without a floor a six-hour
+  blip would mint a permanent credential. Short reigns are still recorded — that
+  history is the only measure of leadership churn the programme has.
+- **Cards are minted while the reign is open**, reading "Since 15 Jul 2026", and
+  gain their end date when it closes. The PNG already posted keeps the older
+  wording, which was true when posted; the verify page stays current.
 
 Flipping any of them is a `.env` edit + PM2 restart — no rebuild, no redeploy.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -195,9 +195,31 @@ a PNG carrying a QR to a public verify page.
   og: tags so a posted link expands into a preview of the card; that preview
   image is the PNG the browser hands back via `POST /api/share/card`, stored
   under `CARD_DIR` (default `server/data/cards`, regenerable).
-- **`shareevents`** logs every share/download (platform + achievement), surfaced
-  in `/api/admin/analytics` — the point of the feature is knowing whether
-  students actually post them.
+- **The code is uniqueness-critical, and the index is what guarantees it.** It is
+  public (printed on the card, in the QR, in the caption), so it must be
+  unguessable but never secret. A duplicate would credit the wrong student on the
+  verify page *and* overwrite their `{verifyId}.png`. `verifyId` therefore carries
+  a **unique partial index**, and `awardAchievements()` in `models/Achievement.js`
+  re-rolls on `E11000`. Randomness alone only makes a clash unlikely.
+  **Run `server/migrations/2026-08-12-unique-verify-id.mjs --apply` before
+  deploying** — the collection already has a non-unique `verifyId_1` from the
+  first release, and Mongo will not redefine an index that keeps its name and
+  changes its options. Mongoose swallows that failure at boot, so skipping the
+  migration leaves the app running with no guarantee and no error.
+- **`shareevents`** logs every share/download/copy. The achievement's category
+  (`kind`, `board`, `place`, `period`, `periodKey`, `earnedAt`) is **copied onto
+  the event** so share-rate-by-category is a group-by rather than a join, and so
+  the record survives any later change to a title or a board's wording.
+- **`achievementviews`** logs hits on the public verify page — the only reach
+  measure the feature has. Crawler hits are flagged (`bot`) and excluded from
+  every reported figure, because LinkedIn fetches each shared URL to build its
+  preview and would otherwise manufacture its own audience. Viewers are members
+  of the public, not participants: **no IP, no cookie, no full referrer** is
+  stored. `viewerDay` is an HMAC of IP+UA under an in-memory salt that rotates
+  daily and is never persisted, so same-device hits collapse for a distinct count
+  but nobody can be identified or followed across days.
+- Both are surfaced on the admin **Achievements** tab (`/api/admin/analytics` →
+  `sharing`). Every rate there divides by cards **held**, never by share actions.
 
 **Env switches** (repo-root `.env` — the app's cwd is the repo root; all default
 OFF, so the feature ships dark):
@@ -207,6 +229,7 @@ OFF, so the feature ships dark):
 | `ACHIEVEMENTS_ENABLED=1` | tab visible to the whole cohort. **Also** turns on tie-aware "1224" ranking in the leaderboard build and the minting of podium cards — with it off, the build ranks 1,2,3… exactly as before and awards nothing. |
 | `ACHIEVEMENTS_EMAILS=a@b.com,…` | named accounts see the tab while it is otherwise off (preview on live data) |
 | `ACHIEVEMENTS_SHARING=1` | Share/Download buttons, and the `share/card` + `share/track` endpoints. Requires the tab to be visible; never the other way round |
+| `VERIFY_VIEW_LOG=0` | turns OFF verify-page view logging (defaults ON). The one switch here that defaults on, because the log is what makes reach measurable at all |
 
 Flipping any of them is a `.env` edit + PM2 restart — no rebuild, no redeploy.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -229,7 +229,25 @@ OFF, so the feature ships dark):
 | `ACHIEVEMENTS_ENABLED=1` | tab visible to the whole cohort. **Also** turns on tie-aware "1224" ranking in the leaderboard build and the minting of podium cards — with it off, the build ranks 1,2,3… exactly as before and awards nothing. |
 | `ACHIEVEMENTS_EMAILS=a@b.com,…` | named accounts see the tab while it is otherwise off (preview on live data) |
 | `ACHIEVEMENTS_SHARING=1` | Share/Download buttons, and the `share/card` + `share/track` endpoints. Requires the tab to be visible; never the other way round |
+| `ACHIEVEMENTS_ALLTIME=1` | mints **all-time** podium cards. Separate switch, default off — see below. Flip it **once, at programme end** |
 | `VERIFY_VIEW_LOG=0` | turns OFF verify-page view logging (defaults ON). The one switch here that defaults on, because the log is what makes reach measurable at all |
+
+**When podium cards are awarded.** Weekly cards come from the **last completed
+week**, never the one in progress. Awarding live only looked idempotent: the
+upsert is keyed on `(studentId, achId)` and `achId` carries no student, so a new
+leader at the next six-hourly run was handed their *own* row rather than
+replacing the previous holder — up to 28 students could each hold a permanent,
+independently verifiable "1st place, week of X" card for the same board. A
+finished week cannot move, so awarding from it yields one set of winners.
+
+All-time boards have the same failure and **no completed period to award from** —
+they only settle when the programme does. Hence `ACHIEVEMENTS_ALLTIME`, off by
+default. Flipping it mints one settled set from the standings **at that moment**
+and closes those titles for good, so flip it at the end; doing it early freezes
+whoever happens to be ahead. Both paths are backed by a settled-placing guard:
+once a placing has any holder it is closed, which still allows ties (awarded
+together in one batch) but stops a later challenger claiming the same title —
+including after a backdated transaction shifts a past week's standings.
 
 Flipping any of them is a `.env` edit + PM2 restart — no rebuild, no redeploy.
 

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1626,7 +1626,7 @@ function AdminView({ admin, auth, onBack }) {
       {tab === 'attendance' && <AdminAttendance data={attendance} onStudent={loadStudent} />}
       {tab === 'live' && <LiveAnalytics active={active} />}
       {tab === 'analytics' && <Analytics data={analytics} />}
-      {tab === 'achievements' && <AdminAchievements data={analytics?.sharing} />}
+      {tab === 'achievements' && <AdminAchievements data={analytics?.sharing} reigns={analytics?.reigns} />}
       {tab === 'students' && <AllStudentsPanel stats={stats} onStudent={loadStudent} auth={auth} />}
       {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} /></section></div>}
     </main>
@@ -1636,8 +1636,9 @@ function AdminView({ admin, auth, onBack }) {
 // Achievements & sharing. The organising idea is that a raw share count is a
 // vanity number — it goes up simply because more cards get minted — so every
 // figure here that can be a rate is one, with cards HELD as the denominator.
-function AdminAchievements({ data }) {
+function AdminAchievements({ data, reigns }) {
   if (!data) return <section className="panel empty">Loading achievement data…</section>;
+  const d = (x) => x ? new Date(x).toLocaleDateString('en-IN', { day: 'numeric', month: 'short', year: 'numeric' }) : '—';
   const r = data.reach || {};
   const pct = (n) => `${n}%`;
   const hrs = data.medianHoursToShare;
@@ -1686,6 +1687,37 @@ function AdminAchievements({ data }) {
             {(data.byPlace || []).map(p => (
               <tr key={p.place}><td>{['', '1st', '2nd', '3rd'][p.place]}</td><td>{p.held}</td><td>{p.shares}</td><td><b>{pct(p.shareRatePct)}</b></td></tr>
             ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Board reigns</h2>
+          <span className="muted">Who has held the top of each all-time board, and for how long.</span>
+        </div>
+        <p className="muted">
+          An all-time board never settles while the programme runs, so the top spot is recorded as a dated
+          reign rather than an outright title. A reign earns a card once it has lasted <b>7 days</b>; shorter
+          ones are still kept here, which is what makes the churn visible.
+        </p>
+        <div className="ach-stats">
+          <div><span>Leadership changes</span><strong>{reigns?.total ?? 0}</strong></div>
+          <div><span>Median reign</span><strong>{reigns?.medianDays == null ? '—' : `${reigns.medianDays} d`}</strong><em>completed only</em></div>
+          <div><span>Currently reigning</span><strong>{reigns?.current?.length ?? 0}</strong><em>one per board</em></div>
+        </div>
+        <table className="table">
+          <thead><tr><th>Board</th><th>Holder</th><th>From</th><th>To</th><th>Days</th><th>SP</th><th>Card</th></tr></thead>
+          <tbody>
+            {(reigns?.history || []).map((r, i) => (
+              <tr key={i}>
+                <td>{r.board}</td><td>{r.name || '—'}</td><td>{d(r.from)}</td>
+                <td>{r.current ? <b>still reigning</b> : d(r.to)}</td>
+                <td>{r.days}</td><td>{r.sp}</td>
+                <td>{r.awarded ? 'yes' : <span className="muted">too short</span>}</td>
+              </tr>
+            ))}
+            {!(reigns?.history || []).length && <tr><td colSpan={7} className="muted">No one has topped a board yet.</td></tr>}
           </tbody>
         </table>
       </section>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -542,8 +542,10 @@ function AchievementTile({ group, me, open, onToggle, onShare, canShare }) {
   );
 }
 
-// Renders the actual PNG the student posts, and hands them the three ways out:
-// LinkedIn, WhatsApp, or just the file. Each one is logged.
+// Renders the actual PNG the student posts, and hands them the two ways out:
+// LinkedIn, or just the file. Each one is logged. WhatsApp was dropped — the
+// point of these cards is a public, checkable post, and a forward to a chat
+// thread is neither.
 // navigator.clipboard is secure-context only (https or localhost), so on any
 // plain-http origin it is simply absent and a copy would fail silently. The
 // textarea trick still works everywhere.
@@ -570,9 +572,17 @@ function ShareModal({ item, me, onClose }) {
   const [copied, setCopied] = useState(false);
   const verifyUrl = `${window.location.origin}${APP_BASE}/verify/${item.verifyId}`;
   const [caption, setCaption] = useState('');
+  // Posting a card is a four-step job on LinkedIn and every step is easy to skip
+  // — most of all uploading the image, without which the post is a bare link.
+  // The tick is not paperwork: it is there to make the steps get read once.
+  const [readSteps, setReadSteps] = useState(false);
 
   useEffect(() => {
-    import('./shareCard.js').then(m => setCaption(m.shareCaption(item, false, verifyUrl)));
+    import('./shareCard.js').then(m => {
+      const text = m.shareCaption(item, verifyUrl);
+      setCaption(text);
+      setGenerated(text);
+    });
   }, [item.achId]);
 
   useEffect(() => {
@@ -594,10 +604,18 @@ function ShareModal({ item, me, onClose }) {
     return () => { live = false; };
   }, [item.achId]);
 
+  // `generated` is the caption as we wrote it; comparing against what's in the
+  // box at share time is the only way to know whether students take our framing
+  // or write their own.
+  const [generated, setGenerated] = useState('');
   const track = (platform) => fetch(`${API}/share/track`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email: me.email, achId: item.achId, platform })
+    body: JSON.stringify({
+      email: me.email, achId: item.achId, platform,
+      captionEdited: !!generated && caption !== generated,
+      captionChars: caption.length
+    })
   }).catch(() => {});
 
   // Two ways to get the picture into the post without the student handling a file:
@@ -605,9 +623,8 @@ function ShareModal({ item, me, onClose }) {
   //  2. failing that, post the verify link and let the platform expand it into a
   //     preview of the card (that's what the og:image on /verify/:code is for)
   // Downloading is a fallback, not the route.
-  const share = async (platform) => {
-    const { shareCaption, dataUrlToFile } = await import('./shareCard.js');
-    const caption = shareCaption(item, platform === 'whatsapp', verifyUrl);
+  const share = async () => {
+    const { dataUrlToFile } = await import('./shareCard.js');
     const file = png ? dataUrlToFile(png, `spurti-${item.achId.replace(/[:]/g, '-')}.png`) : null;
 
     // Only phones get the share sheet. Desktop Chrome/Safari also advertise
@@ -624,16 +641,12 @@ function ShareModal({ item, me, onClose }) {
       }
     }
 
-    track(platform);
-    if (platform === 'linkedin') {
-      // LinkedIn cannot be handed post text by URL — it opens an empty composer
-      // whatever you pass. Copying first is what makes the paste possible.
-      const ok = await copyText(caption);
-      setCopied(ok);
-      window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(verifyUrl)}`, '_blank', 'noopener');
-    } else if (platform === 'whatsapp') {
-      window.open(`https://wa.me/?text=${encodeURIComponent(caption)}`, '_blank', 'noopener');
-    }
+    track('linkedin');
+    // LinkedIn cannot be handed post text by URL — it opens an empty composer
+    // whatever you pass. Copying first is what makes the paste possible.
+    const ok = await copyText(caption);
+    setCopied(ok);
+    window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(verifyUrl)}`, '_blank', 'noopener');
   };
 
   const justDownload = async () => {
@@ -652,34 +665,46 @@ function ShareModal({ item, me, onClose }) {
         {error && <p className="muted">{error}</p>}
         {!png && !error && <p className="muted">Drawing your card…</p>}
         {png && <img className="share-preview" src={png} alt={`${item.title} — ${item.period}`} />}
-        <div className="share-actions">
-          <button className="primary" disabled={!png} onClick={() => share('linkedin')}>Share on LinkedIn</button>
-          <button className="wa" disabled={!png} onClick={() => share('whatsapp')}>Share on WhatsApp</button>
-          <button className="secondary" disabled={!png} onClick={justDownload}>Download card</button>
-        </div>
         <div className="caption-box">
           <div className="caption-head">
             <b>Your caption</b>
-            <button className="mini-copy" onClick={async () => setCopied(await copyText(caption))}>
+            <button className="mini-copy" onClick={async () => { track('copy'); setCopied(await copyText(caption)); }}>
               {copied ? 'Copied ✓' : 'Copy'}
             </button>
           </div>
-          <textarea value={caption} onChange={e => { setCaption(e.target.value); setCopied(false); }} rows={7} />
+          <textarea value={caption} onChange={e => { setCaption(e.target.value); setCopied(false); }} rows={12} />
           <p>LinkedIn always opens an empty box — paste this in with <b>Ctrl+V</b> (<b>Cmd+V</b> on Mac). Edit it first if you like.</p>
         </div>
 
-        <div className="tag-hint">
-          <b>Tag us in your post</b>
-          <p>In the LinkedIn box type <b>@Vicharanashala</b> and pick the lab page, then <b>@Sakshi</b> and pick her
-          from the list. Choosing from the list is what makes it a real tag — typed text alone doesn't reach us.</p>
-          <div className="tag-links">
-            <a href="https://www.linkedin.com/company/vicharanashala/" target="_blank" rel="noopener">The lab page →</a>
-            <a href="https://www.linkedin.com/in/sakshivk/" target="_blank" rel="noopener">Sakshi's profile →</a>
-          </div>
+        <div className="post-howto">
+          <b>How to post this — read before you click</b>
+          <ol>
+            <li><b>Download the card first.</b> LinkedIn will not pick the picture up on its own; you attach it yourself in a moment.</li>
+            <li>Click <b>Share on LinkedIn</b>. Your caption is copied for you and the composer opens with your verify link already attached.</li>
+            <li><b>Add the card image to the post</b> — the photo button in the composer, then the file you just downloaded. Skip this and your post is only a link.</li>
+            <li><b>Paste the caption</b> (Ctrl+V / Cmd+V).</li>
+            <li><b>Tag us.</b> Type <b>@Vicharanashala</b> and pick the lab page, then <b>@Sakshi</b> and pick her from
+            the list. Picking from the dropdown is what makes it a real tag — typed text alone doesn't reach anyone.
+            <span className="tag-links">
+              <a href="https://www.linkedin.com/company/vicharanashala/" target="_blank" rel="noopener">The lab page →</a>
+              <a href="https://www.linkedin.com/in/sakshivk/" target="_blank" rel="noopener">Sakshi's profile →</a>
+            </span></li>
+          </ol>
+          <label className="ack">
+            <input type="checkbox" checked={readSteps} onChange={e => setReadSteps(e.target.checked)} />
+            <span>I've read the steps — in particular that I add the image myself.</span>
+          </label>
         </div>
+
+        <div className="share-actions">
+          <button className="secondary" disabled={!png} onClick={justDownload}>Download card</button>
+          <button className="primary" disabled={!png || !readSteps} onClick={share}>Share on LinkedIn</button>
+        </div>
+
         <p className="muted share-note">
-          On a phone, Share hands the picture straight to the app you pick. On a computer it posts your verify link,
-          which shows the card in the post — and anyone who clicks it lands on proof the achievement is real.
+          On a phone, Share hands the picture straight to LinkedIn and you can skip step 3 — but samagama.in isn't
+          built for small screens, so this is probably a job for a computer. Either way the verify link travels with
+          the post: anyone who clicks it lands on proof the achievement is real.
         </p>
       </section>
     </div>
@@ -1571,7 +1596,8 @@ function AdminView({ admin, auth, onBack }) {
       const id = setInterval(loadActive, 10000);
       return () => clearInterval(id);
     }
-    if (tab === 'analytics' && !analytics) loadAnalytics();
+    // Both tabs read /admin/analytics — the sharing block rides along with it.
+    if ((tab === 'analytics' || tab === 'achievements') && !analytics) loadAnalytics();
   }, [tab]);
 
   return (
@@ -1581,7 +1607,7 @@ function AdminView({ admin, auth, onBack }) {
         <div><p className="eyebrow">Admin Dashboard</p><h1>Spurti Control Room</h1></div>
         <div className="score-card"><span>Yet to onboard</span><strong>{stats?.yetToOnboard ?? admin.yetToOnboard ?? 0}</strong><span className="divider">|</span><span>Active</span><strong>{stats?.activeStudents ?? admin.activeStudents ?? admin.students ?? 0}</strong><span className="divider">|</span><span>Excused</span><strong>{stats?.excusedStudents ?? admin.excusedStudents ?? 0}</strong><em>{stats?.transactions ?? admin.transactions ?? 0} txns</em></div>
       </header>
-      <Tabs tab={tab} setTab={setTab} tabs={[['leaderboard','Leaderboard'], ['attendance','Attendance'], ['live','Live'], ['analytics','Analytics'], ['students','Students']]} />
+      <Tabs tab={tab} setTab={setTab} tabs={[['leaderboard','Leaderboard'], ['attendance','Attendance'], ['live','Live'], ['analytics','Analytics'], ['achievements','Achievements'], ['students','Students']]} />
       {tab === 'leaderboard' && (
         <section className="panel">
           <div className="panel-head">
@@ -1600,9 +1626,119 @@ function AdminView({ admin, auth, onBack }) {
       {tab === 'attendance' && <AdminAttendance data={attendance} onStudent={loadStudent} />}
       {tab === 'live' && <LiveAnalytics active={active} />}
       {tab === 'analytics' && <Analytics data={analytics} />}
+      {tab === 'achievements' && <AdminAchievements data={analytics?.sharing} />}
       {tab === 'students' && <AllStudentsPanel stats={stats} onStudent={loadStudent} auth={auth} />}
       {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} /></section></div>}
     </main>
+  );
+}
+
+// Achievements & sharing. The organising idea is that a raw share count is a
+// vanity number — it goes up simply because more cards get minted — so every
+// figure here that can be a rate is one, with cards HELD as the denominator.
+function AdminAchievements({ data }) {
+  if (!data) return <section className="panel empty">Loading achievement data…</section>;
+  const r = data.reach || {};
+  const pct = (n) => `${n}%`;
+  const hrs = data.medianHoursToShare;
+  const latency = hrs === null || hrs === undefined ? '—'
+    : hrs < 48 ? `${hrs} h` : `${Math.round(hrs / 24)} d`;
+
+  return (
+    <>
+      <section className="panel">
+        <h2>Achievements &amp; sharing</h2>
+        <div className="ach-stats">
+          <div><span>Cards held</span><strong>{data.achievementsHeld}</strong></div>
+          <div><span>Cards shared</span><strong>{data.achievementsShared}</strong><em>{pct(data.shareRatePct)} of held</em></div>
+          <div><span>Share actions</span><strong>{data.totalShares}</strong><em>{data.last7Days} in last 7 days</em></div>
+          <div><span>Students sharing</span><strong>{data.sharers}</strong></div>
+          <div><span>Median earn → share</span><strong>{latency}</strong></div>
+          <div><span>Captions rewritten</span><strong>{pct(data.captionEditedPct)}</strong></div>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>By category</h2>
+          <span className="muted">Share rate = distinct cards shared ÷ cards held, so categories that mint more aren't flattered.</span>
+        </div>
+        <table className="table">
+          <thead><tr><th>Category</th><th>Held</th><th>Shared</th><th>Share rate</th><th>Share actions</th><th>Views</th></tr></thead>
+          <tbody>
+            {(data.categories || []).map(c => (
+              <tr key={c.key}>
+                <td>{c.label}</td><td>{c.held}</td><td>{c.sharedCards}</td>
+                <td><b>{pct(c.shareRatePct)}</b></td><td>{c.shares}</td><td>{c.views}</td>
+              </tr>
+            ))}
+            {!(data.categories || []).length && <tr><td colSpan={6} className="muted">No cards issued yet.</td></tr>}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="panel">
+        <h2>By placing</h2>
+        <p className="muted">Whether a 1st is posted more readily than a 3rd — all three carry the same title, so this is the only place the difference shows.</p>
+        <table className="table">
+          <thead><tr><th>Place</th><th>Held</th><th>Share actions</th><th>Share rate</th></tr></thead>
+          <tbody>
+            {(data.byPlace || []).map(p => (
+              <tr key={p.place}><td>{['', '1st', '2nd', '3rd'][p.place]}</td><td>{p.held}</td><td>{p.shares}</td><td><b>{pct(p.shareRatePct)}</b></td></tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Reach</h2>
+          <span className="muted">Did the posts get looked at?</span>
+        </div>
+        <div className="ach-stats">
+          <div><span>Verify page views</span><strong>{r.views ?? 0}</strong><em>humans only</em></div>
+          <div><span>Unique viewer-days</span><strong>{r.uniqueViewerDays ?? 0}</strong></div>
+          <div><span>Views per share</span><strong>{r.viewsPerShare ?? 0}</strong></div>
+          <div><span>Crawler hits</span><strong>{r.botViews ?? 0}</strong><em>excluded above</em></div>
+          <div><span>Bad codes</span><strong>{r.notFound ?? 0}</strong></div>
+        </div>
+        {!!(r.byRef || []).length && (
+          <table className="table">
+            <thead><tr><th>Came from</th><th>Views</th></tr></thead>
+            <tbody>{r.byRef.map(x => <tr key={x.ref}><td>{x.ref}</td><td>{x.count}</td></tr>)}</tbody>
+          </table>
+        )}
+        <p className="muted">
+          A viewer-day is one device on one day, counted through a hash that is thrown away nightly — it cannot
+          identify anyone and cannot follow the same person to the next day. Verify-page visitors are members of
+          the public, not study participants, so no IP or cookie is stored.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2>Where cards go</h2>
+        <div className="ach-stats">
+          {Object.entries(data.byPlatform || {}).map(([k, v]) => (
+            <div key={k}><span>{k}</span><strong>{v}</strong></div>
+          ))}
+          {!Object.keys(data.byPlatform || {}).length && <p className="muted">Nothing shared yet.</p>}
+        </div>
+      </section>
+
+      <section className="panel">
+        <h2>Top sharers</h2>
+        <table className="table">
+          <thead><tr><th>Name</th><th>Email</th><th>Share actions</th><th>Cards</th><th>Last</th></tr></thead>
+          <tbody>
+            {(data.topSharers || []).map(s => (
+              <tr key={s.email}><td>{s.name}</td><td>{s.email}</td><td>{s.shares}</td><td>{s.achievements}</td>
+                <td>{s.last ? new Date(s.last).toLocaleDateString('en-IN') : '—'}</td></tr>
+            ))}
+            {!(data.topSharers || []).length && <tr><td colSpan={5} className="muted">No shares yet.</td></tr>}
+          </tbody>
+        </table>
+      </section>
+    </>
   );
 }
 

--- a/client/src/shareCard.js
+++ b/client/src/shareCard.js
@@ -305,30 +305,109 @@ export async function renderCard(a, s, verifyUrl) {
   return canvas.toDataURL('image/png');
 }
 
-// The caption a student posts with the card. The four hashtags and the profile
-// tag are what make the posts findable when we go looking for reach. When a
-// verify URL is passed it goes in too — that link is what LinkedIn expands into
-// a preview of the card, so a post carries the image even without an upload.
-export function shareCaption(a, forWhatsApp = false, verifyUrl = '') {
-  const what = a.period && a.period !== 'All-time' ? `${a.title} (${a.period})` : a.title;
-  // No profile link in the text. LinkedIn only turns a name into a real tag when
-  // it's picked from the composer's @-dropdown — pasted text never notifies
-  // anyone, it just reads like a footnote. The UI asks for the tag instead.
-  // Hashtags do survive a paste, which is why they stay.
+// The caption is about the achievement, not about the system that issued it.
+// Three beats carry it: what was won, what earning it actually involved, and a
+// line worth reading. Nobody's feed needs the scoring rules explained.
+const WON_IT_BY = {
+  total: {
+    1: 'Top of the cohort on overall points — earned across standups, polls, peer-learning sessions, and the questions I answered for other interns.',
+    2: 'Second across the whole cohort — standups, polls, peer-learning sessions, and the questions I answered for other interns.',
+    3: 'Third across the whole cohort — standups, polls, peer-learning sessions, and the questions I answered for other interns.'
+  },
+  attendance: {
+    1: 'This one is just for showing up. Every standup, start to finish, week after week.',
+    2: 'This one is just for showing up. Every standup, start to finish, week after week.',
+    3: 'This one is just for showing up. Every standup, start to finish, week after week.'
+  },
+  poll: {
+    1: 'Won inside the sessions themselves — reading the question properly and getting the answer right more often than anyone else.',
+    2: 'Won inside the sessions themselves — reading the question properly and getting the answer right, more often than almost anyone.',
+    3: 'Won inside the sessions themselves — reading the question properly and getting the answer right, more often than almost anyone.'
+  },
+  spa: {
+    1: 'Earned by sitting down with other interns — learning from them, and teaching what I had already worked out.',
+    2: 'Earned by sitting down with other interns — learning from them, and teaching what I had already worked out.',
+    3: 'Earned by sitting down with other interns — learning from them, and teaching what I had already worked out.'
+  },
+  query: {
+    1: 'Earned by being the one who answered when other interns were stuck.',
+    2: 'Earned by answering other interns when they were stuck.',
+    3: 'Earned by answering other interns when they were stuck.'
+  }
+};
+
+// One quote per board and per milestone. Attributions are the real ones: the
+// "excellence is a habit" line is Durant's gloss on Aristotle, not Aristotle,
+// and is credited that way here because the post is public and someone will check.
+const QUOTES = {
+  total: '"We are what we repeatedly do. Excellence, then, is not an act, but a habit."\n— Will Durant',
+  attendance: '"Little by little, a little becomes a lot."\n— Tanzanian proverb',
+  poll: '"The important thing is not to stop questioning."\n— Albert Einstein',
+  spa: '"While we teach, we learn."\n— Seneca',
+  query: '"No one has ever become poor by giving."\n— Anne Frank',
+  level: '"A journey of a thousand miles begins with a single step."\n— Lao Tzu',
+  legend: '"Excellence is a continuous process and not an accident."\n— A. P. J. Abdul Kalam',
+  club3600: '"You can\'t cross the sea merely by standing and staring at the water."\n— Rabindranath Tagore'
+};
+
+// Legend's threshold is a server-side number that may well be raised later, so
+// the figure is read back out of the achievement's own `detail` ("Crossed 1,500
+// SP") rather than written in here — a hardcoded 1,500 would keep printing in
+// captions long after the cards had stopped meaning it.
+function legendPoints(a) {
+  const n = /([\d,]+)\s*SP/i.exec(a.detail || '');
+  return n ? `${n[1]} Spurti Points` : 'The Legend badge';
+}
+
+function whatItTook(a) {
+  if (a.kind === 'rank') return WON_IT_BY[a.board]?.[a.place] || '';
+  if (a.achId === 'ms:legend') return `${legendPoints(a)}. There is no fast way to this one — it is the whole internship's work, added up.`;
+  const lvl = /^ms:level:(\d+)$/.exec(a.achId || '');
+  if (lvl) return `${(Number(lvl[1]) * 100).toLocaleString('en-IN')} Spurti Points, built up one session at a time.`;
+  if (a.achId === 'ms:club3600') return '3,600 minutes of standups — the full attendance goal for the internship, finished.';
+  return '';
+}
+
+function quoteFor(a) {
+  if (a.kind === 'rank') return QUOTES[a.board] || '';
+  if (a.achId === 'ms:legend') return QUOTES.legend;
+  if (a.achId === 'ms:club3600') return QUOTES.club3600;
+  if (/^ms:level:\d+$/.test(a.achId || '')) return QUOTES.level;
+  return '';
+}
+
+// All three podium places share one title — "Cohort Champion" is what 1st, 2nd
+// and 3rd are all called, and only the medal drawn on the card tells them apart.
+// In text there is no medal, so a 3rd place would read as an outright win unless
+// the caption says the place in words. That is what this is for.
+const PLACE_WORD = { 1: '1st place', 2: '2nd place', 3: '3rd place' };
+
+// No profile link in the text: LinkedIn only turns a name into a real tag when
+// it is picked from the composer's @-dropdown, so a pasted link notifies nobody
+// and just reads like a footnote. The modal asks for the @-tag instead.
+// Hashtags do survive a paste, which is why they stay.
+export function shareCaption(a, verifyUrl = '') {
+  const place = a.kind === 'rank' ? PLACE_WORD[a.place] : '';
+  const when = a.period && a.period !== 'All-time' ? a.period : '';
+  const head = [a.title, place, when].filter(Boolean).join(' — ');
   const lines = [
-    `🏆 Achievement unlocked on Spurti: ${what}!`,
+    `${head}.`,
     '',
-    'Part of the Vicharanashala VLED Summership at IIT Ropar, where Spurti Points track real engagement and consistency. Grateful for the momentum — onward. 🚀',
+    whatItTook(a),
     '',
-    // Two kinds of tag doing two jobs: the first three are distinctive enough to
-    // search on later and actually find these posts; the last two buy reach in
-    // feeds that don't know what Spurti is. Five is about LinkedIn's useful limit
-    // — more starts to cost reach rather than add it. "#sp" was dropped: far too
-    // common to find anything by.
-    '#Spurti #SpurtiPoints #Vicharanashala #VLEDSummership #IITRopar'
+    quoteFor(a),
+    ''
   ];
-  if (verifyUrl) lines.push('', verifyUrl);
-  return lines.join('\n');
+  // The link is the whole point of the card: it opens a page that confirms the
+  // achievement, so the post can be checked instead of taken on trust.
+  if (verifyUrl) lines.push('Verified here, if anyone wants to check:', verifyUrl, '');
+  // Two kinds of tag doing two jobs: the first three are distinctive enough to
+  // search on later and actually find these posts; the last two buy reach in
+  // feeds that don't know what Spurti is. Five is about LinkedIn's useful limit
+  // — more starts to cost reach rather than add it. "#sp" was dropped: far too
+  // common to find anything by.
+  lines.push('#Spurti #SpurtiPoints #Vicharanashala #VLEDSummership #IITRopar');
+  return lines.filter((l, i, arr) => !(l === '' && arr[i - 1] === '')).join('\n');
 }
 
 // A PNG data URL as a File, so it can go into navigator.share({ files }) — that

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -742,9 +742,25 @@ input {
 .share-preview { width: 100%; max-height: 52vh; object-fit: contain; border-radius: 12px; box-shadow: 0 14px 34px rgba(20,60,75,.18); }
 .share-actions { display: flex; flex-wrap: wrap; gap: 9px; }
 .share-actions button { flex: 1 1 130px; border-radius: 9px; padding: 11px 12px; font-weight: 800; font-size: 13px; cursor: pointer; border: 0; }
-.share-actions .wa { background: #25d366; color: #06371c; }
 .share-actions button:disabled { opacity: .5; cursor: default; }
 .share-note { font-size: 12px; }
+
+/* The steps sit between the caption and the buttons deliberately — the Share
+   button is disabled until the tick, so the block cannot be scrolled past. */
+.post-howto { border: 1px solid #dbe4e8; border-left: 3px solid var(--primary); border-radius: 9px; padding: 11px 13px; background: #f6fafb; }
+.post-howto b { font-size: 13px; }
+.post-howto ol { margin: 7px 0 9px; padding-left: 18px; display: grid; gap: 5px; }
+.post-howto li { font-size: 12.5px; line-height: 1.5; color: #475569; }
+.post-howto .tag-links { display: flex; gap: 14px; margin-top: 5px; }
+
+/* Admin: achievements & sharing */
+.ach-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-bottom: 4px; }
+.ach-stats > div { border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; background: #fafdff; }
+.ach-stats span { display: block; color: var(--muted); font-size: 11.5px; text-transform: uppercase; letter-spacing: .04em; }
+.ach-stats strong { display: block; font-size: 26px; color: var(--primary); margin: 3px 0 1px; }
+.ach-stats em { display: block; font-style: normal; font-size: 12px; color: var(--muted); }
+.post-howto .ack { display: flex; gap: 8px; align-items: flex-start; font-size: 12.5px; font-weight: 700; color: #334155; cursor: pointer; }
+.post-howto .ack input { margin-top: 2px; flex: none; width: 15px; height: 15px; accent-color: var(--primary); cursor: pointer; }
 
 /* ---- Public verify page ------------------------------------------------- */
 .verify-page { display: grid; place-items: center; min-height: 100vh; }
@@ -762,10 +778,6 @@ input {
 .verify-awarded { font-size: 10.5px; letter-spacing: .18em; text-transform: uppercase; color: #94a3b8; margin: 0; }
 .verify-name { font-size: 21px; font-weight: 700; margin: 3px 0 6px; }
 .verify-code { font-family: ui-monospace, Menlo, monospace; font-size: 12px; color: #94a3b8; margin-top: 14px; }
-.tag-hint { border: 1px solid #dbe4e8; border-left: 3px solid var(--primary); border-radius: 9px; padding: 11px 13px; background: #f6fafb; }
-.tag-hint b { font-size: 13px; }
-.tag-hint p { margin: 4px 0 6px; font-size: 12.5px; color: #475569; }
-.tag-hint a { font-size: 12.5px; font-weight: 700; color: var(--primary); }
 .tag-links { display: flex; flex-wrap: wrap; gap: 14px; }
 .caption-box { display: grid; gap: 7px; }
 .caption-head { display: flex; align-items: center; justify-content: space-between; }

--- a/server/migrations/2026-08-12-unique-verify-id.mjs
+++ b/server/migrations/2026-08-12-unique-verify-id.mjs
@@ -1,0 +1,86 @@
+// Makes verifyId unique.
+//
+// Must be run BEFORE deploying the code that relies on it. The collection
+// already carries a NON-unique `verifyId_1` index from the first release, and
+// Mongo refuses to redefine an index that keeps its name but changes its
+// options (IndexKeySpecsConflict). Mongoose's auto-indexing swallows that
+// failure at startup, so without this script the app would come up looking
+// healthy with no unique index at all — the guarantee silently absent.
+//
+//   MONGO_URI=... node server/migrations/2026-08-12-unique-verify-id.mjs [--apply]
+//
+// Without --apply it only reports. Safe to re-run.
+
+import mongoose from 'mongoose';
+
+const APPLY = process.argv.includes('--apply');
+const URI = process.env.MONGO_URI;
+if (!URI) { console.error('MONGO_URI is required'); process.exit(1); }
+
+await mongoose.connect(URI);
+const col = mongoose.connection.db.collection('achievements');
+const say = (...a) => console.log(...a);
+
+// 1. Duplicates must be dealt with first — a unique index cannot be built over
+//    them, and the build failing is how you find out the hard way.
+const dupes = await col.aggregate([
+  { $match: { verifyId: { $type: 'string' } } },
+  { $group: { _id: '$verifyId', n: { $sum: 1 }, ids: { $push: '$_id' } } },
+  { $match: { n: { $gt: 1 } } }
+]).toArray();
+
+const total = await col.countDocuments();
+const withCode = await col.countDocuments({ verifyId: { $type: 'string' } });
+say(`achievements: ${total} rows, ${withCode} with a code, ${total - withCode} without`);
+
+if (dupes.length) {
+  say(`\n!! ${dupes.length} duplicate code(s) — these MUST be resolved before the index can be built:`);
+  for (const d of dupes) say(`   ${d._id} used by ${d.n} rows: ${d.ids.join(', ')}`);
+  say('\nRe-issuing a code invalidates any card already posted with it, so decide');
+  say('deliberately which row keeps the code. Not doing that automatically.');
+  await mongoose.disconnect();
+  process.exit(1);
+}
+say('no duplicate codes — safe to build the unique index');
+
+// 2. Swap the index.
+const existing = await col.indexes();
+const old = existing.find((i) => i.name === 'verifyId_1');
+const alreadyRight = old && old.unique && old.partialFilterExpression;
+
+if (alreadyRight) {
+  say('\nunique partial index already in place — nothing to do');
+} else if (!APPLY) {
+  say(`\nwould drop ${old ? `existing index ${JSON.stringify(old.key)} (unique: ${!!old.unique})` : 'nothing'}`);
+  say('would create { verifyId: 1 } unique, partial on $type:string');
+  say('\nre-run with --apply to make the change');
+} else {
+  if (old) { await col.dropIndex('verifyId_1'); say('dropped old verifyId_1'); }
+  await col.createIndex(
+    { verifyId: 1 },
+    { unique: true, partialFilterExpression: { verifyId: { $type: 'string' } }, name: 'verifyId_1' }
+  );
+  const now = (await col.indexes()).find((i) => i.name === 'verifyId_1');
+  say(`created: ${JSON.stringify(now)}`);
+}
+
+// 3. Backfill periodKey on rows issued before the field existed. It is derived
+//    from achId, which already encodes the window:
+//      rank:poll:week:2026-08-03:1  -> 2026-08-03
+//      rank:total:all:all:3 | ms:*  -> all
+const stale = await col.find({ $or: [{ periodKey: { $exists: false } }, { periodKey: '' }] },
+  { projection: { achId: 1 } }).toArray();
+if (!stale.length) {
+  say('\nperiodKey: nothing to backfill');
+} else if (!APPLY) {
+  say(`\nwould backfill periodKey on ${stale.length} row(s)`);
+} else {
+  const ops = stale.map((d) => {
+    const m = /^rank:[^:]+:week:(\d{4}-\d{2}-\d{2}):/.exec(d.achId || '');
+    return { updateOne: { filter: { _id: d._id }, update: { $set: { periodKey: m ? m[1] : 'all' } } } };
+  });
+  const res = await col.bulkWrite(ops, { ordered: false });
+  say(`\nperiodKey backfilled on ${res.modifiedCount} row(s)`);
+}
+
+await mongoose.disconnect();

--- a/server/models/Achievement.js
+++ b/server/models/Achievement.js
@@ -18,21 +18,81 @@ const achievementSchema = new mongoose.Schema({
   icon: { type: String, default: '🏆' },
   title: { type: String, required: true },   // e.g. "Poll Champion"
   period: { type: String, default: '' },     // "Week of Aug 3–9" | "All-time"
+  // Sortable/groupable twin of `period`: the week's Monday as 2026-08-03, or
+  // 'all'. `period` is display text and changes if the wording ever does, so
+  // analysis groups on this instead of parsing achId.
+  periodKey: { type: String, default: '', index: true },
   detail: { type: String, default: '' },     // stat line, e.g. "240 SP"
-  verifyId: { type: String, index: true },   // public code, e.g. SPRT-4F2A-9C1D
+  verifyId: { type: String },                // public code, e.g. SPRT-4F2A-9C1D (indexed below)
   earnedAt: { type: Date, default: Date.now }
 }, { timestamps: true });
 
 achievementSchema.index({ studentId: 1, achId: 1 }, { unique: true });
 
+// The verify code is PUBLIC — printed on the card, inside the QR, and in the
+// posted caption — so it never needs to be secret, but two students must never
+// share one: the verify page would credit the wrong person and the stored card
+// PNG (named {verifyId}.png) would overwrite theirs. Randomness alone can only
+// make that unlikely; this index is what makes it impossible. Partial, because
+// a plain unique index treats every code-less row as a duplicate `null`.
+achievementSchema.index(
+  { verifyId: 1 },
+  { unique: true, partialFilterExpression: { verifyId: { $type: 'string' } } }
+);
+
 // Crockford-ish alphabet: no I/L/O/U/0/1, so a code read off a printed card is
-// unambiguous. 8 chars from 30 symbols ≈ 6.6e11 combinations.
+// unambiguous. 8 chars from 30 symbols = 6.56e11 combinations.
 const ALPHABET = '23456789ABCDEFGHJKMNPQRSTVWXYZ';
+// 256 is not a multiple of 30, so a plain `byte % 30` would make the first 16
+// symbols 12.5% likelier than the rest. Redrawing the 16 bytes above the last
+// whole multiple costs nothing and keeps every symbol equally likely.
+const LIMIT = 256 - (256 % ALPHABET.length);   // 240
+
 export function newVerifyId() {
-  const bytes = crypto.randomBytes(8);
   let s = '';
-  for (const b of bytes) s += ALPHABET[b % ALPHABET.length];
+  while (s.length < 8) {
+    for (const b of crypto.randomBytes(8 - s.length)) {
+      if (b < LIMIT) s += ALPHABET[b % ALPHABET.length];
+    }
+  }
   return `SPRT-${s.slice(0, 4)}-${s.slice(4, 8)}`;
 }
 
-export default mongoose.model('Achievement', achievementSchema);
+const Achievement = mongoose.model('Achievement', achievementSchema);
+
+// Awards a batch of achievements, re-rolling any code the unique index rejects.
+// Each spec is { filter, doc } and is upserted with $setOnInsert, so an
+// achievement already held keeps the code it was first issued.
+//
+// Two different duplicate-key errors can come back and they mean opposite
+// things: one on studentId_1_achId_1 means the student already has this
+// achievement (two builds raced — nothing to do), while one on verifyId_1 means
+// the code clashed and must be re-rolled. Only the second is retried.
+export async function awardAchievements(specs, attempts = 5) {
+  let pending = specs.map((s) => ({ ...s, doc: { ...s.doc, verifyId: newVerifyId() } }));
+  for (let i = 0; i < attempts && pending.length; i++) {
+    const ops = pending.map((s) => ({
+      updateOne: { filter: s.filter, update: { $setOnInsert: s.doc }, upsert: true }
+    }));
+    try {
+      await Achievement.bulkWrite(ops, { ordered: false });
+      return;
+    } catch (err) {
+      const writeErrors = err?.writeErrors || [];
+      if (!writeErrors.length) throw err;
+      const clashed = [];
+      for (const we of writeErrors) {
+        const info = we.err || we;
+        if (info.code !== 11000) throw err;
+        // Re-roll only the code clashes; the achId clash is a benign race.
+        if (/verifyId/.test(info.errmsg || '')) clashed.push(pending[info.index]);
+      }
+      pending = clashed.map((s) => ({ ...s, doc: { ...s.doc, verifyId: newVerifyId() } }));
+    }
+  }
+  if (pending.length) {
+    throw new Error(`could not mint a unique verifyId after ${attempts} attempts`);
+  }
+}
+
+export default Achievement;

--- a/server/models/AchievementView.js
+++ b/server/models/AchievementView.js
@@ -1,0 +1,63 @@
+import crypto from 'crypto';
+import mongoose from 'mongoose';
+
+// One row per hit on a public /verify/:code page. Shares tell you what students
+// were willing to post; this tells you whether posting reached anyone — the
+// difference between intent and effect, and the only reach measure the feature
+// can produce.
+//
+// The people in this collection are NOT participants: they are members of the
+// public who clicked a LinkedIn post. Nothing that could identify one of them
+// is stored — no IP, no cookie, no persistent id (see `viewerDay` below).
+const achievementViewSchema = new mongoose.Schema({
+  verifyId: { type: String, required: true, index: true },
+  achId: { type: String, default: '' },
+  studentId: { type: String, default: '', index: true },   // whose card was viewed
+  board: { type: String, default: '' },
+  kind: { type: String, default: '' },
+  found: { type: Boolean, default: true },                 // false = code matched nothing
+  ref: { type: String, default: '' },                      // referrer HOST only, never the full URL
+  uaFamily: { type: String, default: 'other' },            // coarse bucket, not the UA string
+  bot: { type: Boolean, default: false, index: true },
+  // Unique-visitor signal that cannot be traced back to a person: a hash of
+  // (IP + user-agent) under a salt that is generated in memory and rotated
+  // daily, never written down. Two hits from one device on one day collide, so
+  // they can be counted once; the same device tomorrow gets an unrelated value,
+  // so nobody can be followed across days. Distinct-count only — never a key.
+  viewerDay: { type: String, default: '', index: true },
+  at: { type: Date, default: Date.now, index: true }
+});
+
+// The salt lives only in this process's memory and dies with it, which is the
+// point: there is no stored secret that could later be used to re-derive who a
+// viewer was. A restart just starts a new bucket.
+let salt = crypto.randomBytes(32);
+let saltDay = '';
+function dailySalt() {
+  const today = new Date().toISOString().slice(0, 10);
+  if (today !== saltDay) { salt = crypto.randomBytes(32); saltDay = today; }
+  return salt;
+}
+
+export function viewerDayHash(ip, ua) {
+  if (!ip) return '';
+  return crypto.createHmac('sha256', dailySalt()).update(`${ip}|${ua || ''}`).digest('hex').slice(0, 16);
+}
+
+// Link unfurlers hit every shared URL to build the preview card, so without
+// this every share would manufacture its own "views" and the reach numbers
+// would be measuring our own og:image tags.
+const BOTS = /bot|crawler|spider|facebookexternalhit|linkedinbot|slackbot|whatsapp|telegram|twitterbot|discordbot|preview|embedly|quora link preview|redditbot|applebot|bingpreview|curl|wget|python-requests|headlesschrome/i;
+export function isBot(ua) { return BOTS.test(String(ua || '')); }
+
+export function uaFamilyOf(ua) {
+  const s = String(ua || '');
+  if (/iPhone|iPad|iPod/i.test(s)) return 'ios';
+  if (/Android/i.test(s)) return 'android';
+  if (/Windows/i.test(s)) return 'windows';
+  if (/Macintosh|Mac OS X/i.test(s)) return 'mac';
+  if (/Linux/i.test(s)) return 'linux';
+  return 'other';
+}
+
+export default mongoose.model('AchievementView', achievementViewSchema);

--- a/server/models/BoardReign.js
+++ b/server/models/BoardReign.js
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+
+// Who has held the top of each all-time board, and for how long.
+//
+// An all-time board never settles while the programme runs, so "1st place,
+// All-time" cannot be awarded honestly — every successive leader would hold an
+// unqualified claim to the same title. A reign fixes the claim by dating it:
+// "top of the Overall board, 12 Aug – 3 Sep" is true of each holder, the spans
+// don't overlap, and nothing has to be revoked when someone is overtaken.
+//
+// This collection is the record of leadership itself, kept whether or not a
+// reign ever earns a card — so a lead held for six hours still shows up in the
+// history even though it is too brief to commemorate. That makes it the only
+// place the programme's leadership churn is captured.
+const boardReignSchema = new mongoose.Schema({
+  board: { type: String, required: true, index: true },   // total|attendance|poll|spa|query
+  studentId: { type: String, required: true, index: true },
+  name: { type: String, default: '' },
+  from: { type: Date, required: true },
+  to: { type: Date, default: null },                      // null = still reigning
+  sp: { type: Number, default: 0 },                       // their SP on this board, kept current
+  peakSp: { type: Number, default: 0 },
+  awarded: { type: Boolean, default: false },             // has it earned a card yet
+  achId: { type: String, default: '' }
+}, { timestamps: true });
+
+// Finding the open reign for a board is the hot path on every build.
+boardReignSchema.index({ board: 1, to: 1 });
+
+export default mongoose.model('BoardReign', boardReignSchema);

--- a/server/models/ShareEvent.js
+++ b/server/models/ShareEvent.js
@@ -3,14 +3,41 @@ import mongoose from 'mongoose';
 // One row per time a student shares or downloads an achievement card. This is
 // the point of the whole feature — knowing whether students actually post them,
 // and which achievements are worth posting.
+//
+// The achievement's category is copied onto the event rather than joined back
+// through achId. It costs a few bytes and makes "which category gets shared
+// most" a single group-by; it also freezes what the achievement WAS at the
+// moment it was shared, which a join would silently lose if a title or a
+// board's wording ever changed.
 const shareEventSchema = new mongoose.Schema({
   studentId: { type: String, required: true, index: true },
   email: { type: String, default: '' },
   name: { type: String, default: '' },
-  achId: { type: String, required: true },
+
+  achId: { type: String, required: true, index: true },
+  verifyId: { type: String, default: '', index: true },
   title: { type: String, default: '' },
+  kind: { type: String, default: '', index: true },     // rank | milestone
+  board: { type: String, default: '', index: true },    // total|attendance|poll|spa|query ('' for milestones)
+  place: { type: Number, default: 0 },                  // 1|2|3, 0 for milestones
+  period: { type: String, default: '' },
+  periodKey: { type: String, default: '' },
+
+  // Copied so earn→share latency needs no join. This is the interesting one:
+  // whether a card is posted the day it lands or sat on for a fortnight.
+  earnedAt: { type: Date, default: null },
+
+  // Whether the student rewrote the caption we generated before posting, and
+  // how long theirs was. Speaks to whether the framing is theirs or ours.
+  captionEdited: { type: Boolean, default: false },
+  captionChars: { type: Number, default: 0 },
+
   platform: { type: String, enum: ['linkedin', 'whatsapp', 'download', 'copy', 'native'], required: true },
   at: { type: Date, default: Date.now, index: true }
 });
+
+// The two group-bys the research actually runs.
+shareEventSchema.index({ board: 1, at: -1 });
+shareEventSchema.index({ kind: 1, place: 1 });
 
 export default mongoose.model('ShareEvent', shareEventSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ import LeaderboardSnapshot from './models/LeaderboardSnapshot.js';
 import Achievement from './models/Achievement.js';
 import ShareEvent from './models/ShareEvent.js';
 import AchievementView, { isBot, uaFamilyOf, viewerDayHash } from './models/AchievementView.js';
+import BoardReign from './models/BoardReign.js';
 import { buildAchievementState, verifyAchievement } from './services/achievements.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import Commitment from './models/Commitment.js';
@@ -781,7 +782,7 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
   const last7Days = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
   const last30Days = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
-  const [allStudents, sessions, attendance, transactions, events, shares, achievements, views] = await Promise.all([
+  const [allStudents, sessions, attendance, transactions, events, shares, achievements, views, reigns] = await Promise.all([
     Student.find().lean(),
     Session.find().sort({ endDateTime: 1 }).lean(),
     AttendanceRecord.find().lean(),
@@ -791,7 +792,8 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
     // The full rows, not a count: per-category share rates need the cards HELD
     // in each category as their denominator.
     Achievement.find({}, { achId: 1, kind: 1, board: 1, place: 1, studentId: 1, earnedAt: 1 }).lean(),
-    AchievementView.find({}, { bot: 1, board: 1, kind: 1, ref: 1, viewerDay: 1, found: 1 }).lean()
+    AchievementView.find({}, { bot: 1, board: 1, kind: 1, ref: 1, viewerDay: 1, found: 1 }).lean(),
+    BoardReign.find().sort({ from: -1 }).lean()
   ]);
   const statusCounts = { active: 0, 'yet to onboard': 0, excused: 0 };
   for (const s of allStudents) { if (s.status in statusCounts) statusCounts[s.status]++; }
@@ -903,7 +905,8 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
       pollDebits: pollDebits.length,
       topDrops
     },
-    sharing: shareSummary(shares, achievements, views, last7Days)
+    sharing: shareSummary(shares, achievements, views, last7Days),
+    reigns: reignSummary(reigns)
   });
 });
 
@@ -1027,6 +1030,30 @@ function shareSummary(shares, achievements, views, since) {
     topSharers: [...byStudent.values()]
       .map((r) => ({ name: r.name, email: r.email, shares: r.shares, achievements: r.achievements.size, last: r.last }))
       .sort((a, b) => b.shares - a.shares).slice(0, 15)
+  };
+}
+
+// Who has held the top of each board and for how long. Short reigns are kept
+// even though they never earn a card — the churn is the interesting part.
+function reignSummary(reigns) {
+  const DAY = 86400000;
+  const rows = reigns.map((r) => ({
+    board: BOARD_LABEL[r.board] || r.board,
+    name: r.name, studentId: r.studentId,
+    from: r.from, to: r.to,
+    days: Math.max(0, Math.round((((r.to ? new Date(r.to) : new Date()) - new Date(r.from)) / DAY) * 10) / 10),
+    sp: r.peakSp || r.sp,
+    awarded: !!r.awarded,
+    current: !r.to
+  }));
+  const byBoard = {};
+  for (const r of rows) byBoard[r.board] = (byBoard[r.board] || 0) + 1;
+  return {
+    total: rows.length,
+    current: rows.filter((r) => r.current),
+    changesByBoard: Object.entries(byBoard).map(([board, n]) => ({ board, n })).sort((a, b) => b.n - a.n),
+    medianDays: median(rows.filter((r) => !r.current).map((r) => r.days)),
+    history: rows.slice(0, 40)
   };
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -15,6 +15,7 @@ import SessionEvent from './models/SessionEvent.js';
 import LeaderboardSnapshot from './models/LeaderboardSnapshot.js';
 import Achievement from './models/Achievement.js';
 import ShareEvent from './models/ShareEvent.js';
+import AchievementView, { isBot, uaFamilyOf, viewerDayHash } from './models/AchievementView.js';
 import { buildAchievementState, verifyAchievement } from './services/achievements.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import Commitment from './models/Commitment.js';
@@ -522,6 +523,40 @@ api.get('/verify/:code', async (req, res) => {
   res.json(result);
 });
 
+// Records that a card was looked at. Fire-and-forget: a credential page must
+// never fail, or be slowed down, because analytics did.
+//
+// Deliberately not stored: the visitor's IP, any cookie, and the full referrer
+// (only its host). These are members of the public who followed a link, not
+// consented participants — see models/AchievementView.js. Set
+// VERIFY_VIEW_LOG=0 to switch the whole thing off.
+const VIEW_LOG_ON = process.env.VERIFY_VIEW_LOG !== '0';
+function logAchievementView(req, code, result) {
+  if (!VIEW_LOG_ON) return;
+  const verifyId = String(code || '').trim().toUpperCase();
+  const ua = req.get('user-agent') || '';
+  let ref = '';
+  try { ref = req.get('referer') ? new URL(req.get('referer')).host : ''; } catch { ref = ''; }
+  // The category is re-read here rather than added to verifyAchievement's
+  // return value: that payload is public JSON, and studentId has no business
+  // being in it just to make logging convenient.
+  (async () => {
+    const a = result ? await Achievement.findOne({ verifyId }, { achId: 1, studentId: 1, board: 1, kind: 1 }).lean() : null;
+    await AchievementView.create({
+      verifyId,
+      achId: a?.achId || '',
+      studentId: a?.studentId || '',
+      board: a?.board || '',
+      kind: a?.kind || '',
+      found: !!result,
+      ref,
+      uaFamily: uaFamilyOf(ua),
+      bot: isBot(ua),
+      viewerDay: viewerDayHash(req.ip, ua)
+    });
+  })().catch(() => { /* never let logging break a credential page */ });
+}
+
 // The card is drawn in the browser, so the server never sees it unless the
 // client hands it over. It's stored once per achievement purely so the verify
 // page has an og:image — that's what makes a posted link show the card without
@@ -554,7 +589,7 @@ api.post('/share/card', async (req, res) => {
 // Every share and download is logged so the admin can see who posts, how often,
 // and which achievements are actually worth posting.
 api.post('/share/track', async (req, res) => {
-  const { achId, platform } = req.body || {};
+  const { achId, platform, captionEdited, captionChars } = req.body || {};
   if (!achId || !['linkedin', 'whatsapp', 'download', 'copy', 'native'].includes(platform)) {
     return res.status(400).json({ error: 'achId and a valid platform required' });
   }
@@ -565,7 +600,11 @@ api.post('/share/track', async (req, res) => {
   if (!ach) return res.status(404).json({ error: 'Achievement not found' });
   await ShareEvent.create({
     studentId: String(student._id), email: student.email, name: student.name,
-    achId, title: ach.title, platform
+    achId, verifyId: ach.verifyId || '', title: ach.title,
+    kind: ach.kind, board: ach.board, place: ach.place,
+    period: ach.period, periodKey: ach.periodKey || '', earnedAt: ach.earnedAt || null,
+    captionEdited: !!captionEdited, captionChars: Number(captionChars) || 0,
+    platform
   });
   res.json({ ok: true });
 });
@@ -742,14 +781,17 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
   const last7Days = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
   const last30Days = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
-  const [allStudents, sessions, attendance, transactions, events, shares, achievementCount] = await Promise.all([
+  const [allStudents, sessions, attendance, transactions, events, shares, achievements, views] = await Promise.all([
     Student.find().lean(),
     Session.find().sort({ endDateTime: 1 }).lean(),
     AttendanceRecord.find().lean(),
     SPTransaction.find().lean(),
     SessionEvent.find({ timestamp: { $gte: last30Days } }).lean(),
     ShareEvent.find().lean(),
-    Achievement.countDocuments()
+    // The full rows, not a count: per-category share rates need the cards HELD
+    // in each category as their denominator.
+    Achievement.find({}, { achId: 1, kind: 1, board: 1, place: 1, studentId: 1, earnedAt: 1 }).lean(),
+    AchievementView.find({}, { bot: 1, board: 1, kind: 1, ref: 1, viewerDay: 1, found: 1 }).lean()
   ]);
   const statusCounts = { active: 0, 'yet to onboard': 0, excused: 0 };
   for (const s of allStudents) { if (s.status in statusCounts) statusCounts[s.status]++; }
@@ -861,37 +903,127 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
       pollDebits: pollDebits.length,
       topDrops
     },
-    sharing: shareSummary(shares, achievementCount, last7Days)
+    sharing: shareSummary(shares, achievements, views, last7Days)
   });
 });
 
-// Who shares their achievement cards, how often, and which achievements travel.
-// `shareRate` is the honest headline: how many of the cards students hold have
-// ever actually been shared.
-function shareSummary(shares, achievementCount, since) {
+const BOARD_LABEL = {
+  total: 'Overall SP', attendance: 'Attendance', poll: 'Polls',
+  spa: 'Peer Learning', query: 'Queries', '': 'Milestones'
+};
+const median = (xs) => {
+  if (!xs.length) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+
+// Who shares their achievement cards, which categories travel, and whether any
+// of it reaches anyone.
+//
+// The headline is `shareRatePct` — of the cards students actually hold, how
+// many were ever posted. A raw share count flatters itself: it rises simply
+// because more cards get minted. The per-category rates work the same way,
+// dividing shares by the cards HELD in that category, which is the only way
+// "Polls gets shared more than Attendance" means anything when the two mint at
+// different volumes.
+function shareSummary(shares, achievements, views, since) {
   const byStudent = new Map();
   const byPlatform = {};
-  const byTitle = new Map();
   const sharedAch = new Set();
+  const latencies = [];
+  let edited = 0;
+
+  // Cards HELD per category — the denominator for every rate below.
+  const cat = new Map();
+  const bucket = (key, label) => {
+    if (!cat.has(key)) cat.set(key, { key, label, held: 0, shares: 0, sharedCards: new Set(), views: 0 });
+    return cat.get(key);
+  };
+  for (const a of achievements) {
+    const key = a.kind === 'rank' ? a.board : 'milestone';
+    bucket(key, key === 'milestone' ? 'Milestones' : (BOARD_LABEL[a.board] || a.board)).held += 1;
+  }
+
+  const byPlace = {
+    1: { shares: 0, held: 0, cards: new Set() },
+    2: { shares: 0, held: 0, cards: new Set() },
+    3: { shares: 0, held: 0, cards: new Set() }
+  };
+  for (const a of achievements) if (a.place >= 1 && a.place <= 3) byPlace[a.place].held += 1;
+
   for (const s of shares) {
     byPlatform[s.platform] = (byPlatform[s.platform] || 0) + 1;
     sharedAch.add(`${s.studentId}:${s.achId}`);
+    if (s.captionEdited) edited += 1;
+    if (s.earnedAt) latencies.push((new Date(s.at) - new Date(s.earnedAt)) / 3600000);
+    if (s.place >= 1 && s.place <= 3) {
+      byPlace[s.place].shares += 1;
+      byPlace[s.place].cards.add(`${s.studentId}:${s.achId}`);
+    }
+
+    const key = s.kind === 'rank' ? s.board : 'milestone';
+    const b = bucket(key, key === 'milestone' ? 'Milestones' : (BOARD_LABEL[s.board] || s.board));
+    b.shares += 1;
+    b.sharedCards.add(`${s.studentId}:${s.achId}`);
+
     let row = byStudent.get(s.studentId);
     if (!row) { row = { name: s.name, email: s.email, shares: 0, achievements: new Set(), last: s.at }; byStudent.set(s.studentId, row); }
     row.shares += 1;
     row.achievements.add(s.achId);
     if (s.at > row.last) row.last = s.at;
-    byTitle.set(s.title || '—', (byTitle.get(s.title || '—') || 0) + 1);
   }
+
+  // Reach. Crawler hits are excluded everywhere: LinkedIn fetches every posted
+  // URL to build its preview, so counting bots would mean counting our own
+  // og:image tags as an audience.
+  const human = views.filter((v) => !v.bot);
+  // A hit on a code that matches nothing is a mistyped or probed URL, not
+  // someone looking at a card. Counted separately so it can't inflate reach.
+  const real = human.filter((v) => v.found);
+  for (const v of real) {
+    const key = v.kind === 'rank' ? v.board : 'milestone';
+    if (v.kind) bucket(key, key === 'milestone' ? 'Milestones' : (BOARD_LABEL[v.board] || v.board)).views += 1;
+  }
+  const byRef = {};
+  for (const v of real) if (v.ref) byRef[v.ref] = (byRef[v.ref] || 0) + 1;
+
+  const categories = [...cat.values()]
+    .map((c) => ({
+      key: c.key, label: c.label, held: c.held, shares: c.shares,
+      sharedCards: c.sharedCards.size,
+      shareRatePct: c.held ? Math.round((c.sharedCards.size / c.held) * 100) : 0,
+      views: c.views
+    }))
+    .sort((a, b) => b.shareRatePct - a.shareRatePct || b.shares - a.shares);
+
+  const latencyHrs = median(latencies);
   return {
     totalShares: shares.length,
     sharers: byStudent.size,
     last7Days: shares.filter((s) => s.at >= since).length,
-    achievementsHeld: achievementCount,
+    achievementsHeld: achievements.length,
     achievementsShared: sharedAch.size,
-    shareRatePct: achievementCount ? Math.round((sharedAch.size / achievementCount) * 100) : 0,
+    shareRatePct: achievements.length ? Math.round((sharedAch.size / achievements.length) * 100) : 0,
+    captionEditedPct: shares.length ? Math.round((edited / shares.length) * 100) : 0,
+    medianHoursToShare: latencyHrs === null ? null : Math.round(latencyHrs * 10) / 10,
     byPlatform,
-    topTitles: [...byTitle.entries()].map(([title, count]) => ({ title, count })).sort((a, b) => b.count - a.count).slice(0, 8),
+    categories,
+    // Rate is distinct cards shared over cards held, exactly as the category
+    // table does it. Dividing by share ACTIONS would let one card shared twice
+    // report 200%, which is a number no reader can interpret.
+    byPlace: [1, 2, 3].map((p) => ({
+      place: p, held: byPlace[p].held, shares: byPlace[p].shares, sharedCards: byPlace[p].cards.size,
+      shareRatePct: byPlace[p].held ? Math.round((byPlace[p].cards.size / byPlace[p].held) * 100) : 0
+    })),
+    reach: {
+      views: real.length,
+      botViews: views.length - human.length,
+      uniqueViewerDays: new Set(real.map((v) => v.viewerDay).filter(Boolean)).size,
+      notFound: human.length - real.length,
+      viewsPerShare: shares.length ? Math.round((real.length / shares.length) * 10) / 10 : 0,
+      byRef: Object.entries(byRef).map(([ref, count]) => ({ ref, count })).sort((a, b) => b.count - a.count).slice(0, 8)
+    },
     topSharers: [...byStudent.values()]
       .map((r) => ({ name: r.name, email: r.email, shares: r.shares, achievements: r.achievements.size, last: r.last }))
       .sort((a, b) => b.shares - a.shares).slice(0, 15)
@@ -942,7 +1074,10 @@ async function verifyPageHtml(req, code) {
     img ? `<meta property="og:image:height" content="1350">` : '',
     `<title>${esc(title)}</title>`
   ].filter(Boolean).join('\n  ');
-  return html.replace(/<title>.*?<\/title>/i, '').replace('</head>', `  ${tags}\n</head>`);
+  // `found` drives the status code: a credential page that answers 200 for a
+  // code nobody was ever issued would let a made-up link look live to anything
+  // that only checks the status (crawlers, link unfurlers, a sceptical reader).
+  return { found: !!result, html: html.replace(/<title>.*?<\/title>/i, '').replace('</head>', `  ${tags}\n</head>`) };
 }
 
 if (fs.existsSync(clientDist)) {
@@ -950,7 +1085,12 @@ if (fs.existsSync(clientDist)) {
   app.use(express.static(clientDist, { index: false }));
   app.get(['/spurti/verify/:code', '/verify/:code'], async (req, res) => {
     try {
-      res.type('html').send(await verifyPageHtml(req, req.params.code));
+      const { found, html } = await verifyPageHtml(req, req.params.code);
+      // Logged here and NOT on /api/verify: a human loads this page and then
+      // the SPA fetches the API, so counting both would double every real view.
+      // A crawler only ever hits this route, which is what the bot flag is for.
+      logAchievementView(req, req.params.code, found);
+      res.status(found ? 200 : 404).type('html').send(html);
     } catch {
       res.sendFile(path.join(clientDist, 'index.html'));
     }

--- a/server/services/achievements.js
+++ b/server/services/achievements.js
@@ -1,4 +1,4 @@
-import Achievement, { newVerifyId } from '../models/Achievement.js';
+import Achievement, { awardAchievements } from '../models/Achievement.js';
 import AttendanceRecord from '../models/AttendanceRecord.js';
 import { levelFor } from './levels.js';
 
@@ -72,14 +72,14 @@ export async function buildAchievementState(student) {
 
   const toPersist = specs.filter((s) => s.earned);
   if (toPersist.length) {
-    await Achievement.bulkWrite(toPersist.map((s) => ({ updateOne: {
+    await awardAchievements(toPersist.map((s) => ({
       filter: { studentId: sid, achId: s.achId },
-      update: { $setOnInsert: {
+      doc: {
         studentId: sid, achId: s.achId, kind: 'milestone', board: '', place: 0,
-        icon: s.icon, title: s.title, period: s.period, detail: s.detail,
-        verifyId: newVerifyId(), earnedAt: new Date()
-      } },
-      upsert: true } })), { ordered: false });
+        icon: s.icon, title: s.title, period: s.period, periodKey: 'all',
+        detail: s.detail, earnedAt: new Date()
+      }
+    })));
   }
 
   const rows = await Achievement.find({ studentId: sid }).sort({ earnedAt: -1 }).lean();

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -1,7 +1,7 @@
 import Student from '../models/Student.js';
 import SPTransaction from '../models/SPTransaction.js';
 import LeaderboardSnapshot from '../models/LeaderboardSnapshot.js';
-import Achievement, { newVerifyId } from '../models/Achievement.js';
+import Achievement, { awardAchievements } from '../models/Achievement.js';
 import { levelFor } from './levels.js';
 
 const CAT_LABEL = { total: 'Overall', attendance: 'Best Attendance', poll: 'Poll Champions', spa: 'Top SPA', query: 'Top Query Answerers' };
@@ -139,15 +139,16 @@ export async function computeAndStoreLeaderboards() {
   const add = (r, b, place) => {
     const wk = b.window === 'week' ? weekStart.toISOString().slice(0, 10) : 'all';
     const achId = `rank:${b.category}:${b.window}:${wk}:${place}`;
-    ops.push({ updateOne: {
+    ops.push({
       filter: { studentId: r.studentId, achId },
-      update: { $setOnInsert: {
+      doc: {
         studentId: r.studentId, achId, kind: 'rank', board: b.category, place,
         icon: PLACE_ICON[place], title: ACH_TITLE[b.category],
         period: b.window === 'week' ? `Week of ${label}` : 'All-time',
-        detail: `${r.sp} SP`, verifyId: newVerifyId(), earnedAt: now
-      } },
-      upsert: true } });
+        periodKey: wk,
+        detail: `${r.sp} SP`, earnedAt: now
+      }
+    });
   };
   for (const b of boards) {
     if (!awardsOn) break;
@@ -159,7 +160,7 @@ export async function computeAndStoreLeaderboards() {
       for (const r of tied) add(r, b, place);
     }
   }
-  if (ops.length) await Achievement.bulkWrite(ops, { ordered: false });
+  if (ops.length) await awardAchievements(ops);
 
   return { boards: boards.length, groups: groups.length, achievementOps: ops.length, weekStart, weekLabel: label, students: students.length };
 }

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -2,6 +2,7 @@ import Student from '../models/Student.js';
 import SPTransaction from '../models/SPTransaction.js';
 import LeaderboardSnapshot from '../models/LeaderboardSnapshot.js';
 import Achievement, { awardAchievements } from '../models/Achievement.js';
+import BoardReign from '../models/BoardReign.js';
 import { levelFor } from './levels.js';
 
 const CAT_LABEL = { total: 'Overall', attendance: 'Best Attendance', poll: 'Poll Champions', spa: 'Top SPA', query: 'Top Query Answerers' };
@@ -70,14 +71,10 @@ export async function computeAndStoreLeaderboards() {
   // unique 1,2,3… ranks and no cards. Read here, not at import, so the flag is
   // whatever the .env said when the process started, however it was started.
   const awardsOn = process.env.ACHIEVEMENTS_ENABLED === '1';
-  // All-time podiums are a SEPARATE switch, default off, because unlike a week
-  // an all-time board never settles while the programme is running. Awarding it
-  // live handed every successive leader their own permanent "1st place,
-  // All-time" card — three leaders, three cards, all verifying as genuine, none
-  // of them exclusive. There is no completed period to award from, so the only
-  // honest moment is one the operator picks: flip this at programme end and a
-  // single settled set is minted.
-  const allTimeOn = awardsOn && process.env.ACHIEVEMENTS_ALLTIME === '1';
+  // All-time boards are NOT awarded as plain podiums. They never settle while
+  // the programme runs, so an unqualified "1st place, All-time" would be handed
+  // to every successive leader in turn. They are handled as dated reigns
+  // instead — see trackReigns below.
   const weekStart = weekStartIST(now);
   const label = weekLabel(weekStart);
   // The week the cards are for. The boards on screen still show the week in
@@ -170,37 +167,31 @@ export async function computeAndStoreLeaderboards() {
 
     awardBoards = [
       { window: 'week', category: 'total', rows: build(students, pTotal) },
-      ...CATS.map((cat) => ({ window: 'week', category: cat, rows: build(students, pCat(cat)) })),
-      ...(allTimeOn
-        ? boards.filter((b) => b.window === 'all' && b.scope === 'all')
-            .map((b) => ({ window: 'all', category: b.category, rows: b.rows }))
-        : [])
+      ...CATS.map((cat) => ({ window: 'week', category: cat, rows: build(students, pCat(cat)) }))
     ];
 
     // Belt and braces against a placing being awarded twice with different
     // winners — a late backdated transaction could shift even a settled week's
-    // standings, and an all-time board moves whenever anyone earns. Once a
-    // placing has any holder it is closed, so ties (awarded together in one
-    // batch) still work while a later challenger cannot claim the same title.
+    // standings. Once a placing has any holder it is closed, so ties (awarded
+    // together in one batch) still work while a later challenger cannot claim
+    // the same title.
     const wk = weekKey(prevWeekStart);
     const already = await Achievement.find(
-      { $or: [{ achId: { $regex: `^rank:[^:]+:week:${wk}:` } }, { achId: { $regex: '^rank:[^:]+:all:all:' } }] },
-      { achId: 1 }
+      { achId: { $regex: `^rank:[^:]+:week:${wk}:` } }, { achId: 1 }
     ).lean();
     settled = new Set(already.map((a) => a.achId));
   }
 
   const add = (r, b, place) => {
-    const wk = b.window === 'week' ? weekKey(prevWeekStart) : 'all';
-    const achId = `rank:${b.category}:${b.window}:${wk}:${place}`;
+    const wk = weekKey(prevWeekStart);
+    const achId = `rank:${b.category}:week:${wk}:${place}`;
     if (settled.has(achId)) return;                  // this placing is already awarded
     ops.push({
       filter: { studentId: r.studentId, achId },
       doc: {
         studentId: r.studentId, achId, kind: 'rank', board: b.category, place,
         icon: PLACE_ICON[place], title: ACH_TITLE[b.category],
-        period: b.window === 'week' ? `Week of ${prevLabel}` : 'All-time',
-        periodKey: wk,
+        period: `Week of ${prevLabel}`, periodKey: wk,
         detail: `${r.sp} SP`, earnedAt: now
       }
     });
@@ -215,9 +206,104 @@ export async function computeAndStoreLeaderboards() {
   }
   if (ops.length) await awardAchievements(ops);
 
+  const reigns = awardsOn ? await trackReigns(boards, now) : { changes: 0, minted: 0 };
+
   return {
     boards: boards.length, groups: groups.length, achievementOps: ops.length,
     weekStart, weekLabel: label, awardedWeek: awardsOn ? prevLabel : null,
-    students: students.length
+    reigns, students: students.length
   };
+}
+
+const DAY = 86400000;
+// How long the top spot must be held before it is worth a card. The build runs
+// four times a day and early in a cohort the lead can change between runs, so
+// without a floor a six-hour blip would mint a permanent credential.
+const MIN_REIGN_MS = 7 * DAY;
+
+function istDate(d) {
+  const x = new Date(d.getTime() + IST_MS);
+  return `${x.getUTCDate()} ${MON[x.getUTCMonth()]}`;
+}
+function istYear(d) { return new Date(d.getTime() + IST_MS).getUTCFullYear(); }
+function reignPeriod(from, to) {
+  return to
+    ? `${istDate(from)} – ${istDate(to)} ${istYear(to)}`
+    : `Since ${istDate(from)} ${istYear(from)}`;
+}
+
+// Keeps `boardreign` in step with who currently tops each all-time board, and
+// mints a card once a reign has lasted long enough to mean something.
+//
+// Only 1st place has a reign: "reigning champion" is a real idea, while "was
+// second for a while" is not, and the places below the top shuffle constantly.
+async function trackReigns(boards, now) {
+  let changes = 0;
+  const ops = [];
+  const closedAwarded = [];
+
+  for (const b of boards.filter((x) => x.window === 'all' && x.scope === 'all')) {
+    const leaders = b.rows.filter((r) => r.rank === 1 && r.sp > 0);
+    const open = await BoardReign.findOne({ board: b.category, to: null });
+
+    // A tie keeps the sitting holder if they are still among the leaders —
+    // being caught up with is not the same as being overtaken.
+    const stillLeading = open && leaders.some((r) => r.studentId === open.studentId);
+
+    if (open && !stillLeading) {
+      open.to = now;
+      await open.save();
+      if (open.awarded) closedAwarded.push(open);
+      changes += 1;
+    }
+
+    if (stillLeading) {
+      const me = leaders.find((r) => r.studentId === open.studentId);
+      open.sp = me.sp;
+      open.peakSp = Math.max(open.peakSp || 0, me.sp);
+      await open.save();
+    } else {
+      for (const r of leaders) {
+        await BoardReign.create({
+          board: b.category, studentId: r.studentId, name: r.name,
+          from: now, to: null, sp: r.sp, peakSp: r.sp
+        });
+        changes += 1;
+      }
+    }
+  }
+
+  // Mint for any reign — open or closed — that has now lasted long enough.
+  const ripe = await BoardReign.find({ awarded: false });
+  for (const rg of ripe) {
+    const held = (rg.to ? rg.to.getTime() : now.getTime()) - rg.from.getTime();
+    if (held < MIN_REIGN_MS) continue;
+    const achId = `rank:${rg.board}:reign:${weekKey(rg.from)}:1`;
+    ops.push({
+      filter: { studentId: rg.studentId, achId },
+      doc: {
+        studentId: rg.studentId, achId, kind: 'rank', board: rg.board, place: 1,
+        icon: PLACE_ICON[1], title: ACH_TITLE[rg.board],
+        period: reignPeriod(rg.from, rg.to), periodKey: weekKey(rg.from),
+        detail: `${rg.peakSp || rg.sp} SP`, earnedAt: rg.from
+      }
+    });
+    rg.awarded = true;
+    rg.achId = achId;
+    await rg.save();
+  }
+  if (ops.length) await awardAchievements(ops);
+
+  // A reign that ends after its card was minted: the card said "Since 12 Aug"
+  // and must now read "12 Aug – 3 Sep". The already-posted PNG keeps the older
+  // wording, which was true when it was posted; the verify page is the record
+  // that stays current.
+  for (const rg of closedAwarded) {
+    await Achievement.updateOne(
+      { studentId: rg.studentId, achId: rg.achId },
+      { $set: { period: reignPeriod(rg.from, rg.to), detail: `${rg.peakSp || rg.sp} SP` } }
+    );
+  }
+
+  return { changes, minted: ops.length, closed: closedAwarded.length };
 }

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -30,6 +30,12 @@ function weekStartIST(now) {
   const monMidnightIst = Date.UTC(ist.getUTCFullYear(), ist.getUTCMonth(), ist.getUTCDate() - daysSinceMon);
   return new Date(monMidnightIst - IST_MS);
 }
+// The week's Monday as an IST calendar date. A week starts at 00:00 IST, which
+// is 18:30 UTC the evening BEFORE, so slicing the UTC instant would name every
+// week after the preceding Sunday — "2026-08-02" for the week of Aug 3–9.
+function weekKey(weekStartUtc) {
+  return new Date(weekStartUtc.getTime() + IST_MS).toISOString().slice(0, 10);
+}
 function weekLabel(weekStartUtc) {
   const s = new Date(weekStartUtc.getTime() + IST_MS);
   const e = new Date(s.getTime() + 6 * 86400000);
@@ -64,8 +70,20 @@ export async function computeAndStoreLeaderboards() {
   // unique 1,2,3… ranks and no cards. Read here, not at import, so the flag is
   // whatever the .env said when the process started, however it was started.
   const awardsOn = process.env.ACHIEVEMENTS_ENABLED === '1';
+  // All-time podiums are a SEPARATE switch, default off, because unlike a week
+  // an all-time board never settles while the programme is running. Awarding it
+  // live handed every successive leader their own permanent "1st place,
+  // All-time" card — three leaders, three cards, all verifying as genuine, none
+  // of them exclusive. There is no completed period to award from, so the only
+  // honest moment is one the operator picks: flip this at programme end and a
+  // single settled set is minted.
+  const allTimeOn = awardsOn && process.env.ACHIEVEMENTS_ALLTIME === '1';
   const weekStart = weekStartIST(now);
   const label = weekLabel(weekStart);
+  // The week the cards are for. The boards on screen still show the week in
+  // progress; only the awarding waits for it to finish.
+  const prevWeekStart = new Date(weekStart.getTime() - 7 * 86400000);
+  const prevLabel = weekLabel(prevWeekStart);
 
   const students = await Student.find(
     { status: { $ne: 'excused' } },
@@ -123,11 +141,17 @@ export async function computeAndStoreLeaderboards() {
   await Promise.all(boards.map((b) => LeaderboardSnapshot.updateOne({ boardKey: b.boardKey }, { $set: b }, { upsert: true })));
   await LeaderboardSnapshot.deleteMany({ boardKey: { $nin: [...keys] } });
 
-  // Award permanent podium achievements — 1st, 2nd and 3rd on each GLOBAL board,
-  // weekly and all-time. Idempotent: `earnedAt` and `verifyId` are set on insert
-  // only, so re-running the build six-hourly never mints a second card for the
-  // same board+period. A weekly win carries its week in the achId, so winning
-  // the same board in a later week IS a new, separately shareable achievement.
+  // Award permanent podium achievements — 1st, 2nd and 3rd on each GLOBAL board.
+  //
+  // WEEKLY CARDS COME FROM THE LAST COMPLETED WEEK, NEVER THE ONE IN PROGRESS.
+  // Awarding live looked idempotent but was not: the upsert is keyed on
+  // (studentId, achId) and achId carries no student, so a different leader at
+  // the next six-hourly run did not replace the previous one — they were handed
+  // their own row. Monday's leader, Wednesday's and Sunday's would each end up
+  // holding a permanent, independently verifiable "1st place, week of X" card
+  // for the same board. Four runs a day meant up to 28 holders of one placing.
+  // A finished week's standings cannot move, so awarding from them gives one
+  // set of winners and makes re-running genuinely a no-op.
   //
   // Not awarded here (deliberate, v1 scope):
   //  · onboarding-group boards — they overlap the cohort-wide win and would more
@@ -136,23 +160,52 @@ export async function computeAndStoreLeaderboards() {
   //    a field of thirty, which isn't the same achievement as a podium.
   const TIE_MAX = 3;      // a place shared by more than 3 people isn't a placing
   const ops = [];
+  let awardBoards = [];
+  let settled = new Set();
+
+  if (awardsOn) {
+    const prevWeekMap = await sumByStudentCat({ dateTime: { $gte: prevWeekStart, $lt: weekStart } });
+    const pTotal = (sid) => (prevWeekMap.get(sid)?.total) || 0;
+    const pCat = (cat) => (sid) => (prevWeekMap.get(sid)?.cat[cat]) || 0;
+
+    awardBoards = [
+      { window: 'week', category: 'total', rows: build(students, pTotal) },
+      ...CATS.map((cat) => ({ window: 'week', category: cat, rows: build(students, pCat(cat)) })),
+      ...(allTimeOn
+        ? boards.filter((b) => b.window === 'all' && b.scope === 'all')
+            .map((b) => ({ window: 'all', category: b.category, rows: b.rows }))
+        : [])
+    ];
+
+    // Belt and braces against a placing being awarded twice with different
+    // winners — a late backdated transaction could shift even a settled week's
+    // standings, and an all-time board moves whenever anyone earns. Once a
+    // placing has any holder it is closed, so ties (awarded together in one
+    // batch) still work while a later challenger cannot claim the same title.
+    const wk = weekKey(prevWeekStart);
+    const already = await Achievement.find(
+      { $or: [{ achId: { $regex: `^rank:[^:]+:week:${wk}:` } }, { achId: { $regex: '^rank:[^:]+:all:all:' } }] },
+      { achId: 1 }
+    ).lean();
+    settled = new Set(already.map((a) => a.achId));
+  }
+
   const add = (r, b, place) => {
-    const wk = b.window === 'week' ? weekStart.toISOString().slice(0, 10) : 'all';
+    const wk = b.window === 'week' ? weekKey(prevWeekStart) : 'all';
     const achId = `rank:${b.category}:${b.window}:${wk}:${place}`;
+    if (settled.has(achId)) return;                  // this placing is already awarded
     ops.push({
       filter: { studentId: r.studentId, achId },
       doc: {
         studentId: r.studentId, achId, kind: 'rank', board: b.category, place,
         icon: PLACE_ICON[place], title: ACH_TITLE[b.category],
-        period: b.window === 'week' ? `Week of ${label}` : 'All-time',
+        period: b.window === 'week' ? `Week of ${prevLabel}` : 'All-time',
         periodKey: wk,
         detail: `${r.sp} SP`, earnedAt: now
       }
     });
   };
-  for (const b of boards) {
-    if (!awardsOn) break;
-    if (b.scope !== 'all') continue;                 // global boards only in v1
+  for (const b of awardBoards) {
     for (const place of [1, 2, 3]) {
       const tied = b.rows.filter((r) => r.rank === place);
       // A placing needs a real score: the top of a table of zeroes is not a win.
@@ -162,5 +215,9 @@ export async function computeAndStoreLeaderboards() {
   }
   if (ops.length) await awardAchievements(ops);
 
-  return { boards: boards.length, groups: groups.length, achievementOps: ops.length, weekStart, weekLabel: label, students: students.length };
+  return {
+    boards: boards.length, groups: groups.length, achievementOps: ops.length,
+    weekStart, weekLabel: label, awardedWeek: awardsOn ? prevLabel : null,
+    students: students.length
+  };
 }


### PR DESCRIPTION
Three related fixes to the achievements feature, all found while finishing the share flow. Nothing here is live: the feature is still dark behind `ACHIEVEMENTS_ENABLED`, which is why two of these could be fixed cleanly rather than migrated around.

## 1. Verify codes were not actually unique

The code is **public** — printed on the card, inside the QR, and in the posted caption — so it never needs to be secret, but two students must never share one. A duplicate would credit the wrong person on the verify page *and* overwrite their `{verifyId}.png`, which is the og:image LinkedIn serves into the preview.

`verifyId` carried a plain non-unique index and there was no collision check, so uniqueness rested on randomness alone — roughly **1 in 500** across a cohort's worth of codes, worse because `byte % 30` made 16 of the 30 symbols 12.5% likelier.

- **unique partial index** on `verifyId` (partial, or every code-less row collides as a duplicate `null`)
- `awardAchievements()` re-rolls on `E11000`, distinguishing the two duplicate-key errors: a clash on `studentId_1_achId_1` is a benign build race, one on `verifyId_1` is a code collision
- `byte % 30` → **rejection sampling**

### ⚠️ Migration required, before the code

```
MONGO_URI=… node server/migrations/2026-08-12-unique-verify-id.mjs --apply
```

The collection already carries a non-unique `verifyId_1` from the first release, and Mongo will not redefine an index that keeps its name and changes its options. **Mongoose swallows that failure at boot**, so deploying without this leaves the app running with no unique index and no error — the guarantee silently absent. The script refuses to run over existing duplicates rather than re-issue a code that may already sit in a posted card, and backfills `periodKey`. Dry-run by default, idempotent.

Doing this now is nearly free: only three preview codes exist in prod.

## 2. Weekly cards were awarded from the week in progress

The most damaging bug in the feature. The upsert is keyed on `(studentId, achId)` and `achId` carries no student, so when the lead changed at the next six-hourly run the new leader was handed their **own** row rather than replacing the previous holder:

```
holders of "1st place, Polls, week of Aug 10": 3
   student-A  SPRT-HCFW-FGGD
   student-B  SPRT-ADYE-ZWWA
   student-C  SPRT-KACZ-AFYX
```

Up to 28 holders of one placing at four runs a day, each with a genuine, independently verifiable QR — on a feature whose whole point is a checkable credential.

Weekly cards now come from the **last completed week**, whose standings cannot move. A settled-placing guard backs it up: once a placing has any holder it is closed, so ties still work (awarded together in one batch) but a backdated transaction cannot mint a second set.

Also fixes the week key: a week starts 00:00 IST = 18:30 UTC the evening before, so slicing the UTC instant named every week after the preceding Sunday — `periodKey 2026-08-02` on a card reading "Week of Aug 3–9".

## 3. All-time top spot becomes a dated reign

All-time boards have the same fault and **no completed period to award from** — they settle only when the programme does. Dating the claim dissolves the problem: "top of the Overall board, 15 Jul – 12 Aug 2026" is true of every holder, the spans do not overlap, and nobody's card is revoked when they are overtaken.

New `boardreign` collection records every leadership change whether or not it earns a card, which makes it the only place the programme's leadership churn is captured.

- **1st place only** — "reigning champion" is a real idea; "was second for a while" is not
- **a reign earns a card after 7 days** — the build runs four times a day and the lead can change between runs early in a cohort, so without a floor a six-hour blip mints a permanent credential
- **minted while the reign is open**, reading "Since 15 Jul 2026", gaining its end date when it closes. An already-posted PNG keeps the older wording, which was true when posted; the verify page stays current
- a tie keeps the sitting holder — being caught up with is not being overtaken

This replaces `ACHIEVEMENTS_ALLTIME` (introduced and then removed within this branch): reigns are always safe to mint, so there is nothing left to gate. **All-time 2nd and 3rd cards go away**; weekly keeps all three places.

## Measurement

`ShareEvent` carries the achievement's category (`kind`, `board`, `place`, `period`, `periodKey`, `earnedAt`) so share-rate-by-category is a group-by rather than a join, and the record survives a later change to a title or a board's wording. Plus `captionEdited` / `captionChars`. The caption Copy button finally logs the `copy` platform that was already in the enum.

New `achievementviews` records verify-page hits — nothing logged them before, so sharing was measurable but reach was not. Logged on the HTML page route only, **not** `/api/verify`, since a human triggers both and it would double-count every view. Crawler hits are flagged and excluded everywhere: LinkedIn fetches each posted URL to build its preview and would otherwise manufacture its own audience.

**Privacy.** Verify-page visitors are members of the public, not consented participants. No IP, no cookie, no full referrer (host only). `viewerDay` is an HMAC under a salt generated in memory and rotated daily, never persisted — unique *device-days*, which cannot identify anyone or follow them across days. `VERIFY_VIEW_LOG=0` switches it off.

New admin **Achievements** tab renders a payload that was already being computed and thrown away, plus the reign history. Every rate divides by cards **held**, never by share actions.

## Share flow

Captions carry what the achievement took plus a quote per category, and **state the place in words** — all three podium places share one title, so a 3rd would otherwise read as an outright win. Legend's threshold is read from the achievement rather than hardcoded, so raising it later doesn't leave the caption lying. WhatsApp removed; a gated how-to block replaces it, with the tag instructions folded into it (they had been sitting *below* the buttons, where anyone following the steps would never see them).

Also fixes two stale `shareCaption(item, false, verifyUrl)` calls left by an earlier signature change — `false` was landing in the `verifyUrl` slot.

## Verification

- Forced-collision test: duplicate rejected by the index; clashing doc re-rolled while its batch-mate was untouched; re-run kept the original code; 5,000 mints → 5,000 distinct; alphabet even to within sampling noise (2.7%, was 12.5% systematic)
- Migration exercised against a DB carrying the old index, then re-run for idempotence
- Weekly fix driven through the real build, including a backdated transaction that would previously have minted a second holder
- Reign lifecycle simulated across two months: no card at 3 days, minted at 8 while open, end date applied on being overtaken, a 2-day reign recorded but not commemorated
- Share modal and admin tab rendered and screenshotted against a local demo DB
- Real data caught two rate bugs, since fixed: 3rd place reported **200%** (one card shared twice), and views of a nonexistent code counted as reach

## Deploy order

```
1. run the migration (before the code)
2. pull, npm install, npm run build, restart
3. only then flip ACHIEVEMENTS_ENABLED=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
