### PR TITLE
feat(admin): /admin/integrity-check - ledger integrity audit (inspired with #6)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -775,6 +775,59 @@ api.get('/admin/active', adminGuard, (_req, res) => {
   res.json(viewers);
 });
 
+// Admin integrity audit: verifies every student's totalSp equals the sum of their
+// appliedDelta transactions, and flags negative-SP students + deltaMode issues.
+api.get('/admin/integrity-check', adminGuard, async (_req, res) => {
+  const issues = await SPTransaction.aggregate([
+    { $group: { _id: '$email', computedBalance: { $sum: '$appliedDelta' }, transactions: { $sum: 1 } } },
+    {
+      $lookup: {
+        from: 'students',
+        localField: '_id',
+        foreignField: 'email',
+        pipeline: [{ $project: { email: 1, totalSp: 1, name: 1 } }],
+        as: 'student'
+      }
+    },
+    { $unwind: { path: '$student', preserveNullAndEmpty: false } },
+    { $match: { $expr: { $ne: ['$computedBalance', '$student.totalSp'] } } },
+    {
+      $project: {
+        _id: 0,
+        email: '$_id',
+        name: '$student.name',
+        storedTotalSp: '$student.totalSp',
+        computedBalance: 1,
+        discrepancy: { $subtract: ['$student.totalSp', '$computedBalance'] },
+        transactions: 1
+      }
+    },
+    { $sort: { discrepancy: -1 } }
+  ]);
+
+  const negativeSp = await Student.find({ totalSp: { $lt: 0 } })
+    .select('email name totalSp')
+    .lean();
+
+  const deltaModeIssues = await SPTransaction.countDocuments({ deltaMode: 'percent' });
+
+  res.json({
+    clean: issues.length === 0 && negativeSp.length === 0,
+    checkedAt: new Date().toISOString(),
+    summary: {
+      totalIssues: issues.length,
+      studentsWithNegativeSp: negativeSp.length,
+      deltaModeIssues,
+      totalStudentsChecked: await Student.countDocuments({ status: 'active' })
+    },
+    balanceDiscrepancies: issues,
+    negativeSpStudents: negativeSp,
+    deltaModeFixNeeded: deltaModeIssues > 0
+      ? `Run: db.sptransactions.updateMany({deltaMode:'percent'},{$set:{deltaMode:'percentage'}})`
+      : null
+  });
+});
+
 api.get('/admin/analytics', adminGuard, async (_req, res) => {
   const now = new Date();
   const lastHour = new Date(now.getTime() - 60 * 60 * 1000);


### PR DESCRIPTION
## feat(admin): `/admin/integrity-check` — ledger integrity audit

Verifies the **source-of-truth invariant** documented in CONTEXT.md: per-student
`sum(appliedDelta)` in `sptransactions` must equal `totalSp` in `students`.

Extracted as a **standalone, security-clean** endpoint from PR #6's bundled
integrity-audit feature (that PR also carried a recharts dashboard duplicating
main's existing `/admin/analytics`, a recovery-mission UI overlapping #165, and
an SP-floor that's moot since scoring moved to the positive-only pipeline).

### What it does

`GET /api/admin/integrity-check` (admin-only, existing fail-closed `adminGuard`):

- **Aggregation runs in MongoDB** (no full-collection loads into Node memory):
  group `sptransactions` by email → `$sum appliedDelta`, `$lookup` the student,
  filter rows where computed balance ≠ `students.totalSp`.
- Returns **balance discrepancies** sorted by size (`storedTotalSp`,
  `computedBalance`, `discrepancy`, txn count), **negative-SP students**, and a
  count of **legacy `deltaMode:'percent'`** records with the exact Mongo fixup
  hint (`updateMany` to `'percentage'`).
- `clean: true` when zero discrepancies and zero negative-SP students.

### Safety

- Admin-only (`adminGuard`, env-only `ADMIN_EMAIL`/`ADMIN_TOKEN`, fail-closed —
  no spoofable headers).
- **Read-only**: no transactions, no SP writes, no schema changes, no new
  dependencies. One additive route only (`server/server.js`, +53 lines).

### Verification

- `node --check server/server.js` — clean.
- Aggregation verified against main's schema (`SPTransaction` has `email`,
  `appliedDelta`, `deltaMode`; `Student` has `email`, `totalSp`, `name`).
