### PR TITLE
feat(pipeline): send step alerts somewhere a human will see them

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -233,6 +233,8 @@ OFF, so the feature ships dark):
 | `ACHIEVEMENTS_ENABLED=1` | tab visible to the whole cohort. **Also** turns on tie-aware "1224" ranking in the leaderboard build and the minting of podium cards — with it off, the build ranks 1,2,3… exactly as before and awards nothing. |
 | `ACHIEVEMENTS_EMAILS=a@b.com,…` | named accounts see the tab while it is otherwise off (preview on live data) |
 | `ACHIEVEMENTS_SHARING=1` | Share/Download buttons, and the `share/card` + `share/track` endpoints. Requires the tab to be visible; never the other way round |
+| `ALERT_WEBHOOK_URL=…` | where sp-refresh POSTs an alert when a step fails twice running (see below). Unset = the alert only reaches `logs/sp-refresh.log` and the admin dashboard |
+| `ALERT_WEBHOOK_SECRET=…` | shared secret sent in the alert body, same pattern as the survey Apps Script endpoints |
 | `VERIFY_VIEW_LOG=0` | turns OFF verify-page view logging (defaults ON). The one switch here that defaults on, because the log is what makes reach measurable at all |
 
 **When podium cards are awarded.** Weekly cards come from the **last completed
@@ -362,3 +364,45 @@ mandatory sessions 15 May → 27 Jun (36 qualifying sessions; 26 Jun was a holid
   sptransactions ~47,955. Superseded by the 28 Jun mirror-rubric run above.
 - 27 May Morning ingestion: attendance ✅ poll ✅ chat ✅ (429 students got +5 SP from chat)
 - 37 peer-escalation SP penalty reviews (camera off) created in `chat_s_p_reviews` — pending admin approval
+
+## Pipeline alerting
+
+`sync-attendance-records` failed **31 runs in a row over eight days** and nobody
+noticed: it is non-fatal by design, and the only trace was one line per run in a
+4,700-line log. Non-fatal must not mean invisible.
+
+Every step in `sp-refresh.sh` now runs through `run_step`, which writes
+`logs/step-health.tsv` (`name / status / lastRun / consecutiveFailures / lastOk`),
+and after **two consecutive failures** logs `!!! ALERT: …` and POSTs
+`ALERT_WEBHOOK_URL`. Success resets the counter. Fatal vs non-fatal is unchanged
+— `rubric APPLY` and `sync-levels` still abort the run.
+
+The same file is served at `/api/admin/analytics` → `pipeline` and rendered as a
+**Pipeline health** table on the admin Analytics tab, red once a step is alerting.
+
+**The box cannot send email itself** — no MTA, no local SMTP, no mail library, no
+credentials, and cron has no `MAILTO`. So alerts leave via a webhook. The intended
+target is a **Google Apps Script web app**, which this project already uses for
+the survey sheet sync: it runs as the owner, so `MailApp.sendEmail()` sends from
+their own account and **no mail password is ever stored on the server**. Slack or
+Discord webhooks work equally well — the body is
+`{ secret, host, text }`.
+
+```javascript
+// Apps Script: Deploy > New deployment > Web app, execute as me, anyone can access.
+function doPost(e) {
+  var p = JSON.parse(e.postData.contents);
+  if (p.secret !== 'PUT_THE_SAME_SECRET_AS_ALERT_WEBHOOK_SECRET_HERE') {
+    return ContentService.createTextOutput('no');
+  }
+  MailApp.sendEmail({
+    to: 'imsakshivk@gmail.com',
+    subject: '[Spurti] pipeline alert on ' + p.host,
+    body: p.text
+  });
+  return ContentService.createTextOutput('ok');
+}
+```
+
+The POST is best-effort with a 15s timeout: an alerting channel must never be the
+reason a scoring run hangs or fails.

--- a/sp-refresh.sh
+++ b/sp-refresh.sh
@@ -47,12 +47,35 @@ HEALTH="$REPO/logs/step-health.tsv"      # name \t status \t lastRun \t consecFa
 ALERT_AFTER=2
 touch "$HEALTH"
 
-_health_set() {
-  local name="$1" status="$2" fails="$3" lastok="$4" tmp
-  tmp=$(mktemp)
-  awk -F'\t' -v n="$name" '$1!=n' "$HEALTH" > "$tmp" 2>/dev/null </dev/null || true
-  printf '%s\t%s\t%s\t%s\t%s\n' "$name" "$status" "$(date -u +%FT%TZ)" "$fails" "$lastok" >> "$tmp"
-  mv "$tmp" "$HEALTH"
+# Where an alert actually goes. The box has no MTA, no local SMTP and no mail
+# credentials, so nothing can be posted from here directly. ALERT_WEBHOOK_URL
+# (in .env) is POSTed a small JSON body instead; a Google Apps Script web app is
+# the intended target, since this project already uses one for the survey sheet
+# sync and an Apps Script sends mail AS the owner — no password ever lands on
+# the server. Slack/Discord webhooks work too. Unset = log only, no error.
+# Read ONLY the alert keys out of .env. Deliberately not `set -a; . .env` —
+# that would export every secret in the file into every child process for the
+# rest of the run, to configure one webhook.
+_envget() { grep -E "^$1=" "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d "\"'\r"; }
+ALERT_WEBHOOK_URL="${ALERT_WEBHOOK_URL:-$(_envget ALERT_WEBHOOK_URL)}"
+ALERT_WEBHOOK_SECRET="${ALERT_WEBHOOK_SECRET:-$(_envget ALERT_WEBHOOK_SECRET)}"
+
+notify() {
+  [ -n "$ALERT_WEBHOOK_URL" ] || return 0
+  local payload
+  # JSON built by node, not by sed — shell quoting is not a serialiser. The
+  # secret goes via the environment so it stays out of the process list.
+  payload=$(ALERT_TEXT="$1" ALERT_HOST="$(hostname)" ALERT_SECRET="$ALERT_WEBHOOK_SECRET" \
+    "$NODE" -e 'process.stdout.write(JSON.stringify({
+      secret: process.env.ALERT_SECRET || "",
+      host: process.env.ALERT_HOST || "",
+      text: process.env.ALERT_TEXT || ""
+    }))' 2>/dev/null) || return 0
+  # Best effort and short-fused: the alerting channel must never be the reason a
+  # scoring run hangs or fails.
+  curl -fsS -m 15 -X POST "$ALERT_WEBHOOK_URL" \
+       -H 'Content-Type: application/json' --data "$payload" >/dev/null 2>&1 \
+    || log "(alert webhook POST failed — the alert is still in this log)"
 }
 
 # run_step <name> <fatal|nonfatal> <note-on-failure> <command...>
@@ -73,7 +96,9 @@ run_step() {
   fails=$((fails + 1))
   _health_set "$name" failed "$fails" "$lastok"
   if [ "$fails" -ge "$ALERT_AFTER" ]; then
-    log "!!! ALERT: $name has FAILED $fails runs in a row (last ok: ${lastok:-never}) — $note"
+    local msg="ALERT: sp-refresh step '$name' has FAILED $fails runs in a row (last ok: ${lastok:-never}). $note"
+    log "!!! $msg"
+    notify "$msg"
   else
     log "$name FAILED — $note"
   fi


### PR DESCRIPTION
The dashboard panel from #161 and the log line both require someone to go and look. The failure mode being fixed is that **nobody looked for eight days**.

## The box cannot send mail

No MTA, no local SMTP, no mail library, no credentials, and cron has no `MAILTO`. Checked before building anything.

So alerts leave via `ALERT_WEBHOOK_URL`. The intended target is a **Google Apps Script web app** — this project already uses one for the survey sheet sync, it runs *as the owner*, so `MailApp.sendEmail()` sends from your own account and **no mail password ever lands on the server**. Slack and Discord webhooks take the same body. Unset means log-only, no error.

## Details that matter

- **Only the two alert keys are read from `.env`**, by grep. `set -a; . .env` would have exported every secret in the file into every child process for the rest of the run, to configure one webhook.
- **The JSON is built by node, not sed.** Shell quoting is not a serialiser, and an alert body is exactly the kind of string that contains quotes. Verified with `"`, `&`, `<>`, a backslash and an em-dash — all survive intact.
- **The secret goes to node via the environment, not argv**, so it stays out of `ps`.
- **Best effort, 15s timeout.** The alerting channel must never be why a scoring run hangs or fails.

`CONTEXT.md` documents the switches and carries the Apps Script to paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)