### PR TITLE
fix(migration): load .env so the script runs on the server

### DIFF
--- a/server/migrations/2026-08-12-unique-verify-id.mjs
+++ b/server/migrations/2026-08-12-unique-verify-id.mjs
@@ -7,15 +7,21 @@
 // failure at startup, so without this script the app would come up looking
 // healthy with no unique index at all — the guarantee silently absent.
 //
-//   MONGO_URI=... node server/migrations/2026-08-12-unique-verify-id.mjs [--apply]
+// Run from the repo root, which is where dotenv looks for .env:
+//   node server/migrations/2026-08-12-unique-verify-id.mjs [--apply]
 //
 // Without --apply it only reports. Safe to re-run.
 
+import 'dotenv/config';
 import mongoose from 'mongoose';
 
 const APPLY = process.argv.includes('--apply');
 const URI = process.env.MONGO_URI;
-if (!URI) { console.error('MONGO_URI is required'); process.exit(1); }
+if (!URI) {
+  console.error('MONGO_URI is not set. Run this from the repo root so .env is picked up,');
+  console.error('or pass it explicitly: MONGO_URI=... node server/migrations/…');
+  process.exit(1);
+}
 
 await mongoose.connect(URI);
 const col = mongoose.connection.db.collection('achievements');


### PR DESCRIPTION
The migration read `process.env.MONGO_URI` but never imported dotenv, so on the server — the only place it needs to run — it exited with `MONGO_URI is required`. Every other script picks the URI up through `config.js`, which does `import 'dotenv/config'`; this does the same.

Found while running the deploy for #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)