### PR TITLE
feat(pipeline): alert on repeatedly failing steps, and show it on the dashboard

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1627,6 +1627,7 @@ function AdminView({ admin, auth, onBack }) {
       {tab === 'live' && <LiveAnalytics active={active} />}
       {tab === 'analytics' && <Analytics data={analytics} />}
       {tab === 'achievements' && <AdminAchievements data={analytics?.sharing} reigns={analytics?.reigns} />}
+      {tab === 'analytics' && <PipelineHealth data={analytics?.pipeline} />}
       {tab === 'students' && <AllStudentsPanel stats={stats} onStudent={loadStudent} auth={auth} />}
       {studentProfile && <div className="overlay"><section className="modal wide"><div className="modal-head"><h2>{studentProfile.student.name}</h2><button className="icon" onClick={() => setStudentProfile(null)}>x</button></div><SpBank transactions={studentProfile.transactions} /></section></div>}
     </main>
@@ -1636,6 +1637,38 @@ function AdminView({ admin, auth, onBack }) {
 // Achievements & sharing. The organising idea is that a raw share count is a
 // vanity number — it goes up simply because more cards get minted — so every
 // figure here that can be a rate is one, with cards HELD as the denominator.
+// Whether the six-hourly SP pipeline is actually working. This exists because
+// sync-attendance-records failed 31 runs in a row over eight days and the only
+// evidence was one line per run in a 4,700-line log file.
+function PipelineHealth({ data }) {
+  if (!data?.available) return null;
+  const when = (t) => t ? new Date(t).toLocaleString('en-IN', { dateStyle: 'medium', timeStyle: 'short' }) : 'never';
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <h2>Pipeline health</h2>
+        <span className={data.alerting ? 'error' : 'muted'}>
+          {data.alerting ? `${data.alerting} step(s) failing repeatedly` : 'all steps healthy'}
+        </span>
+      </div>
+      <table className="table">
+        <thead><tr><th>Step</th><th>Status</th><th>Consecutive failures</th><th>Last run</th><th>Last ok</th></tr></thead>
+        <tbody>
+          {data.steps.map(s => (
+            <tr key={s.name} className={s.consecutiveFailures >= 2 ? 'step-alert' : ''}>
+              <td>{s.name}</td>
+              <td>{s.status === 'ok' ? 'ok' : <b className="error">failed</b>}</td>
+              <td>{s.consecutiveFailures > 0 ? <b className="error">{s.consecutiveFailures}</b> : '—'}</td>
+              <td>{when(s.lastRun)}</td>
+              <td>{s.lastOk ? when(s.lastOk) : <b className="error">never</b>}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
 function AdminAchievements({ data, reigns }) {
   if (!data) return <section className="panel empty">Loading achievement data…</section>;
   const d = (x) => x ? new Date(x).toLocaleDateString('en-IN', { day: 'numeric', month: 'short', year: 'numeric' }) : '—';

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -753,6 +753,9 @@ input {
 .post-howto li { font-size: 12.5px; line-height: 1.5; color: #475569; }
 .post-howto .tag-links { display: flex; gap: 14px; margin-top: 5px; }
 
+tr.step-alert { background: #fff1f0; }
+tr.step-alert td { border-color: #f3c9c5; }
+
 /* Admin: achievements & sharing */
 .ach-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-bottom: 4px; }
 .ach-stats > div { border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; background: #fafdff; }

--- a/server/server.js
+++ b/server/server.js
@@ -906,7 +906,8 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
       topDrops
     },
     sharing: shareSummary(shares, achievements, views, last7Days),
-    reigns: reignSummary(reigns)
+    reigns: reignSummary(reigns),
+    pipeline: pipelineHealth()
   });
 });
 
@@ -1055,6 +1056,34 @@ function reignSummary(reigns) {
     medianDays: median(rows.filter((r) => !r.current).map((r) => r.days)),
     history: rows.slice(0, 40)
   };
+}
+
+// Pipeline health, written by sp-refresh.sh's run_step (logs/step-health.tsv:
+// name \t status \t lastRun \t consecutiveFailures \t lastOk). Surfaced on the
+// admin dashboard because a failing step that only writes to a log file is a
+// step nobody notices — sync-attendance-records failed 31 runs over eight days
+// exactly that way.
+const STEP_HEALTH_FILE = process.env.STEP_HEALTH_FILE || path.join(rootDir, 'logs', 'step-health.tsv');
+function pipelineHealth() {
+  try {
+    if (!fs.existsSync(STEP_HEALTH_FILE)) return { available: false, steps: [] };
+    const steps = fs.readFileSync(STEP_HEALTH_FILE, 'utf8').split('\n')
+      .map((l) => l.split('\t'))
+      .filter((c) => c.length >= 4 && c[0])
+      .map(([name, status, lastRun, fails, lastOk]) => ({
+        name, status, lastRun, lastOk: lastOk || null,
+        consecutiveFailures: Number(fails) || 0
+      }))
+      .sort((a, b) => b.consecutiveFailures - a.consecutiveFailures || a.name.localeCompare(b.name));
+    return {
+      available: true,
+      failing: steps.filter((s) => s.status !== 'ok').length,
+      alerting: steps.filter((s) => s.consecutiveFailures >= 2).length,
+      steps
+    };
+  } catch {
+    return { available: false, steps: [] };
+  }
 }
 
 function last24Hours(now) {

--- a/sp-refresh.sh
+++ b/sp-refresh.sh
@@ -36,6 +36,54 @@ fi
 
 log() { echo "[$(date -u +%FT%TZ)] $*" >> "$LOG"; }
 
+# ── Step runner with failure tracking ────────────────────────────────────────
+# sync-attendance-records failed 31 runs in a row over eight days without anyone
+# noticing: it is non-fatal by design (a display collection must not block SP
+# scoring), and a single "FAILED (non-fatal)" line in a 4,700-line log is
+# invisible. Each step's outcome is now recorded, consecutive failures counted,
+# and a step that fails twice running shouts in the log AND shows up on the
+# admin dashboard, which is somewhere a human actually looks.
+HEALTH="$REPO/logs/step-health.tsv"      # name \t status \t lastRun \t consecFails \t lastOk
+ALERT_AFTER=2
+touch "$HEALTH"
+
+_health_set() {
+  local name="$1" status="$2" fails="$3" lastok="$4" tmp
+  tmp=$(mktemp)
+  awk -F'\t' -v n="$name" '$1!=n' "$HEALTH" > "$tmp" 2>/dev/null </dev/null || true
+  printf '%s\t%s\t%s\t%s\t%s\n' "$name" "$status" "$(date -u +%FT%TZ)" "$fails" "$lastok" >> "$tmp"
+  mv "$tmp" "$HEALTH"
+}
+
+# run_step <name> <fatal|nonfatal> <note-on-failure> <command...>
+run_step() {
+  local name="$1" mode="$2" note="$3"; shift 3
+  local prev fails lastok
+  prev=$(awk -F'\t' -v n="$name" '$1==n{print $4"|"$5}' "$HEALTH" 2>/dev/null </dev/null)
+  fails=${prev%%|*}; lastok=${prev#*|}
+  [ -n "$fails" ] || fails=0
+  [ "$fails" = "$prev" ] && lastok=""
+
+  if "$@" >> "$LOG" 2>&1; then
+    log "$name ok"
+    _health_set "$name" ok 0 "$(date -u +%FT%TZ)"
+    return 0
+  fi
+
+  fails=$((fails + 1))
+  _health_set "$name" failed "$fails" "$lastok"
+  if [ "$fails" -ge "$ALERT_AFTER" ]; then
+    log "!!! ALERT: $name has FAILED $fails runs in a row (last ok: ${lastok:-never}) — $note"
+  else
+    log "$name FAILED — $note"
+  fi
+  if [ "$mode" = fatal ]; then
+    log "$name is fatal — aborting this run"
+    exit 1
+  fi
+  return 1
+}
+
 log "=== sp-refresh start ==="
 
 # Load guard: the APPLY rewrites ~90k sptransactions; doing that under heavy load
@@ -59,48 +107,31 @@ fi
 
 # Step 0: pull the latest Spandan evening-poll sessions (incremental). Non-fatal:
 # if the API is down we still re-score with whatever is already mirrored.
-if "$NODE" pipeline/spandan-poll-fetch.cjs >> "$LOG" 2>&1; then
-  log "spandan fetch ok"
-else
-  log "spandan fetch FAILED (non-fatal) — scoring with existing spandan_polls"
-fi
+run_step "spandan fetch" nonfatal "scoring with existing spandan_polls" \
+  "$NODE" pipeline/spandan-poll-fetch.cjs || true
 
 # Step 1: re-score (APPLY). Backs up before writing.
-if APPLY=1 OUT_DIR="$OUT_DIR" "$NODE" --max-old-space-size=2048 \
-     pipeline/sp-rubric-build-mirror.cjs >> "$LOG" 2>&1; then
-  log "rubric APPLY ok"
-else
-  log "rubric APPLY FAILED — skipping sync-levels (SP ledger untouched on failure)"
-  exit 1
-fi
+run_step "rubric APPLY" fatal "SP ledger untouched on failure" \
+  env APPLY=1 OUT_DIR="$OUT_DIR" "$NODE" --max-old-space-size=2048 pipeline/sp-rubric-build-mirror.cjs
 
 # Step 2: refresh derived Levels / Trophy League / Legend fields.
-if "$NODE" sync-levels.cjs >> "$LOG" 2>&1; then
-  log "sync-levels ok"
-else
-  log "sync-levels FAILED — SP applied but derived level fields may be stale"
-  exit 1
-fi
+run_step "sync-levels" fatal "SP applied but derived level fields may be stale" \
+  "$NODE" sync-levels.cjs
 
 # Step 2b: fold attendance minutes into attendancerecords (drives the My-Journey
 # 3600-minute standup goal). Parses "present X of Y min (Z%)" from the attendance
 # transactions the rubric just wrote. Non-fatal — SP is unaffected if this fails.
-if "$NODE" pipeline/sync-attendance-records.cjs >> "$LOG" 2>&1; then
-  log "sync-attendance-records ok"
-else
-  log "sync-attendance-records FAILED (non-fatal) — attendance minutes/3600 goal may be stale"
-fi
+run_step "sync-attendance-records" nonfatal "attendance minutes/3600 goal may be stale" \
+  "$NODE" pipeline/sync-attendance-records.cjs || true
 
 # Step 3: rebuild the SP-trajectory snapshot (cohort/group reference lines for the
 # student trajectory modal). Non-fatal — the student's own line is always live.
-if "$NODE" server/scripts/buildTrajectories.js >> "$LOG" 2>&1; then
-  log "trajectory snapshot ok"
-else
-  log "trajectory snapshot FAILED (non-fatal) — cohort lines may be stale"
-fi
+run_step "trajectory snapshot" nonfatal "cohort lines may be stale" \
+  "$NODE" server/scripts/buildTrajectories.js || true
 
 # Step 3b: rebuild cached leaderboard boards (weekly/all-time/category/cohort).
-if "$NODE" server/scripts/buildLeaderboards.js >> "$LOG" 2>&1; then log "leaderboards ok"; else log "leaderboards FAILED (non-fatal)"; fi
+run_step "leaderboards" nonfatal "boards may be stale" \
+  "$NODE" server/scripts/buildLeaderboards.js || true
 
 # Housekeeping: weekly retention — keep last 2 days of dailies + 1 snapshot/week for 12 weeks.
 OUT_DIR="$OUT_DIR" WEEKS=12 DAILY_DAYS=2 "$REPO/sp-runs-retention.sh" >> "$LOG" 2>&1 || true


### PR DESCRIPTION
`sync-attendance-records` failed **31 runs in a row across eight days** and nobody noticed. It's non-fatal by design — a display collection must not block SP scoring — but the only evidence was one `FAILED (non-fatal)` line per run in a 4,700-line log. Non-fatal should not mean invisible.

## The alert

Every step in `sp-refresh.sh` now goes through `run_step`, which records its outcome to `logs/step-health.tsv`, counts consecutive failures, and after two in a row logs something hard to miss:

```
!!! ALERT: sync-attendance-records has FAILED 2 runs in a row (last ok: never)
```

Success resets the counter and stamps `lastOk`. Fatal vs non-fatal behaviour is unchanged — `rubric APPLY` and `sync-levels` still abort the run, the rest still carry on.

## Somewhere you'd actually look

The same data is served at `/api/admin/analytics` and rendered as a **Pipeline health** table on the admin Analytics tab, red once a step has failed twice. A log file was demonstrably not enough.

## A hang the test caught

`awk` with an unset filename reads **stdin** and blocks forever — a missing `HEALTH` path would have *hung* the entire refresh rather than failing it. Both reads now redirect from `/dev/null`.

## Verified against the real helper

first failure logs plainly · second and third alert with the count · success resets to 0 and sets `lastOk` · a later failure returns to 1 without alerting and keeps `lastOk` · two steps don't clobber each other's row

🤖 Generated with [Claude Code](https://claude.com/claude-code)