### PR TITLE
fix(reigns): a crowded top is not a reign — apply TIE_MAX

### DIFF
--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -278,7 +278,15 @@ async function trackReigns(boards, now) {
   const closedAwarded = [];
 
   for (const b of boards.filter((x) => x.window === 'all' && x.scope === 'all')) {
-    const leaders = b.rows.filter((r) => r.rank === 1 && r.sp > 0);
+    const tiedTop = b.rows.filter((r) => r.rank === 1 && r.sp > 0);
+    // The same TIE_MAX rule the podium uses: a top shared by more than three
+    // people is not a placing, and it is certainly not a reign. This is not
+    // hypothetical here — the SPA scheme caps at 50 questions x5 + 30 peers x8 =
+    // 490 SP, and 110 students sit on exactly that, so its all-time top is a
+    // permanent 110-way tie. Without this the first build opened 110 reigns on
+    // one board. When the top is that crowded nobody reigns: any open reign
+    // closes and none is opened.
+    const leaders = tiedTop.length > TIE_MAX ? [] : tiedTop;
     const open = await BoardReign.findOne({ board: b.category, to: null });
 
     // A tie keeps the sitting holder if they are still among the leaders —


### PR DESCRIPTION
The first live build opened **110 reigns on one board**.

The SPA scheme caps at 50 questions x5 + 30 peers x8 = **490 SP**, and 110 students sit on exactly that, so the all-time SPA top is a *permanent* 110-way tie. `trackReigns` opened a reign for every tied leader.

The podium already had the rule — `TIE_MAX`, a placing shared by more than three people is not a placing — and reigns never got it. They do now: when the top is that crowded nobody reigns, any open reign closes, and none opens. A board with a ceiling most of the cohort can reach simply has no reigning champion, which is the honest answer.

```
one clear leader  -> spa reigns: 1 | open: 1
6-way tie at cap  -> spa reigns: 1 | open: 0   nobody reigns, previous reign closed
```

Found by running `buildLeaderboards` by hand at go-live rather than waiting for cron. **No cards were minted** by the bogus reigns — all were under the 7-day qualifying period — so the cleanup is a delete with nothing issued to revoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)