### PR TITLE
feat: stop minting SPA cards until the scoring is settled

### DIFF
--- a/server/scripts/backfillWeeklyAchievements.mjs
+++ b/server/scripts/backfillWeeklyAchievements.mjs
@@ -38,7 +38,7 @@ import SPTransaction from '../models/SPTransaction.js';
 import Achievement, { awardAchievements } from '../models/Achievement.js';
 import {
   rankRows, weeklyPodiumSpecs, sumByStudentCat, weeklyTotal,
-  weekStartIST, weekKey, weekLabel, CATS, WEEKLY_EXCLUDED_CATEGORIES
+  weekStartIST, weekKey, weekLabel, CATS, WEEKLY_EXCLUDED_CATEGORIES, AWARD_EXCLUDED_BOARDS
 } from '../services/leaderboards.js';
 
 const WEEK = 7 * 86400000;
@@ -50,7 +50,10 @@ const arg = (name, fallback = null) => {
 };
 const APPLY = process.argv.includes('--apply');
 const ONLY_BOARD = arg('--board');
-const BOARDS = ONLY_BOARD ? [ONLY_BOARD] : ['total', ...CATS];
+// An explicit --board can still target an excluded one deliberately; the
+// default list honours the exclusion.
+const BOARDS = ONLY_BOARD ? [ONLY_BOARD]
+  : ['total', ...CATS].filter((b) => !AWARD_EXCLUDED_BOARDS.includes(b));
 
 const URI = process.env.MONGO_URI;
 if (!URI) {
@@ -147,6 +150,7 @@ const held = new Set(
 console.log(`backfill ${weekKey(from)} … ${weekKey(to)}   boards: ${BOARDS.join(', ')}`);
 console.log(`${students.length} non-excused students, ${held.size} weekly placings already held`);
 console.log(`weekly Overall SP excludes: ${WEEKLY_EXCLUDED_CATEGORIES.join(', ')}`);
+if (AWARD_EXCLUDED_BOARDS.length) console.log(`boards minting no cards: ${AWARD_EXCLUDED_BOARDS.join(', ')}`);
 console.log(APPLY ? '\nMODE: APPLY — cards will be written\n' : '\nMODE: dry run — nothing will be written\n');
 
 const all = [];

--- a/server/services/leaderboards.js
+++ b/server/services/leaderboards.js
@@ -48,6 +48,16 @@ function weekLabel(weekStartUtc) {
 // A placing shared by more than this many people isn't a placing.
 const TIE_MAX = 3;
 
+// Boards that mint no cards, weekly or reign, while their scoring is unsettled.
+//
+// `spa` is out for now: the scheme caps at 50 questions x5 + 30 peers x8 = 490
+// SP and 110 students already sit on exactly that, so "top of Peer Learning" is
+// a permanent mass tie and the weekly placings are decided by who reached the
+// ceiling first rather than by who did most. TIE_MAX already stops it minting a
+// reign; this stops the weekly cards too, until the scoring is reworked.
+// Removing 'spa' from this list is all it takes to turn them back on.
+export const AWARD_EXCLUDED_BOARDS = ['spa'];
+
 // The weekly TOTAL board measures what a student did during that week, so the
 // +100 `initial` joining grant is excluded: it is awarded for starting, not for
 // anything done, and a student who joined mid-week would otherwise top the board
@@ -231,7 +241,9 @@ export async function computeAndStoreLeaderboards() {
     const settled = new Set(already.map((a) => a.achId));
 
     const period = `Week of ${prevLabel}`;
-    for (const [category, valueOf] of [['total', pTotal], ...CATS.map((c) => [c, pCat(c)])]) {
+    const awardable = [['total', pTotal], ...CATS.map((c) => [c, pCat(c)])]
+      .filter(([category]) => !AWARD_EXCLUDED_BOARDS.includes(category));
+    for (const [category, valueOf] of awardable) {
       ops.push(...weeklyPodiumSpecs({
         rows: rankRows(students, valueOf, true),
         category, weekKey: wk, period, earnedAt: now, settled
@@ -277,7 +289,9 @@ async function trackReigns(boards, now) {
   const ops = [];
   const closedAwarded = [];
 
-  for (const b of boards.filter((x) => x.window === 'all' && x.scope === 'all')) {
+  const reignable = boards.filter((x) => x.window === 'all' && x.scope === 'all'
+    && !AWARD_EXCLUDED_BOARDS.includes(x.category));
+  for (const b of reignable) {
     const tiedTop = b.rows.filter((r) => r.rank === 1 && r.sp > 0);
     // The same TIE_MAX rule the podium uses: a top shared by more than three
     // people is not a placing, and it is certainly not a reign. This is not


### PR DESCRIPTION
The SPA scheme caps at 50 questions x5 + 30 peers x8 = **490 SP**, and 110 students already sit on exactly that. So "top of Peer Learning" is a permanent mass tie, and the weekly placings underneath it reward whoever reached the ceiling first rather than whoever did most — not something worth issuing a permanent public credential for.

`AWARD_EXCLUDED_BOARDS` turns a board off for **both** weekly cards and reigns. `TIE_MAX` (#158) already blocked the reign; this covers the weekly cards. The backfill honours it too, though `--board spa` can still target it deliberately.

Reversing it is deleting `'spa'` from one array.

The 21 SPA cards already minted by the backfill are being removed separately — none were shared, none had verify-page views, so nothing is in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)