### PR TITLE
fix(standup): correct weekly avg denominator + IST-explicit week/day windows

### DIFF
--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -104,11 +104,15 @@ export async function buildJourneyState(student) {
 }
 
 const DAY_MS = 86400000;
-const startOfToday = () => { const d = new Date(); d.setHours(0, 0, 0, 0); return d; };
+const IST_MS = 5.5 * 3600 * 1000;
+const startOfToday = () => {
+  const ist = new Date(Date.now() + IST_MS);
+  return new Date(Date.UTC(ist.getUTCFullYear(), ist.getUTCMonth(), ist.getUTCDate()) - IST_MS);
+};
 const addDays = (d, n) => { const x = new Date(d); x.setDate(x.getDate() + n); return x; };
-// Local date-only string (yyyy-mm-dd) — matches how <input type="date"> works and
+// IST date-only string (yyyy-mm-dd) — matches how <input type="date"> works and
 // avoids UTC/local off-by-one between the picker min/max and server validation.
-const ymd = d => { const x = new Date(d); return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, '0')}-${String(x.getDate()).padStart(2, '0')}`; };
+const ymd = d => { const x = new Date(new Date(d).getTime() + IST_MS); return `${x.getUTCFullYear()}-${String(x.getUTCMonth() + 1).padStart(2, '0')}-${String(x.getUTCDate()).padStart(2, '0')}`; };
 export const STANDUP_MIN_PER_DAY = 60;      // one 60-min standup per working day
 export const STANDUP_DAYS_PER_WEEK = 6;     // 6 working days per week
 

--- a/server/services/standup.js
+++ b/server/services/standup.js
@@ -25,15 +25,19 @@ export const STANDUP = {
 
 export const tierByKey = k => STANDUP.tiers.find(t => t.key === k);
 
-// Current calendar week, Monday 00:00 → Sunday 23:59:59 (local server time).
+const IST_MS = 5.5 * 3600 * 1000;
+
+// Current calendar week, Monday 00:00 → Sunday 23:59:59 IST. Computed via the IST
+// clock so it is correct regardless of the server's timezone.
 function weekWindow(now = new Date()) {
-  const start = new Date(now); start.setHours(0, 0, 0, 0);
-  const dow = (start.getDay() + 6) % 7;           // 0 = Monday
-  start.setDate(start.getDate() - dow);
-  const end = new Date(start); end.setDate(end.getDate() + 6); end.setHours(23, 59, 59, 999);
+  const ist = new Date(now.getTime() + IST_MS);
+  const dow = (ist.getUTCDay() + 6) % 7;           // 0 = Monday
+  const monMidnightIst = Date.UTC(ist.getUTCFullYear(), ist.getUTCMonth(), ist.getUTCDate() - dow);
+  const start = new Date(monMidnightIst - IST_MS);
+  const end = new Date(start.getTime() + 7 * 86400000 - 1);  // Sunday 23:59:59.999
   return { start, end };
 }
-const fmt = d => d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+const fmt = d => new Date(d.getTime() + IST_MS).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
 
 export async function buildStandupState(student) {
   const email = student.email;
@@ -42,9 +46,9 @@ export async function buildStandupState(student) {
   // Attendance already logged this week (informational — the demo settles by button).
   const wk = await AttendanceRecord.find({ email }).lean();
   const thisWeek = wk.filter(r => r.createdAt && new Date(r.createdAt) >= start && new Date(r.createdAt) <= end);
-  const attendedThisWeek = thisWeek.filter(r => (r.attendedMinutes || 0) > 0).length;
-  const avgPctThisWeek = attendedThisWeek
-    ? Math.round(thisWeek.reduce((a, r) => a + (r.attendancePercentage || 0), 0) / attendedThisWeek)
+  const attended = thisWeek.filter(r => (r.attendedMinutes || 0) > 0);
+  const avgPctThisWeek = attended.length
+    ? Math.round(attended.reduce((a, r) => a + (r.attendancePercentage || 0), 0) / attended.length)
     : null;
 
   const commits = await Commitment.find({ email, type: 'standup' }).sort({ createdAt: -1 }).lean();
@@ -59,7 +63,7 @@ export async function buildStandupState(student) {
     weekLabel: `${fmt(start)} – ${fmt(end)}`,
     deadline: end,
     sessionsThisWeek: STANDUP.sessionsPerWeek,
-    attendedThisWeek, avgPctThisWeek,
+    attendedThisWeek: attended.length, avgPctThisWeek,
     tiers: STANDUP.tiers, multipliers: STANDUP.multipliers, penaltyFactor: STANDUP.penaltyFactor,
     totalSp: student.totalSp || 0, available,
     active, history


### PR DESCRIPTION
Fixes two open bugs from the tracking list:

- **#11 (MEDIUM) — standup.js weekly avg understated.** \vgPctThisWeek\ summed \ttendancePercentage\ over ALL of the week's records but divided by only the attended count (\ttendedMinutes > 0\). Any 0-minute records in the week dragged the numerator down while staying out of the denominator, understating the displayed weekly average. Now both numerator and denominator use the attended records only (\server/services/standup.js:49-52\).
- **#19 (LOW) — server-local time assumed IST.** \weekWindow()\ (standup.js) and \startOfToday()\/\ymd()\ (journey.js) used server-local date math, correct only because production runs in IST. They now compute Monday 00:00 → Sunday 23:59:59 IST (and the IST date-only string) explicitly, so they stay correct on any host. Mirrors the existing \IST_MS\ pattern in \server/services/leaderboards.js:28-33\.

Both changes touch \server/services/standup.js\, so they ship together to avoid a merge conflict.

Verified: \
ode --check\ on both files; weekWindow/startOfToday arithmetic sanity-checked for an IST server.