### PR TITLE
fix(server): guard parseCookies against malformed cookies; exact vibe deadline days

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -183,7 +183,14 @@ function parseCookies(header = '') {
   return Object.fromEntries(String(header).split(';').map(part => {
     const index = part.indexOf('=');
     if (index < 0) return null;
-    return [part.slice(0, index).trim(), decodeURIComponent(part.slice(index + 1).trim())];
+    let value;
+    try {
+      value = decodeURIComponent(part.slice(index + 1).trim());
+    } catch {
+      // Malformed %-encoding in one cookie must not take down every session route.
+      return null;
+    }
+    return [part.slice(0, index).trim(), value];
   }).filter(Boolean));
 }
 

--- a/server/services/vibe.js
+++ b/server/services/vibe.js
@@ -34,7 +34,7 @@ export const floorPctFor = course => Math.round(CONFIG.floorHours / course.hours
 function daysFromToday(deadline) {
   const t = new Date(); t.setHours(0, 0, 0, 0);
   const d = new Date(deadline); d.setHours(0, 0, 0, 0);
-  return Math.round((d - t) / 86400000);
+  return Math.floor((d - t) / 86400000);
 }
 
 // Build the full student-facing ViBe state.


### PR DESCRIPTION
Fixes two open bugs from the tracking list:

- **#8 (MEDIUM) — parseCookies URIError on malformed cookie.** \decodeURIComponent\ throws \URIError\ on an invalid \%\ escape in one cookie, which would take down every session route. Each malformed cookie is now skipped (returns \
ull\, filtered out) instead of crashing the request (\server/server.js:183-190\).
- **#17 (LOW) — vibe.js Math.round on days-remaining.** \Math.round\ made the 1–3 day bet window fuzzy by ~12h (a 2.5-day deadline validated as 3 days). \Math.floor\ gives exact whole-day boundaries, matching the \Deadline must be 1–3 days out\ rule (\server/services/vibe.js:37\).

Verified: \
ode --check\ on both files.