### PR TITLE
fix(pipeline): repair sync-attendance-records, and put the cron in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ sp-runs/
 
 # student data — LOCAL ONLY, never commit (untracked 2026-07-14)
 data/
+
+# server-side run output
+logs/
+sp-runs/
+*.bak-*

--- a/HANDOFF_BUTTON_SP_SYNC.md
+++ b/HANDOFF_BUTTON_SP_SYNC.md
@@ -1,0 +1,179 @@
+# HANDOFF → Samagama admin: fix the "SP button" not updating
+
+**For:** the `samagama` / `samagama1` user (you have sudo + the prod `.env` with admin Mongo creds).
+**From:** the Sakshi side (scoring is healthy; the problem is the mirror back into your DB).
+**Goal:** (1) make the SP shown on the samagama.in button correct **right now**, and (2) make sure it **keeps** showing the latest SP automatically, forever.
+
+You can run this whole file top to bottom. Every step is safe (dry-run first, backups noted). Where a decision exists, the answer is already **yes** — just run the command.
+
+---
+
+## 0. 30-second background (why this happens)
+
+There are **two** SP numbers, from **two** databases:
+
+| Shown where | Read from | Owner | State |
+|---|---|---|---|
+| `/spurti` dashboard (after the click) | `sakshi_spurti.students.totalSp` | Sakshi | ✅ correct & current |
+| **The button on samagama.in** | `chatengine.users.spPoints` | **You (Samagama)** | ❌ stale |
+
+Scoring now lives on the **Sakshi side**: a rubric writes `sakshi_spurti.sptransactions` every 6h (verified current — 52k+ txns, scored through today). The button shows `chatengine.users.spPoints`, which is a **mirror** produced by your script **`/var/samagama/server/sync-spurti-from-sakshi.js`** (it copies `sakshi_spurti.sptransactions` → `chatengine.spledgers` and recomputes each `users.spPoints`).
+
+**That mirror has stopped running successfully.** Everything below fixes the mirror and makes it reliable. (The Sakshi side needs no changes.)
+
+---
+
+## 1. Fix it RIGHT NOW (manual mirror run)
+
+Run as the same user the cron uses. Try `samagama` first; if that account doesn't exist use `samagama1`.
+
+```bash
+# 1a. Preview — reads Sakshi's ledger, writes NOTHING. Confirms it can connect + read.
+sudo -u samagama bash -lc 'cd /var/samagama/server && DRY_RUN=1 node sync-spurti-from-sakshi.js'
+```
+
+**Expected good output** is something like:
+```
+her sptransactions: 52030 | mapped rows: 52030 | bad/skipped: 0 | distinct emails: 3074
+our spledgers now: NNNNN (will be REPLACED by the 52030 mapped rows)
+spPoints (sum of her deltas) sample:
+  someone@example.com               current=645 -> 790
+DRY_RUN — would wipe ... insert 52030, recompute spPoints for 3074 emails.
+```
+- If you see `distinct emails: ~3000` and a sample where `current=` differs from the `-> ` target, the script works and the data is just stale → continue to 1b.
+- If it **errors or aborts** here, skip to **§2** (it prints the exact reason — DB auth, `ABORT: source returned N rows`, a stack trace, etc.).
+
+```bash
+# 1b. Apply for real — wipe+reload chatengine.spledgers and recompute every users.spPoints.
+sudo -u samagama bash -lc 'cd /var/samagama/server && node sync-spurti-from-sakshi.js'
+```
+
+**The button is now correct.** Verify with §4. Then do §3 so it stays correct.
+
+> Safety: the script self-aborts without touching anything if Sakshi's ledger returns < 5000 rows (guards against an empty read). It is idempotent — safe to re-run anytime.
+
+---
+
+## 2. Find why it stopped (only if §1a errored, or to confirm the root cause)
+
+```bash
+# What the cron has been logging:
+sudo -u samagama tail -60 /var/samagama/server/logs/updatespurti.log
+sudo -u samagama tail -60 /var/samagama/server/logs/sp-pipeline.log
+# When did the mirror cron last actually run? (mtime = last run)
+sudo -u samagama stat -c '%n  last run: %y' /var/samagama/server/logs/updatespurti.log
+```
+
+Match what you see to the fix:
+
+| Symptom in the log / output | Cause | Fix |
+|---|---|---|
+| Log mtime is **days old**, nothing recent | the every-2h cron isn't firing | §3.A (repair the cron file) |
+| `ABORT: source returned N rows (< 5000)` | ran while Sakshi's rubric was mid-wipe | harmless; next run recovers. Bump frequency in §3.C |
+| `MongoServerError` / `Unauthorized` / auth | `.env` Mongo creds changed | fix `MONGO_URI` in `/var/samagama/server/.env`, re-run §1b |
+| `Cannot find module` / `models/User` | a moved/renamed file | restore the path the script `require`s, re-run §1b |
+| `sp-pipeline.log` shows **`ABORT: sp-rubric-build failed`** | the daily pipeline dies at the old rubric **before** its sync stage | §3.B (remove the obsolete rubric stage) |
+| `JavaScript heap out of memory` in `sp-pipeline.log` | the 2GB zoom stage OOM'd, aborting the run | §3.B decouples the sync so this no longer blocks the button |
+
+In almost all cases the **single most important durable fix is §3.A + §3.B below** — they make the button refresh on its own, decoupled from the fragile daily pipeline.
+
+---
+
+## 3. Make it reliable FOREVER
+
+### 3.A — Guarantee the standalone mirror cron exists and is valid
+
+This is the canonical, self-contained job that keeps the button fresh, independent of everything else. Re-install it exactly (idempotent):
+
+```bash
+sudo tee /etc/cron.d/updatespurti >/dev/null <<'CRON'
+# #updatespurti — mirror Sakshi's sakshi_spurti.sptransactions into our SP store
+# (chatengine.spledgers + users.spPoints) so the samagama.in SP button + /spurti
+# always show the latest score. Wipe-and-reload; idempotent; self-aborts on empty read.
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# Hourly at :20 — Sakshi re-scores every 6h (~:45), so :20 always catches the freshest data.
+20 * * * * samagama cd /var/samagama/server && /usr/bin/node sync-spurti-from-sakshi.js >> /var/samagama/server/logs/updatespurti.log 2>&1
+CRON
+sudo chown root:root /etc/cron.d/updatespurti
+sudo chmod 644 /etc/cron.d/updatespurti     # cron.d files MUST be 644, root-owned, and have NO dot in the name
+sudo systemctl restart cron                  # pick up the change
+```
+
+> This changes the old **every-2-hours** schedule to **hourly** so the button is never more than ~1h behind. (The job is cheap and idempotent.) If the cron user on your box is `samagama1`, change `samagama` in the line above to `samagama1`.
+
+Confirm cron will run it:
+```bash
+systemctl is-active cron        # -> active
+grep -H . /etc/cron.d/updatespurti
+```
+
+### 3.B — Stop the daily pipeline from running the OLD rubric (it now fights Sakshi's and can block the sync)
+
+Scoring moved to the Sakshi side. Your `/var/samagama/server/sp-pipeline.sh` still runs its own old `sp-rubric-build.js` (Stage 2), which (a) overwrites `sakshi_spurti.sptransactions` with stale logic and (b) **fail-fasts the whole script before reaching its own sync stage** when it errors. Remove that stage.
+
+```bash
+# Back up first
+sudo -u samagama cp -a /var/samagama/server/sp-pipeline.sh /var/samagama/server/sp-pipeline.sh.bak.$(date -u +%Y%m%dT%H%M%SZ)
+```
+
+Then edit `/var/samagama/server/sp-pipeline.sh` and **delete the entire Stage 2 block** — these lines:
+
+```bash
+echo "=== $(ts) STAGE 2/3: sp-rubric-build APPLY=1 ==="
+APPLY=1 OUT_DIR=/var/samagama/server/sp-runs $NODE $HEAP sp-rubric-build.js
+rc=$?; echo "--- $(ts) stage2 exit=$rc ---"
+[ $rc -eq 0 ] || { echo "ABORT: sp-rubric-build failed (rc=$rc)"; exit 1; }
+```
+
+Leave Stage 1 (zoom ingest → it feeds Sakshi's mirror), Stage 3 (`sync-spurti-from-sakshi`), and Stages 4–6 as they are. Result: the daily pipeline ingests Zoom and mirrors SP, but no longer runs a competing rubric and no longer aborts before the sync.
+
+> Do **NOT** touch Stage 1 (`zoom-update.js`) — Sakshi's rubric depends on the `zoom_*` data it mirrors. Only Stage 2 (the rubric) is being removed.
+
+### 3.C — (already covered) freshness
+
+With 3.A hourly + 3.B trimmed, the button tracks Sakshi's score within ~1 hour, and a transient failure of any one run self-heals on the next hour. Nothing else is required.
+
+---
+
+## 4. Verify the button is now correct
+
+Pick any active student's email and compare the two sides. Run as samagama (uses your prod `.env` admin creds):
+
+```bash
+sudo -u samagama node -e '
+require("/var/samagama/server/node_modules/dotenv").config({path:"/var/samagama/server/.env"});
+const {MongoClient}=require("/var/samagama/server/node_modules/mongodb");
+(async()=>{
+  const base=(process.env.MONGO_URI||"").replace(/\/[^/?]*(\?.*)?$/,"");
+  const c=await MongoClient.connect(process.env.MONGO_URI);              // chatengine (your DB)
+  const s=await MongoClient.connect(base+"/sakshi_spurti?authSource=admin");
+  // top scorer on the authoritative side
+  const top=await s.db().collection("students").find({}).sort({totalSp:-1}).limit(1).next();
+  const email=top.email;
+  const sak=top.totalSp;
+  const u=await c.db().collection("users").findOne({email},{projection:{spPoints:1,spPointsUpdated:1}});
+  console.log("email            :",email);
+  console.log("Sakshi totalSp   :",sak,"(authoritative — what /spurti shows)");
+  console.log("Button spPoints  :",u?u.spPoints:"(no user)","(what samagama.in shows)");
+  console.log("spPointsUpdated  :",u&&u.spPointsUpdated);
+  console.log(sak===(u&&u.spPoints)?"MATCH ✅ button is in sync":"MISMATCH ❌ re-run §1b");
+  await c.close(); await s.close();
+})().catch(e=>{console.error(e.message);process.exit(1)});'
+```
+
+- `MATCH ✅` → done. The hourly cron (3.A) keeps it that way.
+- `MISMATCH ❌` → re-run §1b; if it persists, the totals genuinely differ — paste the §2 log output back to the Sakshi side.
+
+---
+
+## 5. Summary of what you changed
+
+1. Ran `sync-spurti-from-sakshi.js` once by hand → button correct immediately.
+2. Re-installed `/etc/cron.d/updatespurti` as an **hourly** standalone mirror → button auto-refreshes ≤1h, resilient to single-run failures.
+3. Removed the obsolete **Stage 2 rubric** from `sp-pipeline.sh` → daily pipeline no longer competes with Sakshi's scoring or aborts before its sync stage.
+
+No Sakshi-side change is needed — `sakshi_spurti` is the single source of truth and is already current. If anything looks off on the **values** themselves (not the freshness), that's a Sakshi-side rubric question; everything here is purely the mirror into your `chatengine` DB.
+
+---
+*Generated 2026-06-29. Script referenced: `/var/samagama/server/sync-spurti-from-sakshi.js` (unchanged — only scheduling/pipeline around it is fixed).*

--- a/HANDOFF_TO_SAMAGAMA.md
+++ b/HANDOFF_TO_SAMAGAMA.md
@@ -1,0 +1,103 @@
+# Spurti — Handoff to the `samagama` owner
+
+**From:** Sakshi (Spurti web app + `sakshi_spurti` DB)
+**Date:** 2026-06-27
+
+**TL;DR:** The Spurti SP pipeline (which runs as the `samagama` user) **stopped
+producing data after 23 June**. The student dashboard is up and serving fine,
+but the SP numbers are stale (frozen at 23 Jun). The missing days **cannot be
+scored by anyone until the Zoom fetch runs again**, and that only runs under
+`samagama` — Sakshi has no access to do it. Steps to fix are in Section 4.
+
+---
+
+## 1. What is working
+
+- **Web app / student dashboard:** `https://samagama.in/spurti/` → HTTP 200.
+- **APIs:** `/spurti/api/leaderboard`, `/spurti/api/config` → 200 with live data.
+- **Button / login handoff:** verified end-to-end with a real student — signed
+  token → `/spurti/auth?token=…` → cookie set → `/api/me` returns the student's
+  SP, rank, and transactions. **Students can see their dashboard.**
+
+This is **not an outage.** The only problem is data freshness.
+
+## 2. Why the data is not ingested
+
+The SP data pipeline (your cron jobs in `/var/samagama/server`, running as
+`samagama`) **stopped after 23 June 2026**:
+
+| Signal | Value |
+|--------|-------|
+| Latest `zoom_data` meeting (and the `sakshi_spurti.zoom_*` mirror) | **2026-06-23** |
+| Latest `sptransactions` (scored SP) | **2026-06-23** |
+| Latest `sp-runs/` APPLY backup | **2026-06-16** |
+| Days missing | **24, 25, 26, (27) June** |
+
+Cron itself is alive (the nightly `sp-runs` prune ran on 26 Jun 21:45), so **a
+script is failing, not the scheduler** — almost certainly `zoom-update.js`
+failing on Zoom auth (expired/revoked S2S token). That starves everything
+downstream: no new `zoom_data` → nothing for `sp-rubric-build.js` to score →
+SP frozen at 23 Jun. **The missing days don't exist in any database yet**, so
+they can't be scored until the Zoom fetch succeeds again.
+
+## 3. What access Sakshi has (and why Sakshi can't fix this)
+
+| Resource | Sakshi access |
+|----------|---------------|
+| `sakshi_spurti` database | **read/write** (this is all Sakshi owns) |
+| `zoom_data` database | **none** — "not authorized" |
+| `chatengine` database (roster, start dates) | **none** — "not authorized" |
+| `/var/samagama/server/.env` (Zoom + admin creds) | **none** — `600`, samagama-only |
+| `/var/samagama/server/logs/` | **none** — `drwx-w---- samagama` |
+| Zoom S2S credentials | **none** |
+| `sudo` to `samagama` | **none** (no passwordless sudo) |
+
+Everything Spurti needs (the `zoom_*` data and the `candidates` roster) only
+reaches Sakshi because **your scripts push it into `sakshi_spurti`**. Sakshi
+cannot pull from the source databases, cannot read the Zoom credentials, cannot
+read the pipeline logs, and cannot run the pipeline. So when the samagama-side
+pipeline breaks, **Sakshi can only serve whatever was last pushed (23 Jun) and
+cannot intervene.** Fixing ingestion must be done as `samagama`.
+
+## 4. How to fix it (please run as `samagama`)
+
+### Step 1 — Confirm the cause (read the logs)
+```bash
+tail -60 /var/samagama/server/logs/sakshi-zoom.log
+tail -60 /var/samagama/server/logs/sp-pipeline.log
+```
+Look for a Zoom error (401 / invalid_client / expired token) in `zoom-update.js`.
+**If the Zoom token is dead, renew the Zoom Server-to-Server OAuth app first**
+(`ZOOM_ACCOUNT_ID` / `ZOOM_CLIENT_ID` / `ZOOM_CLIENT_SECRET` in
+`/var/samagama/server/.env`).
+
+### Step 2 — Fetch the missing Zoom days
+```bash
+cd /var/samagama/server
+node --max-old-space-size=2048 zoom-update.js --from 2026-06-24 --to 2026-06-27
+```
+
+### Step 3 — Score (dry preview first, then apply)
+```bash
+node sp-rubric-build.js                       # DRY: prints counts, writes nothing
+APPLY=1 OUT_DIR=/var/samagama/server/sp-runs \
+  node --max-old-space-size=2048 sp-rubric-build.js
+```
+
+### Step 4 — Refresh the records the dashboard reads
+```bash
+node sync-attendance-records.js
+node sync-poll-records.js
+# (sync-spurti-from-sakshi.js too, if the samagama platform still displays SP)
+```
+
+After Step 4, tell me and I'll **verify from Sakshi's side** (read-only): new
+`Day 34–37` sessions present, transaction count up, a sample student's
+`sum(appliedDelta) == totalSp`, and `/api/me` reflecting the new days. Your
+normal cron should then resume on its own once the Zoom token is valid — these
+manual steps just backfill the gap immediately.
+
+---
+
+### What I need back from you
+- Output of **Step 1** (the two `tail` commands) — so we confirm it's the Zoom token.

--- a/pipeline/sync-attendance-records.cjs
+++ b/pipeline/sync-attendance-records.cjs
@@ -14,8 +14,21 @@
  *
  * Safe to re-run (upsert by email+sessionLabel).
  */
-const { MongoClient, ObjectId } = require('/var/samagama/server/node_modules/mongodb');
-require('/var/samagama/server/node_modules/dotenv').config({ path: '/var/samagama/server/.env' });
+// Local modules and local .env. This used to reach into
+// /var/samagama/server/... from when scoring lived on the samagama side; after
+// the 2026-06-28 move the sakshi user cannot READ that .env, so dotenv loaded
+// nothing, MONGO_URI came back undefined, and MongoClient.connect(undefined)
+// died with "Cannot read properties of undefined (reading 'startsWith')" —
+// which looks nothing like a permissions problem. Run from the repo root.
+const { MongoClient, ObjectId } = require('mongodb');
+require('dotenv').config();
+
+if (!process.env.MONGO_URI) {
+  // Fail with something legible instead of the startsWith error above.
+  console.error('MONGO_URI is not set. Run this from the repo root so .env is picked up:');
+  console.error('  cd ~/spurti && node pipeline/sync-attendance-records.cjs');
+  process.exit(1);
+}
 
 const REASON_RE = /present (\d+) of (\d+) min \(([\d.]+)%\)/;
 
@@ -30,7 +43,21 @@ const REASON_RE = /present (\d+) of (\d+) min \(([\d.]+)%\)/;
     .find({ category: 'attendance' })
     .toArray();
 
-  let upserted = 0, skipped = 0;
+  // Batched, not one await per row. This used to issue a separate round trip
+  // for every attendance transaction — around 60,000 of them, sequentially,
+  // which pushed the box's load average past 20 and would have tripped
+  // sp-refresh's own MAX_LOAD guard and skipped the cycle. Same writes, same
+  // upsert semantics, a few dozen round trips instead.
+  const BATCH = 1000;
+  let upserted = 0, skipped = 0, ops = [];
+
+  const flush = async () => {
+    if (!ops.length) return;
+    const r = await db.collection('attendancerecords').bulkWrite(ops, { ordered: false });
+    upserted += (r.upsertedCount || 0) + (r.modifiedCount || 0);
+    ops = [];
+  };
+
   for (const tx of txns) {
     const email = (tx.email || '').toLowerCase().trim();
     if (!email) { skipped++; continue; }
@@ -44,27 +71,30 @@ const REASON_RE = /present (\d+) of (\d+) min \(([\d.]+)%\)/;
     const attendancePercentage = m ? Number(m[3]) : 0;
     const studentId = studentById.get(email) || null;
 
-    await db.collection('attendancerecords').updateOne(
-      { email, sessionLabel },
-      {
-        $set: {
-          email,
-          sessionLabel,
-          qualified,
-          attendedMinutes,
-          totalSessionMinutes,
-          attendancePercentage,
-          ...(studentId ? { studentId } : {}),
-          updatedAt: new Date(),
+    ops.push({
+      updateOne: {
+        filter: { email, sessionLabel },
+        update: {
+          $set: {
+            email,
+            sessionLabel,
+            qualified,
+            attendedMinutes,
+            totalSessionMinutes,
+            attendancePercentage,
+            ...(studentId ? { studentId } : {}),
+            updatedAt: new Date(),
+          },
+          $setOnInsert: { createdAt: new Date() },
         },
-        $setOnInsert: { createdAt: new Date() },
+        upsert: true,
       },
-      { upsert: true }
-    );
-    upserted++;
+    });
+    if (ops.length >= BATCH) await flush();
   }
+  await flush();
 
-  console.log(`Done. upserted=${upserted} skipped=${skipped}`);
+  console.log(`Done. written=${upserted} skipped=${skipped} of ${txns.length} attendance txns`);
 
   // Verify for harsh007rana
   const check = await db.collection('attendancerecords')

--- a/sp-refresh.sh
+++ b/sp-refresh.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# sp-refresh.sh — sakshi-side Spurti SP refresh.
+#
+# Re-scores SP from the sakshi_spurti mirrors and then refreshes the derived
+# Levels / Trophy-League / Legend fields, so any new SP change is picked up and
+# shown to students. Owned by sakshi (see memory: spurti-scoring-ownership).
+#
+# Steps (step 2 only runs if step 1 succeeds):
+#   1. pipeline/sp-rubric-build-mirror.cjs  APPLY=1  (auto-backs-up sptransactions
+#      + students into sp-runs/ before writing)
+#   2. sync-levels.cjs                       (idempotent, derived-only)
+#
+# The /spurti app reads sakshi_spurti live, so students see the new numbers
+# immediately; the samagama-side `updatespurti` cron carries them into chatengine
+# on its next even-hour run. No app restart needed.
+#
+# Self-flocking (single instance) so manual runs and cron can't overlap.
+# Scheduled from the sakshi crontab at 06:00/12:00/18:00/00:00 UTC
+# = 11:30 / 17:30 / 23:30 / 05:30 IST (every 6h, anchored on 11:30 IST).
+set -euo pipefail
+
+REPO=/home/sakshi/spurti
+OUT_DIR="$REPO/sp-runs"
+LOG="$REPO/logs/sp-refresh.log"
+NODE=/usr/bin/node
+
+cd "$REPO"
+mkdir -p "$OUT_DIR" "$REPO/logs"
+
+# Single-instance guard: re-exec under an exclusive lock on our own fd.
+exec 9>"/tmp/sp-refresh.lock"
+if ! flock -n 9; then
+  echo "[$(date -u +%FT%TZ)] another sp-refresh is running; skipping" >> "$LOG"
+  exit 0
+fi
+
+log() { echo "[$(date -u +%FT%TZ)] $*" >> "$LOG"; }
+
+log "=== sp-refresh start ==="
+
+# Load guard: the APPLY rewrites ~90k sptransactions; doing that under heavy load
+# has OOM-crashed mongod (2026-08-04). Wait for the 1-min load to drop below
+# MAX_LOAD; if it stays high for ~30 min, skip this cycle (the next cron retries).
+# Override with FORCE=1 for an urgent manual run.
+MAX_LOAD="${MAX_LOAD:-12}"
+if [ "${FORCE:-0}" != "1" ]; then
+  waited=0
+  while :; do
+    load1=$(awk '{print int($1)}' /proc/loadavg)
+    if [ "$load1" -lt "$MAX_LOAD" ]; then break; fi
+    if [ "$waited" -ge 1800 ]; then
+      log "load ${load1} >= ${MAX_LOAD} for 30 min; SKIPPING this cycle (next cron retries)"
+      exit 0
+    fi
+    log "load ${load1} >= ${MAX_LOAD}; waiting 60s (waited ${waited}s)"
+    sleep 60; waited=$((waited+60))
+  done
+fi
+
+# Step 0: pull the latest Spandan evening-poll sessions (incremental). Non-fatal:
+# if the API is down we still re-score with whatever is already mirrored.
+if "$NODE" pipeline/spandan-poll-fetch.cjs >> "$LOG" 2>&1; then
+  log "spandan fetch ok"
+else
+  log "spandan fetch FAILED (non-fatal) — scoring with existing spandan_polls"
+fi
+
+# Step 1: re-score (APPLY). Backs up before writing.
+if APPLY=1 OUT_DIR="$OUT_DIR" "$NODE" --max-old-space-size=2048 \
+     pipeline/sp-rubric-build-mirror.cjs >> "$LOG" 2>&1; then
+  log "rubric APPLY ok"
+else
+  log "rubric APPLY FAILED — skipping sync-levels (SP ledger untouched on failure)"
+  exit 1
+fi
+
+# Step 2: refresh derived Levels / Trophy League / Legend fields.
+if "$NODE" sync-levels.cjs >> "$LOG" 2>&1; then
+  log "sync-levels ok"
+else
+  log "sync-levels FAILED — SP applied but derived level fields may be stale"
+  exit 1
+fi
+
+# Step 2b: fold attendance minutes into attendancerecords (drives the My-Journey
+# 3600-minute standup goal). Parses "present X of Y min (Z%)" from the attendance
+# transactions the rubric just wrote. Non-fatal — SP is unaffected if this fails.
+if "$NODE" pipeline/sync-attendance-records.cjs >> "$LOG" 2>&1; then
+  log "sync-attendance-records ok"
+else
+  log "sync-attendance-records FAILED (non-fatal) — attendance minutes/3600 goal may be stale"
+fi
+
+# Step 3: rebuild the SP-trajectory snapshot (cohort/group reference lines for the
+# student trajectory modal). Non-fatal — the student's own line is always live.
+if "$NODE" server/scripts/buildTrajectories.js >> "$LOG" 2>&1; then
+  log "trajectory snapshot ok"
+else
+  log "trajectory snapshot FAILED (non-fatal) — cohort lines may be stale"
+fi
+
+# Step 3b: rebuild cached leaderboard boards (weekly/all-time/category/cohort).
+if "$NODE" server/scripts/buildLeaderboards.js >> "$LOG" 2>&1; then log "leaderboards ok"; else log "leaderboards FAILED (non-fatal)"; fi
+
+# Housekeeping: weekly retention — keep last 2 days of dailies + 1 snapshot/week for 12 weeks.
+OUT_DIR="$OUT_DIR" WEEKS=12 DAILY_DAYS=2 "$REPO/sp-runs-retention.sh" >> "$LOG" 2>&1 || true
+
+log "=== sp-refresh done ==="

--- a/sp-runs-retention.sh
+++ b/sp-runs-retention.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# sp-runs-retention.sh — weekly retention for Spurti SP-refresh backups.
+#
+# Policy:
+#   * Keep the last DAILY_DAYS days of ALL run artifacts (fresh rollback safety).
+#   * Keep ONE snapshot per ISO week (the earliest run of the week = Monday's
+#     early-morning run) for the last WEEKS weeks.
+#   * Delete everything else under sp-runs/ that matches the mirror patterns.
+#
+# Artifacts share a timestamp token, e.g. 2026-07-14T0600Z, across:
+#   sp_backup_mirror_<ts>/   sp_ledger_mirror_<ts>.csv   sp_set_aside_mirror_<ts>.csv
+#
+# Set DRY_RUN=1 to only print what WOULD be deleted (no changes).
+set -euo pipefail
+
+OUT_DIR="${OUT_DIR:-/home/sakshi/spurti/sp-runs}"
+WEEKS="${WEEKS:-12}"
+DAILY_DAYS="${DAILY_DAYS:-2}"
+DRY_RUN="${DRY_RUN:-0}"
+
+cd "$OUT_DIR" 2>/dev/null || { echo "no $OUT_DIR"; exit 0; }
+now=$(date -u +%s)
+
+# Union of all run timestamps, from all three artifact types.
+tss=$( { ls -1d sp_backup_mirror_*/ 2>/dev/null | sed -E 's#^sp_backup_mirror_##; s#/$##';
+         ls -1 sp_ledger_mirror_*.csv 2>/dev/null | sed -E 's#^sp_ledger_mirror_##; s#\.csv$##';
+         ls -1 sp_set_aside_mirror_*.csv 2>/dev/null | sed -E 's#^sp_set_aside_mirror_##; s#\.csv$##';
+       } | sort -u )
+
+declare -A keep
+declare -A week_earliest
+
+for ts in $tss; do
+  d=$(echo "$ts" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}') || true
+  [ -z "$d" ] && continue
+  epoch=$(date -u -d "$d" +%s 2>/dev/null) || continue
+  age_days=$(( (now - epoch) / 86400 ))
+
+  # Rule 1: last DAILY_DAYS days -> keep (fresh rollback safety)
+  if [ "$age_days" -le "$DAILY_DAYS" ]; then keep[$ts]=1; fi
+
+  # Rule 2: within WEEKS weeks -> track earliest ts per ISO week
+  if [ "$age_days" -le $((WEEKS*7)) ]; then
+    wk=$(date -u -d "$d" +%G-W%V)
+    cur=${week_earliest[$wk]:-}
+    if [ -z "$cur" ] || [[ "$ts" < "$cur" ]]; then week_earliest[$wk]=$ts; fi
+  fi
+done
+for wk in "${!week_earliest[@]}"; do keep[${week_earliest[$wk]}]=1; done
+
+kept=0; deleted=0
+for ts in $tss; do
+  if [ -n "${keep[$ts]:-}" ]; then
+    kept=$((kept+1)); [ "$DRY_RUN" = "1" ] && echo "KEEP   $ts"
+  else
+    deleted=$((deleted+1))
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "DELETE $ts"
+    else
+      rm -rf "sp_backup_mirror_$ts" "sp_ledger_mirror_$ts.csv" "sp_set_aside_mirror_$ts.csv" 2>/dev/null || true
+    fi
+  fi
+done
+
+echo "---"
+echo "policy: keep last ${DAILY_DAYS}d dailies + 1/week for ${WEEKS} weeks"
+echo "kept=$kept deleted=$deleted dry_run=$DRY_RUN"


### PR DESCRIPTION
Both found while asking why SP is recomputed from scratch every run. (It isn't the bottleneck — the full rebuild of 98k transactions takes **74s** of a **467s** run; `sync-levels` takes **384s**. That's a separate thread.)

## 1. `sync-attendance-records` has never once succeeded

**31 failed runs, 0 ok**, since it was added on 4 Aug.

It required `mongodb` and `dotenv` out of `/var/samagama/server/...`, from when scoring lived on the samagama side. After the 2026-06-28 move the `sakshi` user cannot **read** that `.env`, so dotenv loaded nothing, `MONGO_URI` came back undefined, and `MongoClient.connect(undefined)` died with:

```
Cannot read properties of undefined (reading 'startsWith')
```

— which looks nothing like a permissions problem. The step is marked non-fatal, so it failed quietly every six hours for eight days.

This matters beyond tidiness: the collection it populates drives the **My-Journey 3,600-minute goal** and the **3,600-Minute Club achievement**.

## 2. It also wrote one awaited `updateOne` per transaction

Around **60,000 sequential round trips**. Running it by hand took the box's load average past **21**, which would have tripped `sp-refresh`'s own `MAX_LOAD=12` guard and skipped the cycle. Now batched via `bulkWrite` in chunks of 1000 — same writes, same upsert semantics, a few dozen round trips.

## 3. The production cron was not in version control

`sp-refresh.sh` and `sp-runs-retention.sh` existed **only on the server** — no history, and gone with the box. Both now tracked, along with the two handoff docs. `logs/` and `sp-runs/` gitignored.

`sync-levels.cjs` and `sp-rubric-build-mirror.cjs` were checked against the running copies and are byte-identical, so nothing had drifted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)