### PR TITLE
fix: exclude the joining grant from weekly boards; floor the backfill range

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,6 +161,10 @@ can return the top 50 AND the caller's own rank even outside it):
 - **Windows:** `week` (fixed **Mon 00:00 IST reset**) and `all` (all-time).
 - **Categories:** `total` + per-category `attendance` / `poll` / `spa` (combined
   learn+teach) / `query`. Weekly boards rank by SP *earned in the window*;
+  the weekly **total** board excludes the `initial` joining grant
+  (`WEEKLY_EXCLUDED_CATEGORIES`) — it is awarded for starting, not for anything
+  done, and a mid-week joiner would otherwise top the board on +100 alone ahead
+  of people who actually earned. All-time is unaffected (it reads `totalSp`);
   category boards by SP *from that category*; all-time-total by `students.totalSp`.
 - **Scope:** global, plus **cohort** (onboarding `leaderboardGroup`) for the total
   board.

--- a/server/scripts/backfillWeeklyAchievements.mjs
+++ b/server/scripts/backfillWeeklyAchievements.mjs
@@ -31,7 +31,8 @@ import Student from '../models/Student.js';
 import SPTransaction from '../models/SPTransaction.js';
 import Achievement, { awardAchievements } from '../models/Achievement.js';
 import {
-  rankRows, weeklyPodiumSpecs, sumByStudentCat, weekStartIST, weekKey, weekLabel, CATS
+  rankRows, weeklyPodiumSpecs, sumByStudentCat, weeklyTotal,
+  weekStartIST, weekKey, weekLabel, CATS, WEEKLY_EXCLUDED_CATEGORIES
 } from '../services/leaderboards.js';
 
 const WEEK = 7 * 86400000;
@@ -106,11 +107,12 @@ const held = new Set(
 
 console.log(`backfill ${weekKey(from)} … ${weekKey(to)}   boards: ${BOARDS.join(', ')}`);
 console.log(`${students.length} non-excused students, ${held.size} weekly placings already held`);
+console.log(`weekly Overall SP excludes: ${WEEKLY_EXCLUDED_CATEGORIES.join(', ')}`);
 console.log(APPLY ? '\nMODE: APPLY — cards will be written\n' : '\nMODE: dry run — nothing will be written\n');
 
 const all = [];
 const perStudent = new Map();
-let weeks = 0, emptyWeeks = 0, initialWins = 0;
+let weeks = 0, emptyWeeks = 0;
 
 for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
   const we = new Date(ws.getTime() + WEEK);
@@ -123,7 +125,7 @@ for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
   const specs = [];
   for (const category of BOARDS) {
     const valueOf = category === 'total'
-      ? (sid) => (map.get(sid)?.total) || 0
+      ? (sid) => weeklyTotal(map.get(sid))
       : (sid) => (map.get(sid)?.cat[category]) || 0;
     specs.push(...weeklyPodiumSpecs({
       rows: rankRows(students, valueOf, true),
@@ -137,16 +139,7 @@ for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
   console.log(`${period}  (${wk})  → ${specs.length} card${specs.length === 1 ? '' : 's'}`);
   for (const s of specs) {
     const [, cat, , , place] = s.doc.achId.split(':');
-    // A weekly board sums EVERY category over the window, `initial` included, so
-    // a student who joined that week can top it on the +100 joining grant alone
-    // without having done anything. Flagged rather than silently filtered: the
-    // same is true of the live build, so changing it is a decision about what a
-    // weekly board means, not something this script should decide on its own.
-    const row = map.get(s.doc.studentId);
-    const initialOnly = cat === 'total' && row && (row.cat.initial || 0) === row.total && row.total > 0;
-    if (initialOnly) initialWins += 1;
-    console.log(`    ${place}. ${cat.padEnd(11)} ${nameOf.get(s.doc.studentId)}  ${s.doc.detail}` +
-                (initialOnly ? '   ⚠ joining grant only' : ''));
+    console.log(`    ${place}. ${cat.padEnd(11)} ${nameOf.get(s.doc.studentId)}  ${s.doc.detail}`);
     perStudent.set(s.doc.studentId, (perStudent.get(s.doc.studentId) || 0) + 1);
     held.add(s.doc.achId);          // so a later week in this same run can't re-add it
   }
@@ -155,12 +148,6 @@ for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
 
 console.log(`\n${weeks} week(s) examined, ${emptyWeeks} with no qualifying placing`);
 console.log(`${all.length} card(s) to mint across ${perStudent.size} student(s)`);
-if (initialWins) {
-  console.log(`\n⚠  ${initialWins} of these are Overall-SP placings won on the joining grant alone —`);
-  console.log('   the student earned nothing that week beyond the +100 for starting. A weekly board');
-  console.log('   sums every category including `initial`, and the LIVE build does the same, so this');
-  console.log('   is worth settling before go-live rather than only here.');
-}
 
 const top = [...perStudent.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
 if (top.length) {

--- a/server/scripts/backfillWeeklyAchievements.mjs
+++ b/server/scripts/backfillWeeklyAchievements.mjs
@@ -10,8 +10,9 @@
 //   node server/scripts/backfillWeeklyAchievements.mjs --from 2026-06-01
 //   node server/scripts/backfillWeeklyAchievements.mjs --apply
 //
-//   --from YYYY-MM-DD   first week to consider (default: week of the earliest SP
-//                       transaction). Snapped back to that week's Monday.
+//   --from YYYY-MM-DD   first week to consider (default: the programme start —
+//                       NOT the earliest transaction, which can be junk data).
+//                       Snapped back to that week's Monday.
 //   --to   YYYY-MM-DD   last week to consider (default: the last COMPLETED week —
 //                       the week in progress is never awarded)
 //   --board total|poll|…  restrict to one board
@@ -57,9 +58,32 @@ const lastCompleted = new Date(weekStartIST(new Date()).getTime() - WEEK);
 const firstTx = await SPTransaction.find({}, { dateTime: 1 }).sort({ dateTime: 1 }).limit(1).lean();
 if (!firstTx.length) { console.error('no SP transactions — nothing to backfill'); process.exit(1); }
 
+// The floor is the internship, NOT the earliest transaction. The ledger contains
+// rows dated well outside the programme — there is one in 2006 — and taking the
+// earliest of those as the start walked twenty years of empty weeks and minted a
+// card for a phantom "Week of Jul 31 – Aug 6, 2006". A card is a permanent public
+// credential; it should never be issued for a week the programme did not run.
+const firstStart = await Student.find(
+  { status: { $ne: 'excused' }, internshipStartDate: { $ne: null } },
+  { internshipStartDate: 1 }
+).sort({ internshipStartDate: 1 }).limit(1).lean();
+const programmeStart = firstStart.length ? new Date(firstStart[0].internshipStartDate) : null;
+
+const stray = await SPTransaction.countDocuments(
+  programmeStart ? { dateTime: { $lt: programmeStart } } : { _id: null }
+);
+if (stray) {
+  console.log(`note: ${stray} SP transaction(s) are dated before the programme started ` +
+              `(${programmeStart.toISOString().slice(0, 10)}). They are excluded from the default range; ` +
+              `pass --from explicitly to include them. Worth investigating separately — it is a ledger issue, not an achievements one.`);
+}
+
 const fromArg = arg('--from');
 const toArg = arg('--to');
-let from = weekStartIST(fromArg ? new Date(`${fromArg}T00:00:00+05:30`) : new Date(firstTx[0].dateTime));
+let from = weekStartIST(
+  fromArg ? new Date(`${fromArg}T00:00:00+05:30`)
+          : new Date(Math.max(new Date(firstTx[0].dateTime).getTime(), programmeStart?.getTime() ?? 0))
+);
 let to = toArg ? weekStartIST(new Date(`${toArg}T00:00:00+05:30`)) : lastCompleted;
 if (to > lastCompleted) {
   console.log(`--to is in the current week; clamped to the last completed week (${weekKey(lastCompleted)})`);
@@ -86,7 +110,7 @@ console.log(APPLY ? '\nMODE: APPLY — cards will be written\n' : '\nMODE: dry r
 
 const all = [];
 const perStudent = new Map();
-let weeks = 0, emptyWeeks = 0;
+let weeks = 0, emptyWeeks = 0, initialWins = 0;
 
 for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
   const we = new Date(ws.getTime() + WEEK);
@@ -113,7 +137,16 @@ for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
   console.log(`${period}  (${wk})  → ${specs.length} card${specs.length === 1 ? '' : 's'}`);
   for (const s of specs) {
     const [, cat, , , place] = s.doc.achId.split(':');
-    console.log(`    ${place}. ${cat.padEnd(11)} ${nameOf.get(s.doc.studentId)}  ${s.doc.detail}`);
+    // A weekly board sums EVERY category over the window, `initial` included, so
+    // a student who joined that week can top it on the +100 joining grant alone
+    // without having done anything. Flagged rather than silently filtered: the
+    // same is true of the live build, so changing it is a decision about what a
+    // weekly board means, not something this script should decide on its own.
+    const row = map.get(s.doc.studentId);
+    const initialOnly = cat === 'total' && row && (row.cat.initial || 0) === row.total && row.total > 0;
+    if (initialOnly) initialWins += 1;
+    console.log(`    ${place}. ${cat.padEnd(11)} ${nameOf.get(s.doc.studentId)}  ${s.doc.detail}` +
+                (initialOnly ? '   ⚠ joining grant only' : ''));
     perStudent.set(s.doc.studentId, (perStudent.get(s.doc.studentId) || 0) + 1);
     held.add(s.doc.achId);          // so a later week in this same run can't re-add it
   }
@@ -122,6 +155,12 @@ for (let ws = new Date(from); ws <= to; ws = new Date(ws.getTime() + WEEK)) {
 
 console.log(`\n${weeks} week(s) examined, ${emptyWeeks} with no qualifying placing`);
 console.log(`${all.length} card(s) to mint across ${perStudent.size} student(s)`);
+if (initialWins) {
+  console.log(`\n⚠  ${initialWins} of these are Overall-SP placings won on the joining grant alone —`);
+  console.log('   the student earned nothing that week beyond the +100 for starting. A weekly board');
+  console.log('   sums every category including `initial`, and the LIVE build does the same, so this');
+  console.log('   is worth settling before go-live rather than only here.');
+}
 
 const top = [...perStudent.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
 if (top.length) {

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -48,6 +48,26 @@ function weekLabel(weekStartUtc) {
 // A placing shared by more than this many people isn't a placing.
 const TIE_MAX = 3;
 
+// The weekly TOTAL board measures what a student did during that week, so the
+// +100 `initial` joining grant is excluded: it is awarded for starting, not for
+// anything done, and a student who joined mid-week would otherwise top the board
+// on it alone — beating people who actually earned points. Found when a backfill
+// dry run put a joining grant first with 100 SP and real poll work second on 40.
+//
+// All-time is deliberately unaffected: there the grant is a legitimate part of a
+// lifetime total, and that board reads from `students.totalSp` anyway. The
+// per-category weekly boards are unaffected too, since `initial` is not one of
+// CATS. `manual` is still counted — discretionary SP is a real award for real
+// work, unlike a joining bonus — but it is the next candidate if that changes.
+export const WEEKLY_EXCLUDED_CATEGORIES = ['initial'];
+
+export function weeklyTotal(row) {
+  if (!row) return 0;
+  let t = row.total;
+  for (const c of WEEKLY_EXCLUDED_CATEGORIES) t -= (row.cat[c] || 0);
+  return t;
+}
+
 const levelOfStudent = (s) => levelFor(Math.max(Number(s.highestSpEver) || 0, Number(s.totalSp) || 0));
 
 // Sorted rows for a board. `tieAware` selects standard competition ("1224")
@@ -142,7 +162,7 @@ export async function computeAndStoreLeaderboards() {
   // Tie-aware ranking only once the feature is live; see rankRows.
   const build = (subset, valueOf) => rankRows(subset, valueOf, awardsOn);
 
-  const wTotal = (sid) => (weekMap.get(sid)?.total) || 0;
+  const wTotal = (sid) => weeklyTotal(weekMap.get(sid));
   const wCat = (cat) => (sid) => (weekMap.get(sid)?.cat[cat]) || 0;
   const aCat = (cat) => (sid) => (allMap.get(sid)?.cat[cat]) || 0;
   const byId = new Map(students.map((s) => [String(s._id), s]));
@@ -196,7 +216,7 @@ export async function computeAndStoreLeaderboards() {
 
   if (awardsOn) {
     const prevWeekMap = await sumByStudentCat({ dateTime: { $gte: prevWeekStart, $lt: weekStart } });
-    const pTotal = (sid) => (prevWeekMap.get(sid)?.total) || 0;
+    const pTotal = (sid) => weeklyTotal(prevWeekMap.get(sid));
     const pCat = (cat) => (sid) => (prevWeekMap.get(sid)?.cat[cat]) || 0;
     const wk = weekKey(prevWeekStart);
 


### PR DESCRIPTION
Both found by the first backfill dry run against production. Nothing was written.

## 1. The range started in 2006

Default `--from` took the earliest SP transaction, and the ledger has rows dated far outside the programme, so the run walked twenty years of empty weeks and offered to mint a card for **"Week of Jul 31 – Aug 6, 2006"**. A card is a permanent public credential; it must never be issued for a week the internship did not run.

The floor is now the earliest `internshipStartDate`. Stray rows are reported rather than silently awarded — they're a ledger problem worth investigating separately.

## 2. ⚠️ A joining grant could win a week — this one changes the live board

A weekly board summed **every** category over the window, `initial` included, so a student who joined that week topped Overall SP on the +100 joining grant alone:

```
1. total   anita  100 SP   <- joining grant only
2. total   ben     40 SP   <- actually earned polls
```

A weekly board is meant to measure what someone did that week; a bonus for starting is not that. `weeklyTotal()` now subtracts `WEEKLY_EXCLUDED_CATEGORIES`, and **both the live build and the backfill use it** so they cannot disagree.

Scope is deliberately narrow:

- **all-time is unaffected** — there the grant is a legitimate part of a lifetime total, and that board reads `students.totalSp` anyway
- **per-category weekly boards are unaffected** — `initial` is not one of `CATS`
- **`manual` is still counted** — discretionary SP is a real award for real work, unlike a joining bonus. Next candidate if that view changes.

### This is visible to students

The weekly leaderboard is already live, so the next sp-refresh reorders it **regardless of `ACHIEVEMENTS_ENABLED`**. It is the first change in this feature's stream that the cohort sees today.

## Verified

```
WEEK total board : 1. worker 40   |   2. joiner 0
```

The earner places first; the joiner's +100 no longer counts. The backfill no longer offers the joining-grant card it previously would have, and its range now starts at the programme rather than 2006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)