### PR TITLE
feat(achievements): backfill podium cards for weeks before go-live

### DIFF
--- a/server/scripts/backfillWeeklyAchievements.mjs
+++ b/server/scripts/backfillWeeklyAchievements.mjs
@@ -1,0 +1,143 @@
+// Mints podium cards for weeks that finished BEFORE achievements went live.
+//
+// The live build only ever awards the last completed week, so every earlier week
+// of the internship has winners that were never recognised. This walks those
+// weeks and awards them retrospectively, using the same ranking and podium rules
+// as the live build (`rankRows` / `weeklyPodiumSpecs` in services/leaderboards.js)
+// so the two cannot disagree about who placed.
+//
+//   node server/scripts/backfillWeeklyAchievements.mjs                  # report only
+//   node server/scripts/backfillWeeklyAchievements.mjs --from 2026-06-01
+//   node server/scripts/backfillWeeklyAchievements.mjs --apply
+//
+//   --from YYYY-MM-DD   first week to consider (default: week of the earliest SP
+//                       transaction). Snapped back to that week's Monday.
+//   --to   YYYY-MM-DD   last week to consider (default: the last COMPLETED week —
+//                       the week in progress is never awarded)
+//   --board total|poll|…  restrict to one board
+//   --apply             actually write. Without it, nothing is written.
+//
+// Run from the repo root so .env is picked up. Safe to re-run: a placing that
+// already has a holder is skipped, so this can never hand the same week's title
+// to a second student.
+//
+// `earnedAt` is set to the END of the week in question, not now, so the cards
+// sit in the student's timeline where they actually belong.
+
+import 'dotenv/config';
+import mongoose from 'mongoose';
+import Student from '../models/Student.js';
+import SPTransaction from '../models/SPTransaction.js';
+import Achievement, { awardAchievements } from '../models/Achievement.js';
+import {
+  rankRows, weeklyPodiumSpecs, sumByStudentCat, weekStartIST, weekKey, weekLabel, CATS
+} from '../services/leaderboards.js';
+
+const WEEK = 7 * 86400000;
+const IST_MS = 5.5 * 3600 * 1000;
+
+const arg = (name, fallback = null) => {
+  const i = process.argv.indexOf(name);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+const APPLY = process.argv.includes('--apply');
+const ONLY_BOARD = arg('--board');
+const BOARDS = ONLY_BOARD ? [ONLY_BOARD] : ['total', ...CATS];
+
+const URI = process.env.MONGO_URI;
+if (!URI) {
+  console.error('MONGO_URI is not set. Run this from the repo root so .env is picked up.');
+  process.exit(1);
+}
+await mongoose.connect(URI);
+
+// The week in progress is never awarded — its standings can still move.
+const lastCompleted = new Date(weekStartIST(new Date()).getTime() - WEEK);
+
+const firstTx = await SPTransaction.find({}, { dateTime: 1 }).sort({ dateTime: 1 }).limit(1).lean();
+if (!firstTx.length) { console.error('no SP transactions — nothing to backfill'); process.exit(1); }
+
+const fromArg = arg('--from');
+const toArg = arg('--to');
+let from = weekStartIST(fromArg ? new Date(`${fromArg}T00:00:00+05:30`) : new Date(firstTx[0].dateTime));
+let to = toArg ? weekStartIST(new Date(`${toArg}T00:00:00+05:30`)) : lastCompleted;
+if (to > lastCompleted) {
+  console.log(`--to is in the current week; clamped to the last completed week (${weekKey(lastCompleted)})`);
+  to = lastCompleted;
+}
+if (from > to) { console.error('nothing to do: --from is after the last completed week'); process.exit(1); }
+
+const students = await Student.find(
+  { status: { $ne: 'excused' } },
+  { name: 1, totalSp: 1, highestSpEver: 1 }
+).lean();
+const nameOf = new Map(students.map((s) => [String(s._id), s.name || String(s._id)]));
+
+// Every placing already held, so a re-run — or a week the live build has since
+// awarded — is skipped rather than duplicated.
+const held = new Set(
+  (await Achievement.find({ achId: { $regex: '^rank:[^:]+:week:' } }, { achId: 1 }).lean())
+    .map((a) => a.achId)
+);
+
+console.log(`backfill ${weekKey(from)} … ${weekKey(to)}   boards: ${BOARDS.join(', ')}`);
+console.log(`${students.length} non-excused students, ${held.size} weekly placings already held`);
+console.log(APPLY ? '\nMODE: APPLY — cards will be written\n' : '\nMODE: dry run — nothing will be written\n');
+
+const all = [];
+const perStudent = new Map();
+let weeks = 0, emptyWeeks = 0;
+
+for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
+  const we = new Date(ws.getTime() + WEEK);
+  const map = await sumByStudentCat({ dateTime: { $gte: ws, $lt: we } });
+  const wk = weekKey(ws);
+  const period = `Week of ${weekLabel(ws)}`;
+  // End of the week in IST, which is when these were really earned.
+  const earnedAt = new Date(we.getTime() - 1000);
+
+  const specs = [];
+  for (const category of BOARDS) {
+    const valueOf = category === 'total'
+      ? (sid) => (map.get(sid)?.total) || 0
+      : (sid) => (map.get(sid)?.cat[category]) || 0;
+    specs.push(...weeklyPodiumSpecs({
+      rows: rankRows(students, valueOf, true),
+      category, weekKey: wk, period, earnedAt, settled: held
+    }));
+  }
+
+  weeks += 1;
+  if (!specs.length) { emptyWeeks += 1; continue; }
+
+  console.log(`${period}  (${wk})  → ${specs.length} card${specs.length === 1 ? '' : 's'}`);
+  for (const s of specs) {
+    const [, cat, , , place] = s.doc.achId.split(':');
+    console.log(`    ${place}. ${cat.padEnd(11)} ${nameOf.get(s.doc.studentId)}  ${s.doc.detail}`);
+    perStudent.set(s.doc.studentId, (perStudent.get(s.doc.studentId) || 0) + 1);
+    held.add(s.doc.achId);          // so a later week in this same run can't re-add it
+  }
+  all.push(...specs);
+}
+
+console.log(`\n${weeks} week(s) examined, ${emptyWeeks} with no qualifying placing`);
+console.log(`${all.length} card(s) to mint across ${perStudent.size} student(s)`);
+
+const top = [...perStudent.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+if (top.length) {
+  console.log('\nmost cards landing at once:');
+  for (const [sid, n] of top) console.log(`    ${String(n).padStart(3)}  ${nameOf.get(sid)}`);
+}
+
+if (!all.length) {
+  console.log('\nnothing to do.');
+} else if (!APPLY) {
+  console.log('\nre-run with --apply to write these.');
+} else {
+  await awardAchievements(all);
+  console.log(`\nwrote ${all.length} card(s).`);
+  const now = await Achievement.countDocuments({ achId: { $regex: '^rank:[^:]+:week:' } });
+  console.log(`weekly rank cards in the collection: ${now}`);
+}
+
+await mongoose.disconnect();

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -45,8 +45,57 @@ function weekLabel(weekStartUtc) {
     : `${MON[s.getUTCMonth()]} ${s.getUTCDate()} – ${MON[e.getUTCMonth()]} ${e.getUTCDate()}`;
 }
 
+// A placing shared by more than this many people isn't a placing.
+const TIE_MAX = 3;
+
+const levelOfStudent = (s) => levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0));
+
+// Sorted rows for a board. `tieAware` selects standard competition ("1224")
+// ranking — equal SP shares a rank and the next distinct SP jumps past the tie
+// (1,2,2,4). Display boards only use it once the feature is live; anything that
+// AWARDS must always use it, or a tie silently hands one of the tied students
+// a lower placing than the other.
+export function rankRows(subset, valueOf, tieAware) {
+  const sorted = subset
+    .map((s) => ({ studentId: String(s._id), name: s.name || '', level: levelOfStudent(s), sp: Math.round(valueOf(String(s._id))) }))
+    .sort((a, b) => b.sp - a.sp || a.name.localeCompare(b.name));
+  if (!tieAware) return sorted.map((r, i) => ({ ...r, rank: i + 1 }));
+  let rank = 0, prevSp = null;
+  return sorted.map((r, i) => {
+    if (r.sp !== prevSp) { rank = i + 1; prevSp = r.sp; }
+    return { ...r, rank };
+  });
+}
+
+// The podium cards a single week's board earns. Shared by the live build and
+// the backfill so the two cannot drift apart on what counts as a placing.
+// `settled` closes placings that already have a holder.
+export function weeklyPodiumSpecs({ rows, category, weekKey: wk, period, earnedAt, settled = new Set() }) {
+  const out = [];
+  for (const place of [1, 2, 3]) {
+    const tied = rows.filter((r) => r.rank === place);
+    // A placing needs a real score: the top of a table of zeroes is not a win.
+    if (!tied.length || tied.length > TIE_MAX || tied[0].sp <= 0) continue;
+    const achId = `rank:${category}:week:${wk}:${place}`;
+    if (settled.has(achId)) continue;
+    for (const r of tied) {
+      out.push({
+        filter: { studentId: r.studentId, achId },
+        doc: {
+          studentId: r.studentId, achId, kind: 'rank', board: category, place,
+          icon: PLACE_ICON[place], title: ACH_TITLE[category],
+          period, periodKey: wk, detail: `${r.sp} SP`, earnedAt
+        }
+      });
+    }
+  }
+  return out;
+}
+
+export { weekStartIST, weekKey, weekLabel, CATS };
+
 // Sum appliedDelta per (student, category) over a match window.
-async function sumByStudentCat(match) {
+export async function sumByStudentCat(match) {
   const rows = await SPTransaction.aggregate([
     { $match: match },
     { $group: { _id: { sid: '$studentId', cat: '$category' }, sp: { $sum: '$appliedDelta' } } }
@@ -90,20 +139,8 @@ export async function computeAndStoreLeaderboards() {
   const weekMap = await sumByStudentCat({ dateTime: { $gte: weekStart } });
   const allMap = await sumByStudentCat({});
 
-  const levelOf = (s) => levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0));
-  // Standard competition ("1224") ranking: equal SP shares a rank, and the next
-  // distinct SP jumps past the tie (1,2,2,4 … 1,2,2,2,2,6).
-  const build = (subset, valueOf) => {
-    const sorted = subset
-      .map((s) => ({ studentId: String(s._id), name: s.name || '', level: levelOf(s), sp: Math.round(valueOf(String(s._id))) }))
-      .sort((a, b) => b.sp - a.sp || a.name.localeCompare(b.name));
-    if (!awardsOn) return sorted.map((r, i) => ({ ...r, rank: i + 1 }));
-    let rank = 0, prevSp = null;
-    return sorted.map((r, i) => {
-      if (r.sp !== prevSp) { rank = i + 1; prevSp = r.sp; }
-      return { ...r, rank };
-    });
-  };
+  // Tie-aware ranking only once the feature is live; see rankRows.
+  const build = (subset, valueOf) => rankRows(subset, valueOf, awardsOn);
 
   const wTotal = (sid) => (weekMap.get(sid)?.total) || 0;
   const wCat = (cat) => (sid) => (weekMap.get(sid)?.cat[cat]) || 0;
@@ -155,55 +192,33 @@ export async function computeAndStoreLeaderboards() {
   //    than double the weekly card volume for the least meaningful placing.
   //  · placings below 3rd — "7th on the Polls board this week" can be 7th out of
   //    a field of thirty, which isn't the same achievement as a podium.
-  const TIE_MAX = 3;      // a place shared by more than 3 people isn't a placing
-  const ops = [];
-  let awardBoards = [];
-  let settled = new Set();
+  let ops = [];
 
   if (awardsOn) {
     const prevWeekMap = await sumByStudentCat({ dateTime: { $gte: prevWeekStart, $lt: weekStart } });
     const pTotal = (sid) => (prevWeekMap.get(sid)?.total) || 0;
     const pCat = (cat) => (sid) => (prevWeekMap.get(sid)?.cat[cat]) || 0;
-
-    awardBoards = [
-      { window: 'week', category: 'total', rows: build(students, pTotal) },
-      ...CATS.map((cat) => ({ window: 'week', category: cat, rows: build(students, pCat(cat)) }))
-    ];
+    const wk = weekKey(prevWeekStart);
 
     // Belt and braces against a placing being awarded twice with different
     // winners — a late backdated transaction could shift even a settled week's
     // standings. Once a placing has any holder it is closed, so ties (awarded
     // together in one batch) still work while a later challenger cannot claim
     // the same title.
-    const wk = weekKey(prevWeekStart);
     const already = await Achievement.find(
       { achId: { $regex: `^rank:[^:]+:week:${wk}:` } }, { achId: 1 }
     ).lean();
-    settled = new Set(already.map((a) => a.achId));
-  }
+    const settled = new Set(already.map((a) => a.achId));
 
-  const add = (r, b, place) => {
-    const wk = weekKey(prevWeekStart);
-    const achId = `rank:${b.category}:week:${wk}:${place}`;
-    if (settled.has(achId)) return;                  // this placing is already awarded
-    ops.push({
-      filter: { studentId: r.studentId, achId },
-      doc: {
-        studentId: r.studentId, achId, kind: 'rank', board: b.category, place,
-        icon: PLACE_ICON[place], title: ACH_TITLE[b.category],
-        period: `Week of ${prevLabel}`, periodKey: wk,
-        detail: `${r.sp} SP`, earnedAt: now
-      }
-    });
-  };
-  for (const b of awardBoards) {
-    for (const place of [1, 2, 3]) {
-      const tied = b.rows.filter((r) => r.rank === place);
-      // A placing needs a real score: the top of a table of zeroes is not a win.
-      if (!tied.length || tied.length > TIE_MAX || tied[0].sp <= 0) continue;
-      for (const r of tied) add(r, b, place);
+    const period = `Week of ${prevLabel}`;
+    for (const [category, valueOf] of [['total', pTotal], ...CATS.map((c) => [c, pCat(c)])]) {
+      ops.push(...weeklyPodiumSpecs({
+        rows: rankRows(students, valueOf, true),
+        category, weekKey: wk, period, earnedAt: now, settled
+      }));
     }
   }
+
   if (ops.length) await awardAchievements(ops);
 
   const reigns = awardsOn ? await trackReigns(boards, now) : { changes: 0, minted: 0 };


### PR DESCRIPTION
Mints podium cards for weeks that finished **before** achievements went live. The live build only ever awards the last completed week, so every earlier week of the internship has winners who were never recognised.

## Shared rules, not a second implementation

`rankRows` and `weeklyPodiumSpecs` are lifted out of `computeAndStoreLeaderboards` and used by both it and the backfill. A backfill that quietly disagreed with the live build about who placed would be worse than no backfill.

## Usage

```
node server/scripts/backfillWeeklyAchievements.mjs             # report only
node server/scripts/backfillWeeklyAchievements.mjs --apply
node server/scripts/backfillWeeklyAchievements.mjs --from 2026-06-01 --board poll
```

Dry run by default, and it prints the whole roll — every card, plus which students would receive the most at once. Dropping 40 cards on one person in a single moment is a decision worth seeing before you make it.

## Safety

- **Idempotent** — a placing that already has a holder is skipped, so it can never hand the same week's title to a second student, and cannot collide with a week the live build has already awarded
- **Never awards the week in progress** — its standings can still move
- **`earnedAt` is the end of the week in question**, not now, so cards land in the student's timeline where they belong

## Tested

- six-week fixture → 42 cards; re-run is a clean no-op
- in-progress week stays empty
- 2-way tie → 1224 places `[1,1,3]`, no 2nd place, distinct codes for both winners
- 4-way tie → exceeds `TIE_MAX`, awards nothing
- live build regression-checked either side of the refactor: flag off still means plain ranks and no cards; flag on still awards only the last completed week and opens reigns

Only the cron script imports `services/leaderboards.js`, so the refactor needs no app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)