### PR TITLE
fix(pipeline): the alerting change silently killed the 12:00 refresh

### DIFF
--- a/sp-refresh.sh
+++ b/sp-refresh.sh
@@ -56,7 +56,12 @@ touch "$HEALTH"
 # Read ONLY the alert keys out of .env. Deliberately not `set -a; . .env` —
 # that would export every secret in the file into every child process for the
 # rest of the run, to configure one webhook.
-_envget() { grep -E "^$1=" "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d "\"'\r"; }
+# `|| true` is load-bearing: this script runs under `set -euo pipefail`, and a
+# grep that matches nothing exits 1. Without it, an ABSENT optional key aborts
+# the whole refresh before it logs anything — which is exactly what happened to
+# the 12:00 run on 2026-08-12: lock file and step-health.tsv created, not one
+# line written, no SP rescored, and no error anywhere to explain it.
+_envget() { grep -E "^$1=" "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d "\"'\r" || true; }
 ALERT_WEBHOOK_URL="${ALERT_WEBHOOK_URL:-$(_envget ALERT_WEBHOOK_URL)}"
 ALERT_WEBHOOK_SECRET="${ALERT_WEBHOOK_SECRET:-$(_envget ALERT_WEBHOOK_SECRET)}"
 
@@ -76,6 +81,18 @@ notify() {
   curl -fsS -m 15 -X POST "$ALERT_WEBHOOK_URL" \
        -H 'Content-Type: application/json' --data "$payload" >/dev/null 2>&1 \
     || log "(alert webhook POST failed — the alert is still in this log)"
+}
+
+# Rewrite one step's row in the health file, leaving the others untouched.
+# awk reads from /dev/null as well as the file: with an unset or empty filename
+# awk falls back to STDIN and blocks forever, which would hang the whole refresh
+# rather than fail it.
+_health_set() {
+  local name="$1" status="$2" fails="$3" lastok="$4" tmp
+  tmp=$(mktemp)
+  awk -F'\t' -v n="$name" '$1!=n' "$HEALTH" > "$tmp" 2>/dev/null </dev/null || true
+  printf '%s\t%s\t%s\t%s\t%s\n' "$name" "$status" "$(date -u +%FT%TZ)" "$fails" "$lastok" >> "$tmp"
+  mv "$tmp" "$HEALTH"
 }
 
 # run_step <name> <fatal|nonfatal> <note-on-failure> <command...>


### PR DESCRIPTION
**I broke the cron, and it failed exactly as invisibly as the bug I was fixing.** The 12:00 UTC refresh did not run: no SP rescored, no leaderboards rebuilt, nothing logged.

## Evidence

```
/tmp/sp-refresh.lock       created 12:00   -> the script started
logs/step-health.tsv       created 12:00   -> it got past `touch`
logs/sp-refresh.log        mtime  06:07    -> it wrote NOTHING
no processes running                       -> it had exited
```

## Two faults, both mine

**1.** `set -euo pipefail` + `_envget` grepping `.env` for `ALERT_WEBHOOK_URL`, which isn't set. grep exits 1 when it matches nothing, the assignment inherits that status, and `set -e` aborted the script *before its first log line*. Fixed with `|| true`.

**2.** `_health_set` was **gone entirely** — an earlier block replacement removed it while leaving both of `run_step`'s calls to it. `bash -n` passes happily on a call to an undefined function, so the syntax check I was relying on proved nothing.

## The lesson

A script that runs unattended has to be **executed, not parsed**. There is now a real end-to-end test: the actual helper block sourced under `set -euo pipefail` with a `.env` that lacks the optional keys, exercising a success, two failures and the alert path. It reproduces both bugs and now passes start to finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)