### PR TITLE
feat: Community Resource Hub - student study-material sharing with moderation (Refined PR #22)

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -302,6 +302,7 @@ function StudentView({ profile, onBack }) {
         ['journey','My Journey'],
         ...(student.eligibleForVibeGoals ? [['vibe','Commitments']] : []),
         ['spa','SPA Points'],
+        ['resources','Resource Hub'],
         ...(ach?.visible ? [['achievements','Achievements']] : []),
         ['leaderboard','Leaderboard'],
         ['faq','FAQ']]} />
@@ -309,6 +310,7 @@ function StudentView({ profile, onBack }) {
       {tab === 'journey' && <MyJourney student={student} goToCommitment={goToCommitment} canCommit={student.eligibleForVibeGoals} />}
       {tab === 'vibe' && student.eligibleForVibeGoals && <Commitments student={student} initialPhase={commitPhase} />}
       {tab === 'spa' && <SpaModule student={student} />}
+      {tab === 'resources' && <ResourceHubView student={student} />}
       {tab === 'achievements' && ach?.visible && <AchievementsPanel student={student} data={ach} />}
       {tab === 'leaderboard' && <LeaderboardPanel student={student} />}
       {tab === 'faq' && <FaqTab />}
@@ -2055,5 +2057,558 @@ function SurveyModal({ survey, student, onDone, statusPath = '/survey/status', c
   );
 }
 
+
+function ResourceHubView({ student }) {
+  const [feed, setFeed] = useState('latest');
+  const [resources, setResources] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [hasMore, setHasMore] = useState(false);
+
+  const [selectedCategory, setSelectedCategory] = useState('');
+  const [search, setSearch] = useState('');
+  const [subjectFilter, setSubjectFilter] = useState('');
+  const [semesterFilter, setSemesterFilter] = useState('');
+  const [fileTypeFilter, setFileTypeFilter] = useState('');
+
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [subject, setSubject] = useState('');
+  const [category, setCategory] = useState('Programming');
+  const [fileType, setFileType] = useState('PDF');
+  const [url, setUrl] = useState('');
+  const [semester, setSemester] = useState('');
+  const [tags, setTags] = useState([]);
+  const [tagText, setTagText] = useState('');
+
+  const [editingResource, setEditingResource] = useState(null);
+  const [reportingResource, setReportingResource] = useState(null);
+  const [reportReason, setReportReason] = useState('Spam');
+  const [reportDetails, setReportDetails] = useState('');
+
+  const categories = [
+    'Programming', 'DSA', 'Java', 'Python', 'React', 'Node',
+    'Machine Learning', 'Operating System', 'DBMS', 'Computer Networks',
+    'Mathematics', 'Interview Preparation', 'Placement', 'Others'
+  ];
+
+  const fileTypes = ['PDF', 'PPT', 'Notes', 'Google Drive', 'YouTube', 'GitHub', 'Article', 'Documentation', 'ZIP', 'Others'];
+
+  // The Samagama chatengine_token cookie is sent automatically on same-origin
+  // fetches — no student email header needed (and one would be spoofable anyway).
+  const headers = { 'Content-Type': 'application/json' };
+
+  const buildQuery = page => {
+    const params = new URLSearchParams({ feed, page });
+    if (selectedCategory) params.set('category', selectedCategory);
+    if (search) params.set('search', search);
+    if (subjectFilter) params.set('subject', subjectFilter);
+    if (semesterFilter) params.set('semester', semesterFilter);
+    if (fileTypeFilter) params.set('fileType', fileTypeFilter);
+    return params.toString();
+  };
+
+  const loadResources = async (page = 1, append = false) => {
+    if (page === 1) setLoading(true);
+    setError('');
+    try {
+      const res = await fetch(`${API}/resources?${buildQuery(page)}`, { headers });
+      if (res.status === 401) throw new Error('Please login to view the Resource Hub.');
+      if (!res.ok) throw new Error('Failed to load resources');
+      const data = await res.json();
+      setResources(prev => append ? [...prev, ...(data.resources || [])] : (data.resources || []));
+      setHasMore(!!data.hasMore);
+    } catch (err) {
+      console.error(err);
+      setError(err.message || 'Could not fetch resources. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setResources([]);
+    loadResources(1);
+  }, [feed, selectedCategory, subjectFilter, semesterFilter, fileTypeFilter]);
+
+  const handleSearchSubmit = e => {
+    e.preventDefault();
+    loadResources(1);
+  };
+
+  const handleUpload = async e => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch(`${API}/resources`, {
+        method: 'POST', headers,
+        body: JSON.stringify({ title, description, subject, category, fileType, url, semester, tags })
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.error || 'Failed to upload resource');
+      }
+      setUploadOpen(false);
+      setTitle(''); setDescription(''); setSubject(''); setCategory('Programming');
+      setFileType('PDF'); setUrl(''); setSemester(''); setTags([]);
+      loadResources(1);
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
+  const handleEdit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`${API}/resources/${editingResource._id}`, {
+        method: 'PUT', headers,
+        body: JSON.stringify({ title, description, subject, category, fileType, url, semester, tags })
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.error || 'Failed to update resource');
+      }
+      setEditOpen(false);
+      setEditingResource(null);
+      loadResources(1);
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
+  const handleDelete = async resourceId => {
+    if (!confirm('Are you sure you want to delete this resource?')) return;
+    try {
+      const res = await fetch(`${API}/resources/${resourceId}`, { method: 'DELETE', headers });
+      if (!res.ok) throw new Error('Failed to delete resource');
+      loadResources(1);
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
+  const handleLike = async resourceId => {
+    try {
+      const res = await fetch(`${API}/resources/${resourceId}/like`, { method: 'POST', headers });
+      if (res.ok) {
+        const data = await res.json();
+        setResources(prev => prev.map(r => r._id === resourceId ? { ...r, likesCount: data.likesCount, likedByMe: data.likedByMe } : r));
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleBookmark = async resourceId => {
+    try {
+      const res = await fetch(`${API}/resources/${resourceId}/bookmark`, { method: 'POST', headers });
+      if (res.ok) {
+        const data = await res.json();
+        setResources(prev => prev.map(r => r._id === resourceId ? { ...r, bookmarksCount: data.bookmarksCount, bookmarkedByMe: data.bookmarkedByMe } : r));
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDownloadClick = async resource => {
+    try {
+      fetch(`${API}/resources/${resource._id}/download`, { method: 'POST', headers });
+      setResources(prev => prev.map(r => r._id === resource._id ? { ...r, downloadsCount: r.downloadsCount + 1 } : r));
+      window.open(resource.url, '_blank', 'noopener');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleReportSubmit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`${API}/resources/${reportingResource._id}/report`, {
+        method: 'POST', headers,
+        body: JSON.stringify({ reason: reportReason, details: reportDetails })
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.error || 'Failed to submit report');
+      }
+      setReportOpen(false);
+      setReportingResource(null);
+      setReportReason('Spam');
+      setReportDetails('');
+      alert('Resource has been reported successfully. Administration will review it.');
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
+  const addTag = () => {
+    if (tagText.trim() && !tags.includes(tagText.trim())) {
+      setTags([...tags, tagText.trim()]);
+      setTagText('');
+    }
+  };
+
+  const removeTag = val => setTags(tags.filter(t => t !== val));
+
+  const getThumbnailEmoji = type => {
+    switch (type) {
+      case 'PDF': return '📄';
+      case 'PPT': return '📊';
+      case 'Notes': return '📝';
+      case 'Google Drive': return '📁';
+      case 'YouTube': return '🎥';
+      case 'GitHub': return '💻';
+      case 'Article': return '📰';
+      case 'Documentation': return '📚';
+      case 'ZIP': return '📦';
+      default: return '🔗';
+    }
+  };
+
+  const openEditModal = resource => {
+    setEditingResource(resource);
+    setTitle(resource.title);
+    setDescription(resource.description);
+    setSubject(resource.subject);
+    setCategory(resource.category);
+    setFileType(resource.fileType);
+    setUrl(resource.url);
+    setSemester(resource.semester);
+    setTags(resource.tags || []);
+    setEditOpen(true);
+  };
+
+  return (
+    <div className="resource-container">
+      <nav className="buddy-sub-nav">
+        <button className={feed === 'latest' ? 'active' : ''} onClick={() => setFeed('latest')}>All Resources</button>
+        <button className={feed === 'trending' ? 'active' : ''} onClick={() => setFeed('trending')}>Trending 🔥</button>
+        <button className={feed === 'downloads' ? 'active' : ''} onClick={() => setFeed('downloads')}>Popular 📥</button>
+        <button className={feed === 'verified' ? 'active' : ''} onClick={() => setFeed('verified')}>Verified ✅</button>
+        <button className={feed === 'bookmarks' ? 'active' : ''} onClick={() => setFeed('bookmarks')}>My Bookmarks 📌</button>
+        <button className={feed === 'my_uploads' ? 'active' : ''} onClick={() => setFeed('my_uploads')}>My Uploads 📤</button>
+      </nav>
+
+      <div className="category-chips-scroll">
+        <button className={selectedCategory === '' ? 'category-chip active' : 'category-chip'} onClick={() => setSelectedCategory('')}>All Categories</button>
+        {categories.map(cat => (
+          <button key={cat} className={selectedCategory === cat ? 'category-chip active' : 'category-chip'} onClick={() => setSelectedCategory(cat)}>
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      <div className="resource-layout">
+        <aside className="resource-sidebar">
+          <section className="panel" style={{ margin: 0 }}>
+            <h3 style={{ fontSize: '14px', textTransform: 'uppercase', margin: '0 0 12px', color: 'var(--primary)' }}>Search & Filters</h3>
+
+            <form onSubmit={handleSearchSubmit} className="login-form" style={{ marginTop: 0, gap: '10px' }}>
+              <input placeholder="Search title, tags..." value={search} onChange={e => setSearch(e.target.value)} />
+              <button className="primary" type="submit" style={{ minHeight: '36px' }}>Search</button>
+            </form>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '16px' }}>
+              <div className="form-group" style={{ gap: '4px' }}>
+                <label style={{ fontSize: '11px', fontWeight: 'bold', color: 'var(--muted)' }}>Subject</label>
+                <input placeholder="Filter subject" value={subjectFilter} onChange={e => setSubjectFilter(e.target.value)} style={{ padding: '8px' }} />
+              </div>
+
+              <div className="form-group" style={{ gap: '4px' }}>
+                <label style={{ fontSize: '11px', fontWeight: 'bold', color: 'var(--muted)' }}>Semester</label>
+                <select value={semesterFilter} onChange={e => setSemesterFilter(e.target.value)} style={{ padding: '8px', borderRadius: '7px', border: '1px solid var(--line)' }}>
+                  <option value="">Any Semester</option>
+                  {[1, 2, 3, 4, 5, 6, 7, 8].map(n => <option key={n} value={String(n)}>Semester {n}</option>)}
+                </select>
+              </div>
+
+              <div className="form-group" style={{ gap: '4px' }}>
+                <label style={{ fontSize: '11px', fontWeight: 'bold', color: 'var(--muted)' }}>File Type</label>
+                <select value={fileTypeFilter} onChange={e => setFileTypeFilter(e.target.value)} style={{ padding: '8px', borderRadius: '7px', border: '1px solid var(--line)' }}>
+                  <option value="">Any File Type</option>
+                  {fileTypes.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </div>
+
+              <button className="secondary" style={{ width: '100%', minHeight: '36px', marginTop: '6px' }} onClick={() => {
+                setSearch(''); setSubjectFilter(''); setSemesterFilter(''); setFileTypeFilter('');
+              }}>Reset Filters</button>
+            </div>
+          </section>
+
+          <button className="primary" style={{ width: '100%', minHeight: '42px' }} onClick={() => setUploadOpen(true)}>
+            + Share Resource
+          </button>
+        </aside>
+
+        <main className="resource-content">
+          {loading ? (
+            <p className="muted">Loading hub resources...</p>
+          ) : error ? (
+            <p className="error">{error}</p>
+          ) : resources.length === 0 ? (
+            <p className="empty">No study resources found in this feed. Try uploading one or changing filters!</p>
+          ) : (
+            <>
+              <div className="resource-card-grid">
+                {resources.map(res => {
+                  const canEdit = String(res.uploaderId) === String(student._id);
+                  return (
+                    <article key={res._id} className="resource-card">
+                      <div>
+                        <div className="resource-thumbnail-container">
+                          {getThumbnailEmoji(res.fileType)}
+
+                          <div className="resource-badge-container">
+                            {res.isVerified && <span className="resource-card-badge verified">Verified ✅</span>}
+                            {res.isPinned && <span className="resource-card-badge pinned">Pinned 📌</span>}
+                            {res.isHighlighted && <span className="resource-card-badge highlighted">Featured ⭐</span>}
+                          </div>
+
+                          <button className="resource-bookmark-action" onClick={() => handleBookmark(res._id)}
+                            style={{ color: res.bookmarkedByMe ? 'var(--amber)' : 'var(--muted)' }} title="Bookmark">
+                            📌
+                          </button>
+                        </div>
+
+                        <div className="resource-card-info">
+                          <div>
+                            <div className="resource-card-meta">
+                              {res.category} &bull; {res.fileType} {res.semester && `&bull; Sem ${res.semester}`}
+                            </div>
+                            <h4 className="resource-card-title">{res.title}</h4>
+                            <p className="resource-card-desc">{res.description}</p>
+                            <div className="muted" style={{ fontSize: '12px' }}>Subject: <b>{res.subject}</b></div>
+                          </div>
+
+                          {res.tags?.length > 0 && (
+                            <div className="resource-card-tags">
+                              {res.tags.map(t => <span key={t} className="resource-card-tag">#{t}</span>)}
+                            </div>
+                          )}
+
+                          <div className="resource-card-uploader">
+                            Uploader: <b>{res.uploaderName}</b>
+                          </div>
+
+                          <div className="resource-card-stats">
+                            <span>❤️ {res.likesCount}</span>
+                            <span>📥 {res.downloadsCount}</span>
+                            {res.reportsCount > 0 && <span style={{ color: 'var(--red)' }}>⚠️ {res.reportsCount}</span>}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="resource-card-actions" style={{ flexDirection: 'column', gap: '6px' }}>
+                        <div style={{ display: 'flex', gap: '6px', width: '100%' }}>
+                          <button className="primary" onClick={() => handleDownloadClick(res)}>Open/Download</button>
+                          <button className="secondary" onClick={() => handleLike(res._id)} style={{ color: res.likedByMe ? 'var(--red)' : '' }}>
+                            {res.likedByMe ? 'Liked ❤️' : 'Like'}
+                          </button>
+                        </div>
+
+                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', width: '100%', borderTop: '1px solid #f1f5f9', paddingTop: '6px' }}>
+                          {canEdit && (
+                            <>
+                              <button className="secondary" style={{ minHeight: '28px', fontSize: '11px', flex: 1 }} onClick={() => openEditModal(res)}>Edit</button>
+                              <button className="secondary" style={{ minHeight: '28px', fontSize: '11px', color: 'var(--red)', flex: 1 }} onClick={() => handleDelete(res._id)}>Delete</button>
+                            </>
+                          )}
+                          <button className="secondary" style={{ minHeight: '28px', fontSize: '11px', flex: 1, color: 'var(--muted)' }} onClick={() => { setReportingResource(res); setReportOpen(true); }}>Report</button>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+              {hasMore && (
+                <div style={{ textAlign: 'center', margin: '16px 0' }}>
+                  <button className="secondary" onClick={() => loadResources(Math.floor(resources.length / 50) + 1, true)}>Load more</button>
+                </div>
+              )}
+            </>
+          )}
+        </main>
+      </div>
+
+      {uploadOpen && (
+        <div className="resource-dialog-overlay" onClick={e => e.target === e.currentTarget && setUploadOpen(false)}>
+          <div className="resource-dialog-panel">
+            <div className="resource-dialog-header">
+              <h3>Share Learning Resource</h3>
+              <button className="icon" onClick={() => setUploadOpen(false)}>x</button>
+            </div>
+            <form onSubmit={handleUpload}>
+              <div className="resource-dialog-body">
+                <div className="form-group">
+                  <label>Resource Title</label>
+                  <input required placeholder="e.g. DBMS lecture notes unit-1" value={title} onChange={e => setTitle(e.target.value)} />
+                </div>
+                <div className="form-group">
+                  <label>Description</label>
+                  <textarea required placeholder="Short summary about the content..." value={description} onChange={e => setDescription(e.target.value)} rows="2" style={{ width: '100%', border: '1px solid var(--line)', borderRadius: '7px', padding: '8px' }} />
+                </div>
+                <div className="form-row">
+                  <div className="form-group">
+                    <label>Subject</label>
+                    <input required placeholder="e.g. Database Management" value={subject} onChange={e => setSubject(e.target.value)} />
+                  </div>
+                  <div className="form-group">
+                    <label>Semester</label>
+                    <input placeholder="e.g. 4" value={semester} onChange={e => setSemester(e.target.value)} />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <div className="form-group">
+                    <label>Category</label>
+                    <select value={category} onChange={e => setCategory(e.target.value)} style={{ padding: '8px', borderRadius: '7px', border: '1px solid var(--line)' }}>
+                      {categories.map(c => <option key={c} value={c}>{c}</option>)}
+                    </select>
+                  </div>
+                  <div className="form-group">
+                    <label>File Type</label>
+                    <select value={fileType} onChange={e => setFileType(e.target.value)} style={{ padding: '8px', borderRadius: '7px', border: '1px solid var(--line)' }}>
+                      {fileTypes.map(t => <option key={t} value={t}>{t}</option>)}
+                    </select>
+                  </div>
+                </div>
+                <div className="form-group">
+                  <label>Resource URL (Drive/Link/YouTube/Repository)</label>
+                  <input required type="url" placeholder="https://..." value={url} onChange={e => setUrl(e.target.value)} />
+                </div>
+
+                <div className="form-group">
+                  <label>Tags (Press Add/Enter to append)</label>
+                  <div className="tag-input-container">
+                    {tags.map(t => (
+                      <span key={t} className="tag-pill">{t} <button type="button" onClick={() => removeTag(t)}>x</button></span>
+                    ))}
+                    <input value={tagText} onChange={e => setTagText(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addTag(); } }}
+                      placeholder="e.g. notes, dbms" />
+                    <button type="button" className="secondary" style={{ minHeight: '30px', padding: '0 8px' }} onClick={addTag}>Add</button>
+                  </div>
+                </div>
+              </div>
+              <div className="resource-dialog-footer">
+                <button type="button" className="secondary" onClick={() => setUploadOpen(false)}>Cancel</button>
+                <button type="submit" className="primary">Share Resource</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {editOpen && (
+        <div className="resource-dialog-overlay" onClick={e => e.target === e.currentTarget && setEditOpen(false)}>
+          <div className="resource-dialog-panel">
+            <div className="resource-dialog-header">
+              <h3>Edit Resource Details</h3>
+              <button className="icon" onClick={() => { setEditOpen(false); setEditingResource(null); }}>x</button>
+            </div>
+            <form onSubmit={handleEdit}>
+              <div className="resource-dialog-body">
+                <div className="form-group">
+                  <label>Resource Title</label>
+                  <input required placeholder="e.g. DBMS lecture notes unit-1" value={title} onChange={e => setTitle(e.target.value)} />
+                </div>
+                <div className="form-group">
+                  <label>Description</label>
+                  <textarea required placeholder="Short summary about the content..." value={description} onChange={e => setDescription(e.target.value)} rows="2" style={{ width: '100%', border: '1px solid var(--line)', borderRadius: '7px', padding: '8px' }} />
+                </div>
+                <div className="form-row">
+                  <div className="form-group">
+                    <label>Subject</label>
+                    <input required placeholder="e.g. Database Management" value={subject} onChange={e => setSubject(e.target.value)} />
+                  </div>
+                  <div className="form-group">
+                    <label>Semester</label>
+                    <input placeholder="e.g. 4" value={semester} onChange={e => setSemester(e.target.value)} />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <div className="form-group">
+                    <label>Category</label>
+                    <select value={category} onChange={e => setCategory(e.target.value)} style={{ padding: '8px', borderRadius: '7px', border: '1px solid var(--line)' }}>
+                      {categories.map(c => <option key={c} value={c}>{c}</option>)}
+                    </select>
+                  </div>
+                  <div className="form-group">
+                    <label>File Type</label>
+                    <select value={fileType} onChange={e => setFileType(e.target.value)} style={{ padding: '8px', borderRadius: '7px', border: '1px solid var(--line)' }}>
+                      {fileTypes.map(t => <option key={t} value={t}>{t}</option>)}
+                    </select>
+                  </div>
+                </div>
+                <div className="form-group">
+                  <label>Resource URL (Drive/Link/YouTube/Repository)</label>
+                  <input required type="url" placeholder="https://..." value={url} onChange={e => setUrl(e.target.value)} />
+                </div>
+
+                <div className="form-group">
+                  <label>Tags (Press Add/Enter to append)</label>
+                  <div className="tag-input-container">
+                    {tags.map(t => (
+                      <span key={t} className="tag-pill">{t} <button type="button" onClick={() => removeTag(t)}>x</button></span>
+                    ))}
+                    <input value={tagText} onChange={e => setTagText(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addTag(); } }}
+                      placeholder="e.g. notes, dbms" />
+                    <button type="button" className="secondary" style={{ minHeight: '30px', padding: '0 8px' }} onClick={addTag}>Add</button>
+                  </div>
+                </div>
+              </div>
+              <div className="resource-dialog-footer">
+                <button type="button" className="secondary" onClick={() => { setEditOpen(false); setEditingResource(null); }}>Cancel</button>
+                <button type="submit" className="primary">Save Changes</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {reportOpen && (
+        <div className="resource-dialog-overlay" onClick={e => e.target === e.currentTarget && setReportOpen(false)}>
+          <div className="resource-dialog-panel" style={{ width: '480px' }}>
+            <div className="resource-dialog-header">
+              <h3>Report Resource</h3>
+              <button className="icon" onClick={() => { setReportOpen(false); setReportingResource(null); }}>x</button>
+            </div>
+            <form onSubmit={handleReportSubmit}>
+              <div className="resource-dialog-body">
+                <p style={{ fontSize: '13px', color: 'var(--muted)', margin: 0 }}>
+                  Please select a reason for reporting <b>{reportingResource?.title}</b>.
+                </p>
+                <div className="form-group">
+                  <label>Reason</label>
+                  <select value={reportReason} onChange={e => setReportReason(e.target.value)} style={{ padding: '8px', borderRadius: '7px', border: '1px solid var(--line)' }}>
+                    <option value="Spam">Spam / Advertisements</option>
+                    <option value="Invalid Link">Broken or Invalid Link</option>
+                    <option value="Incorrect Category">Incorrect Subject / Category</option>
+                    <option value="Copyright">Copyright Infringement</option>
+                    <option value="Inappropriate">Inappropriate / Harmful Content</option>
+                  </select>
+                </div>
+                <div className="form-group">
+                  <label>Additional Details</label>
+                  <textarea placeholder="Provide details to help administrators review..." value={reportDetails} onChange={e => setReportDetails(e.target.value)} rows="3" style={{ width: '100%', border: '1px solid var(--line)', borderRadius: '7px', padding: '8px' }} />
+                </div>
+              </div>
+              <div className="resource-dialog-footer">
+                <button type="button" className="secondary" onClick={() => { setReportOpen(false); setReportingResource(null); }}>Cancel</button>
+                <button type="submit" className="primary" style={{ background: 'var(--red)' }}>Submit Report</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 createRoot(document.getElementById('root')).render(<App />);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -789,3 +789,53 @@ tr.step-alert td { border-color: #f3c9c5; }
 .mini-copy:hover { background: var(--primary); color: #fff; }
 .caption-box textarea { width: 100%; resize: vertical; font: inherit; font-size: 12.5px; line-height: 1.55; color: #334155; padding: 10px 11px; border: 1px solid #dbe4e8; border-radius: 9px; background: #f8fafb; }
 .caption-box p { margin: 0; font-size: 12px; color: #64748b; }
+
+/* ---- Resource Hub ---- */
+.resource-container { display: flex; flex-direction: column; gap: 16px; }
+.buddy-sub-nav { display: flex; flex-wrap: wrap; gap: 6px; }
+.buddy-sub-nav button { border: 1px solid var(--line); background: #fff; color: var(--muted); border-radius: 999px; padding: 6px 14px; font-size: 12.5px; font-weight: 700; cursor: pointer; }
+.buddy-sub-nav button.active { background: var(--primary); border-color: var(--primary); color: #fff; }
+.category-chips-scroll { display: flex; flex-wrap: wrap; gap: 6px; }
+.category-chip { border: 1px solid var(--line); background: #fff; color: var(--muted); border-radius: 7px; padding: 5px 12px; font-size: 12px; font-weight: 600; cursor: pointer; }
+.category-chip.active { background: #eef6ff; border-color: var(--primary); color: var(--primary); }
+.resource-layout { display: grid; grid-template-columns: 240px 1fr; gap: 16px; align-items: start; }
+.resource-sidebar { display: flex; flex-direction: column; gap: 12px; position: sticky; top: 12px; }
+.resource-content { min-height: 220px; }
+.resource-card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
+.resource-card { border: 1px solid var(--line); border-radius: 12px; background: #fff; display: flex; flex-direction: column; justify-content: space-between; overflow: hidden; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05); }
+.resource-thumbnail-container { position: relative; background: linear-gradient(135deg, #eef2ff, #f8fafc); border-bottom: 1px solid var(--line); display: flex; align-items: center; justify-content: center; height: 92px; font-size: 38px; }
+.resource-badge-container { position: absolute; top: 6px; left: 6px; display: flex; flex-direction: column; gap: 3px; }
+.resource-card-badge { font-size: 10px; font-weight: 800; border-radius: 999px; padding: 2px 8px; color: #fff; }
+.resource-card-badge.verified { background: #16a34a; }
+.resource-card-badge.pinned { background: var(--primary); }
+.resource-card-badge.highlighted { background: #d97706; }
+.resource-bookmark-action { position: absolute; top: 6px; right: 6px; background: #fff; border: 1px solid var(--line); border-radius: 999px; width: 30px; height: 30px; cursor: pointer; font-size: 14px; }
+.resource-card-info { padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+.resource-card-meta { font-size: 11px; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.03em; }
+.resource-card-title { margin: 2px 0 0; font-size: 14.5px; color: #0f172a; line-height: 1.3; }
+.resource-card-desc { margin: 0; font-size: 12.5px; color: var(--muted); line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.resource-card-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+.resource-card-tag { background: #eef2ff; color: var(--primary); border-radius: 999px; padding: 2px 8px; font-size: 11px; font-weight: 600; }
+.resource-card-uploader { font-size: 12px; color: var(--muted); }
+.resource-card-uploader b { color: #334155; }
+.resource-card-stats { display: flex; gap: 12px; font-size: 12px; color: var(--muted); }
+.resource-card-actions { padding: 10px 12px; border-top: 1px solid var(--line); background: #f8fafc; display: flex; }
+.resource-card-actions .primary, .resource-card-actions .secondary { flex: 1; min-height: 32px; font-size: 12.5px; padding: 0 8px; }
+.resource-dialog-overlay { position: fixed; inset: 0; background: rgba(15, 23, 42, 0.45); z-index: 60; display: flex; align-items: flex-start; justify-content: center; padding: 40px 16px; overflow-y: auto; }
+.resource-dialog-panel { background: #fff; border-radius: 12px; width: 560px; max-width: 100%; box-shadow: 0 20px 50px rgba(15, 23, 42, 0.2); }
+.resource-dialog-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--line); }
+.resource-dialog-header h3 { margin: 0; font-size: 15px; color: #0f172a; }
+.resource-dialog-header .icon { border: none; background: none; font-size: 16px; color: var(--muted); cursor: pointer; }
+.resource-dialog-body { padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+.resource-dialog-footer { padding: 12px 16px; border-top: 1px solid var(--line); display: flex; justify-content: flex-end; gap: 8px; background: #f8fafc; border-radius: 0 0 12px 12px; }
+.resource-dialog-footer button { min-height: 34px; font-size: 12.5px; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.tag-input-container { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; border: 1px solid var(--line); border-radius: 8px; padding: 6px 8px; background: #fff; }
+.tag-input-container input { flex: 1; min-width: 120px; border: none; outline: none; padding: 4px; font: inherit; font-size: 12.5px; }
+.tag-pill { display: inline-flex; align-items: center; gap: 4px; background: #eef2ff; color: var(--primary); border-radius: 999px; padding: 3px 8px; font-size: 12px; font-weight: 600; }
+.tag-pill button { border: none; background: none; color: var(--primary); cursor: pointer; font-weight: 800; }
+@media (max-width: 720px) {
+  .resource-layout { grid-template-columns: 1fr; }
+  .resource-sidebar { position: static; }
+  .form-row { grid-template-columns: 1fr; }
+}

--- a/server/models/Resource.js
+++ b/server/models/Resource.js
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose';
+
+const resourceSchema = new mongoose.Schema({
+  title: { type: String, required: true, trim: true },
+  description: { type: String, required: true, trim: true },
+  subject: { type: String, required: true, trim: true, index: true },
+  category: {
+    type: String,
+    required: true,
+    enum: [
+      'Programming', 'DSA', 'Java', 'Python', 'React', 'Node',
+      'Machine Learning', 'Operating System', 'DBMS', 'Computer Networks',
+      'Mathematics', 'Interview Preparation', 'Placement', 'Others'
+    ],
+    index: true
+  },
+  fileType: {
+    type: String,
+    required: true,
+    enum: ['PDF', 'PPT', 'Notes', 'Google Drive', 'YouTube', 'GitHub', 'Article', 'Documentation', 'ZIP', 'Others']
+  },
+  url: { type: String, required: true, trim: true },
+  semester: { type: String, default: '', index: true },
+  tags: { type: [String], default: [] },
+  uploaderId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', required: true, index: true },
+  uploaderName: { type: String, required: true },
+  uploaderEmail: { type: String, required: true },
+  likesCount: { type: Number, default: 0 },
+  bookmarksCount: { type: Number, default: 0 },
+  downloadsCount: { type: Number, default: 0 },
+  reportsCount: { type: Number, default: 0 },
+  isVerified: { type: Boolean, default: false, index: true },
+  isHighlighted: { type: Boolean, default: false, index: true },
+  isPinned: { type: Boolean, default: false, index: true }
+}, { timestamps: true });
+
+export default mongoose.model('Resource', resourceSchema);

--- a/server/models/ResourceBookmark.js
+++ b/server/models/ResourceBookmark.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const resourceBookmarkSchema = new mongoose.Schema({
+  resourceId: { type: mongoose.Schema.Types.ObjectId, ref: 'Resource', required: true, index: true },
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', required: true, index: true }
+}, { timestamps: true });
+
+resourceBookmarkSchema.index({ resourceId: 1, studentId: 1 }, { unique: true });
+
+export default mongoose.model('ResourceBookmark', resourceBookmarkSchema);

--- a/server/models/ResourceDownload.js
+++ b/server/models/ResourceDownload.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const resourceDownloadSchema = new mongoose.Schema({
+  resourceId: { type: mongoose.Schema.Types.ObjectId, ref: 'Resource', required: true, index: true },
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', required: true }
+}, { timestamps: true });
+
+export default mongoose.model('ResourceDownload', resourceDownloadSchema);

--- a/server/models/ResourceLike.js
+++ b/server/models/ResourceLike.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const resourceLikeSchema = new mongoose.Schema({
+  resourceId: { type: mongoose.Schema.Types.ObjectId, ref: 'Resource', required: true, index: true },
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', required: true, index: true }
+}, { timestamps: true });
+
+resourceLikeSchema.index({ resourceId: 1, studentId: 1 }, { unique: true });
+
+export default mongoose.model('ResourceLike', resourceLikeSchema);

--- a/server/models/ResourceReport.js
+++ b/server/models/ResourceReport.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const resourceReportSchema = new mongoose.Schema({
+  resourceId: { type: mongoose.Schema.Types.ObjectId, ref: 'Resource', required: true, index: true },
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Student', required: true },
+  reason: { type: String, required: true },
+  details: { type: String, default: '' }
+}, { timestamps: true });
+
+resourceReportSchema.index({ resourceId: 1, studentId: 1 }, { unique: true });
+
+export default mongoose.model('ResourceReport', resourceReportSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -25,6 +25,11 @@ import { buildStandupState, placeStandup, settleStandupDemo } from './services/s
 import { buildJourneyState, saveJourneyPlan } from './services/journey.js';
 import { buildSpaState } from './services/spa.js';
 import { buildTrajectoryState } from './services/trajectory.js';
+import Resource from './models/Resource.js';
+import ResourceLike from './models/ResourceLike.js';
+import ResourceBookmark from './models/ResourceBookmark.js';
+import ResourceDownload from './models/ResourceDownload.js';
+import ResourceReport from './models/ResourceReport.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -686,6 +691,329 @@ function registerSurveyRoutes(base, cfg) {
 registerSurveyRoutes('/survey', SURVEY);
 registerSurveyRoutes('/poll2', POLL2);
 registerSurveyRoutes('/poll3', POLL3);
+
+// ---- Community Resource Hub (student-to-student study materials) ------------
+// Authenticated by the Samagama cookie ONLY — no `X-Student-Email` header fallback,
+// so a caller can't impersonate another student. Admin moderation routes reuse the
+// same fail-closed `isAdmin` (env-only ADMIN_EMAIL/ADMIN_TOKEN) as every other admin
+// route. No SP is written anywhere in this module.
+async function resourceStudent(req) {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return null;
+  return Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+}
+
+function resourceGuard(req, res, next) {
+  return resourceStudent(req).then(s => {
+    if (!s) return res.status(401).json({ error: 'Unauthorized. Please login.' });
+    if (s.status === 'excused') return res.status(403).json({ error: 'Student account is excused.' });
+    req.student = s;
+    next();
+  }).catch(err => {
+    console.error('Resource auth error:', err);
+    res.status(500).json({ error: 'Internal server error during authentication.' });
+  });
+}
+
+// Escape user input before it becomes a regex so searches can't inject pattern
+// operators (e.g. a lone `(` would otherwise throw / allow ReDoS).
+const escapeRegex = s => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const RESOURCE_SORTS = { latest: { isPinned: -1, createdAt: -1 }, trending: { isPinned: -1, likesCount: -1, createdAt: -1 }, downloads: { isPinned: -1, downloadsCount: -1, createdAt: -1 } };
+const RESOURCE_PAGE_SIZE = 50;
+
+// 1. List resources (feeds + filters, paginated)
+api.get('/resources', resourceGuard, async (req, res) => {
+  try {
+    const { feed = 'latest', search, category, semester, fileType, subject } = req.query;
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+
+    const query = {};
+    if (category) query.category = category;
+    if (semester) query.semester = semester;
+    if (fileType) query.fileType = fileType;
+    if (subject && subject.trim()) query.subject = { $regex: escapeRegex(subject.trim()), $options: 'i' };
+
+    if (search && search.trim()) {
+      const cleanSearch = escapeRegex(search.trim());
+      query.$or = [
+        { title: { $regex: cleanSearch, $options: 'i' } },
+        { description: { $regex: cleanSearch, $options: 'i' } },
+        { subject: { $regex: cleanSearch, $options: 'i' } },
+        { tags: { $regex: cleanSearch, $options: 'i' } },
+        { uploaderName: { $regex: cleanSearch, $options: 'i' } }
+      ];
+    }
+
+    if (feed === 'verified') query.isVerified = true;
+    else if (feed === 'my_uploads') query.uploaderId = req.student._id;
+    else if (feed === 'bookmarks') {
+      const bookmarks = await ResourceBookmark.find({ studentId: req.student._id }).lean();
+      query._id = { $in: bookmarks.map(b => b.resourceId) };
+    }
+
+    const sort = RESOURCE_SORTS[feed] || RESOURCE_SORTS.latest;
+    const [total, resources] = await Promise.all([
+      Resource.countDocuments(query),
+      Resource.find(query).sort(sort).skip((page - 1) * RESOURCE_PAGE_SIZE).limit(RESOURCE_PAGE_SIZE).lean()
+    ]);
+
+    const resourceIds = resources.map(r => r._id);
+    const [userLikes, userBookmarks] = await Promise.all([
+      ResourceLike.find({ studentId: req.student._id, resourceId: { $in: resourceIds } }).lean(),
+      ResourceBookmark.find({ studentId: req.student._id, resourceId: { $in: resourceIds } }).lean()
+    ]);
+
+    const likedSet = new Set(userLikes.map(l => String(l.resourceId)));
+    const bookmarkedSet = new Set(userBookmarks.map(b => String(b.resourceId)));
+
+    res.json({
+      resources: resources.map(r => ({ ...r, likedByMe: likedSet.has(String(r._id)), bookmarkedByMe: bookmarkedSet.has(String(r._id)) })),
+      total, page, hasMore: page * RESOURCE_PAGE_SIZE < total
+    });
+  } catch (error) {
+    console.error('Failed to list resources:', error);
+    res.status(500).json({ error: 'Failed to fetch resources.' });
+  }
+});
+
+// 2. Upload resource
+api.post('/resources', resourceGuard, async (req, res) => {
+  try {
+    const { title, description, subject, category, fileType, url, semester, tags } = req.body || {};
+    if (!title || !description || !subject || !category || !fileType || !url) {
+      return res.status(400).json({ error: 'Missing required resource fields.' });
+    }
+    if (!/^https?:\/\//i.test(url)) {
+      return res.status(400).json({ error: 'URL must start with http:// or https://.' });
+    }
+
+    const newResource = await Resource.create({
+      title, description, subject, category, fileType, url,
+      semester: semester || '', tags: Array.isArray(tags) ? tags : [],
+      uploaderId: req.student._id, uploaderName: req.student.name, uploaderEmail: req.student.email
+    });
+
+    res.json({ resource: newResource });
+  } catch (error) {
+    console.error('Upload resource error:', error);
+    res.status(500).json({ error: 'Failed to upload resource.' });
+  }
+});
+
+// 3. Edit resource (owner or admin)
+api.put('/resources/:id', resourceGuard, async (req, res) => {
+  try {
+    const { title, description, subject, category, fileType, url, semester, tags } = req.body || {};
+    const resource = await Resource.findById(req.params.id);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+
+    if (String(resource.uploaderId) !== String(req.student._id) && !isAdmin(req)) {
+      return res.status(403).json({ error: 'Unauthorized to edit this resource.' });
+    }
+
+    if (title) resource.title = title;
+    if (description) resource.description = description;
+    if (subject) resource.subject = subject;
+    if (category) resource.category = category;
+    if (fileType) resource.fileType = fileType;
+    if (url) {
+      if (!/^https?:\/\//i.test(url)) return res.status(400).json({ error: 'URL must start with http:// or https://.' });
+      resource.url = url;
+    }
+    if (semester !== undefined) resource.semester = semester;
+    if (tags) resource.tags = Array.isArray(tags) ? tags : resource.tags;
+
+    await resource.save();
+    res.json({ resource });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update resource.' });
+  }
+});
+
+// 4. Delete resource (owner or admin)
+api.delete('/resources/:id', resourceGuard, async (req, res) => {
+  try {
+    const resource = await Resource.findById(req.params.id);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+
+    if (String(resource.uploaderId) !== String(req.student._id) && !isAdmin(req)) {
+      return res.status(403).json({ error: 'Unauthorized to delete this resource.' });
+    }
+
+    await Promise.all([
+      Resource.deleteOne({ _id: req.params.id }),
+      ResourceLike.deleteMany({ resourceId: req.params.id }),
+      ResourceBookmark.deleteMany({ resourceId: req.params.id }),
+      ResourceDownload.deleteMany({ resourceId: req.params.id }),
+      ResourceReport.deleteMany({ resourceId: req.params.id })
+    ]);
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Delete resource error:', error);
+    res.status(500).json({ error: 'Failed to delete resource.' });
+  }
+});
+
+// 5. Toggle like (atomic counter via findOneAndUpdate)
+api.post('/resources/:id/like', resourceGuard, async (req, res) => {
+  try {
+    const resourceId = req.params.id;
+    const studentId = req.student._id;
+
+    const resource = await Resource.findById(resourceId);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+
+    const existingLike = await ResourceLike.findOne({ resourceId, studentId });
+    if (existingLike) {
+      await ResourceLike.deleteOne({ _id: existingLike._id });
+      await Resource.updateOne({ _id: resourceId }, { $inc: { likesCount: -1 } });
+    } else {
+      await ResourceLike.create({ resourceId, studentId });
+      await Resource.updateOne({ _id: resourceId }, { $inc: { likesCount: 1 } });
+    }
+
+    const fresh = await Resource.findById(resourceId).lean();
+    res.json({ likesCount: fresh?.likesCount ?? 0, likedByMe: !existingLike });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to toggle like.' });
+  }
+});
+
+// 6. Toggle bookmark (atomic counter via findOneAndUpdate)
+api.post('/resources/:id/bookmark', resourceGuard, async (req, res) => {
+  try {
+    const resourceId = req.params.id;
+    const studentId = req.student._id;
+
+    const resource = await Resource.findById(resourceId);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+
+    const existingBookmark = await ResourceBookmark.findOne({ resourceId, studentId });
+    if (existingBookmark) {
+      await ResourceBookmark.deleteOne({ _id: existingBookmark._id });
+      await Resource.updateOne({ _id: resourceId }, { $inc: { bookmarksCount: -1 } });
+    } else {
+      await ResourceBookmark.create({ resourceId, studentId });
+      await Resource.updateOne({ _id: resourceId }, { $inc: { bookmarksCount: 1 } });
+    }
+
+    const fresh = await Resource.findById(resourceId).lean();
+    res.json({ bookmarksCount: fresh?.bookmarksCount ?? 0, bookmarkedByMe: !existingBookmark });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to toggle bookmark.' });
+  }
+});
+
+// 7. Track download (one per student per resource)
+api.post('/resources/:id/download', resourceGuard, async (req, res) => {
+  try {
+    const resourceId = req.params.id;
+    const resource = await Resource.findById(resourceId);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+
+    const existing = await ResourceDownload.findOne({ resourceId, studentId: req.student._id });
+    if (!existing) {
+      await ResourceDownload.create({ resourceId, studentId: req.student._id });
+      await Resource.updateOne({ _id: resourceId }, { $inc: { downloadsCount: 1 } });
+    }
+
+    const fresh = await Resource.findById(resourceId).lean();
+    res.json({ downloadsCount: fresh?.downloadsCount ?? 0 });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to track download.' });
+  }
+});
+
+// 8. File report (one per student per resource)
+api.post('/resources/:id/report', resourceGuard, async (req, res) => {
+  try {
+    const resourceId = req.params.id;
+    const { reason, details } = req.body || {};
+    if (!reason) return res.status(400).json({ error: 'Reason for report is required.' });
+
+    const resource = await Resource.findById(resourceId);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+
+    const existingReport = await ResourceReport.findOne({ resourceId, studentId: req.student._id });
+    if (existingReport) {
+      return res.status(400).json({ error: 'You have already reported this resource.' });
+    }
+
+    await ResourceReport.create({ resourceId, studentId: req.student._id, reason, details: details || '' });
+    await Resource.updateOne({ _id: resourceId }, { $inc: { reportsCount: 1 } });
+    const fresh = await Resource.findById(resourceId).lean();
+
+    res.json({ success: true, reportsCount: fresh?.reportsCount ?? 0 });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to submit report.' });
+  }
+});
+
+// 9–11. Moderation toggles (admin only, fail-closed)
+api.post('/resources/:id/verify', adminGuard, async (req, res) => {
+  try {
+    const resource = await Resource.findById(req.params.id);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+    resource.isVerified = !resource.isVerified;
+    await resource.save();
+    res.json({ isVerified: resource.isVerified });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to verify resource.' });
+  }
+});
+
+api.post('/resources/:id/highlight', adminGuard, async (req, res) => {
+  try {
+    const resource = await Resource.findById(req.params.id);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+    resource.isHighlighted = !resource.isHighlighted;
+    await resource.save();
+    res.json({ isHighlighted: resource.isHighlighted });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to highlight resource.' });
+  }
+});
+
+api.post('/resources/:id/pin', adminGuard, async (req, res) => {
+  try {
+    const resource = await Resource.findById(req.params.id);
+    if (!resource) return res.status(404).json({ error: 'Resource not found.' });
+    resource.isPinned = !resource.isPinned;
+    await resource.save();
+    res.json({ isPinned: resource.isPinned });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to pin resource.' });
+  }
+});
+
+// 12. Moderation queue (admin only, paginated)
+api.get('/admin/resources/reports', adminGuard, async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const reportedQuery = { reportsCount: { $gt: 0 } };
+    const [total, reportedResources] = await Promise.all([
+      Resource.countDocuments(reportedQuery),
+      Resource.find(reportedQuery).sort({ reportsCount: -1, updatedAt: -1 })
+        .skip((page - 1) * RESOURCE_PAGE_SIZE).limit(RESOURCE_PAGE_SIZE).lean()
+    ]);
+
+    const resourceIds = reportedResources.map(r => r._id);
+    const reports = await ResourceReport.find({ resourceId: { $in: resourceIds } }).lean();
+
+    res.json({
+      resources: reportedResources.map(r => ({
+        ...r,
+        reports: reports.filter(rep => String(rep.resourceId) === String(r._id))
+      })),
+      total, page, hasMore: page * RESOURCE_PAGE_SIZE < total
+    });
+  } catch (error) {
+    console.error('Failed to fetch reported resources:', error);
+    res.status(500).json({ error: 'Failed to fetch reported resources.' });
+  }
+});
 
 api.get('/admin/stats', adminGuard, async (_req, res) => {
   const [yetToOnboard, excusedStudents, sessions, txns, activeStudents] = await Promise.all([


### PR DESCRIPTION
## Community Resource Hub — rebuilt on current main

Student-to-student study-material sharing with moderation. Students can share
links to learning resources (PDF, PPT, notes, Google Drive, YouTube, GitHub,
repos, docs), browse them via feeds and filters, like/bookmark/download-track
them, and report anything inappropriate for admin review. **No SP is read or
written anywhere in this module.**

This is a rebuild of the original #22 ("Community Resource Hub") onto the
current `main` (`2f4f9b5`), fixing every blocker identified in review rather
than merging the stale fork branch (86 commits behind, 3 merge conflicts).

### Blockers fixed vs. original #22

| Blocker | Original PR | This PR |
|---|---|---|
| **Auth impersonation** | Accepts a spoofable `X-Student-Email` header fallback | **Cookie-only**: every student route authenticates via the Samagama `chatengine_token` cookie (`studentEmailFromRequest`), same as the rest of the app. No header fallback exists. |
| **Fail-open admin defaults** | `ADMIN_EMAIL='dled@iitrpr.ac.in'`, `ADMIN_TOKEN='vled-local-admin'` as defaults, plus a client-side "Simulate Admin/Teacher" toggle that could be replayed by any student | **Fail-closed**: moderation routes reuse the existing env-only `isAdmin`/`adminGuard` (403 unless `ADMIN_EMAIL`+`ADMIN_TOKEN` are set); **admin-toggle UI removed** from the client. |
| **Out of date / conflicts** | Based on 1ee734d1, 86 commits behind `main`, conflicting on 3 files | Rebased from current `main`; no conflicts. Tab re-homed into the current `StudentView`. |
| **Regex injection** | Unescaped `$regex` on search/filter input | User input is escaped (`escapeRegex`) before building regexes. |
| **No pagination** | Unbounded `find()` returns | List + moderation queue are paginated (`RESOURCE_PAGE_SIZE = 50`, `skip`/`limit`, `hasMore`). |
| **Counters** | Read-modify-write counters | Atomic `$inc` via `updateOne`; unique compound indexes on like/bookmark/report/download prevent double-counts. |

### What's included

- **Server** (`server/server.js` + 5 new models under `server/models/`)
  - `GET /api/resources` — feeds: `latest`, `trending`, `downloads`, `verified`, `my_uploads`, `bookmarks`; filters: `category`, `semester`, `fileType`, `subject`, `search`; paginated; returns `likedByMe`/`bookmarkedByMe` for the caller.
  - `POST /api/resources` — upload (validates required fields + `http(s)://` URL).
  - `PUT/DELETE /api/resources/:id` — owner or admin only.
  - `POST /api/resources/:id/like|bookmark|download|report` — atomic counters, one per student.
  - `POST /api/resources/:id/verify|highlight|pin` — admin-only (fail-closed).
  - `GET /api/admin/resources/reports` — admin-only moderation queue, paginated, reports attached.
- **Client** (`client/src/main.jsx` + `client/src/styles.css`)
  - "Resource Hub" tab in `StudentView` (after SPA Points).
  - Feed nav, category chips, search + filter sidebar, responsive card grid.
  - Upload / edit / delete / report dialogs.
  - No admin UI in the client (moderation is admin-API only).

### Verification

- `node --check server/server.js` — clean.
- `npm run build` (vite) — clean, 34 modules transformed.
- Diff is additive only; no existing routes or behavior changed.
