### PR TITLE
fix: atomic vibe SP delta + URL encoding + dead recordViewed + admin header wrapping

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1596,7 +1596,7 @@ function AdminView({ admin, auth, onBack }) {
 
   useEffect(() => { loadLeaderboard(50); fetchStats(); }, []);
   const fetchStats = async () => {
-    const r = await fetch(`${API}/admin/stats`, headers);
+    const r = await fetch(`${API}/admin/stats`, { headers });
     if (r.ok) setStats(await r.json());
   };
   useEffect(() => {
@@ -1964,7 +1964,7 @@ function AllStudentsPanel({ stats, onStudent, auth }) {
   const loadList = async (status) => {
     setLoading(true);
     try {
-      const res = await fetch(`${API}/admin/students-by-status?status=${status}&limit=200`, headers);
+      const res = await fetch(`${API}/admin/students-by-status?status=${encodeURIComponent(status)}&limit=200`, { headers });
       if (res.ok) setList(await res.json());
     } finally {
       setLoading(false);

--- a/server/server.js
+++ b/server/server.js
@@ -767,7 +767,6 @@ api.get('/admin/active', adminGuard, (_req, res) => {
         email,
         name: data.name,
         page: data.page,
-        recordViewed: data.recordViewed,
         secondsAgo: Math.round((now.getTime() - data.lastSeen.getTime()) / 1000)
       });
     }

--- a/server/services/vibe.js
+++ b/server/services/vibe.js
@@ -118,19 +118,32 @@ export function validateBet({ state, course, goalPct, stake, multiplier, deadlin
 // Apply an SP change AND write a matching SP-Bank transaction so the student sees
 // it. Stamps the entry after the latest one so the running balance stays ordered
 // (dummy seed dates can be future-ish). Returns the new balance.
+// Uses atomic findOneAndUpdate to prevent race conditions and guards against
+// negative SP.
 export async function applySpDelta(email, delta, reason) {
-  const student = await Student.findOne({ email });
-  const newTotal = (student.totalSp || 0) + delta;
-  student.totalSp = newTotal;
-  if (newTotal > (student.highestSpEver || 0)) student.highestSpEver = newTotal;
-  await student.save();
+  if (!delta) {
+    const s = await Student.findOne({ email }, { totalSp: 1 }).lean();
+    return s ? s.totalSp || 0 : 0;
+  }
+  const student = await Student.findOneAndUpdate(
+    { email, $expr: { $gte: [{ $add: [{ $ifNull: ['$totalSp', 0] }, delta] }, 0] } },
+    [{ $set: {
+      totalSp: { $add: [{ $ifNull: ['$totalSp', 0] }, delta] },
+      highestSpEver: { $max: [
+        { $ifNull: ['$highestSpEver', 0] },
+        { $add: [{ $ifNull: ['$totalSp', 0] }, delta] }
+      ]}
+    }}],
+    { new: true }
+  );
+  if (!student) throw new Error(`Cannot apply delta ${delta}: insufficient SP or student not found (${email})`);
   const last = await SPTransaction.findOne({ email }).sort({ dateTime: -1 }).lean();
   const when = new Date(Math.max(Date.now(), (last?.dateTime ? new Date(last.dateTime).getTime() + 60000 : 0)));
   await SPTransaction.create({
     email, studentId: student._id, category: 'manual', sessionLabel: '',
-    deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: newTotal, reason, dateTime: when
+    deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: student.totalSp, reason, dateTime: when
   });
-  return newTotal;
+  return student.totalSp;
 }
 
 // DEMO ONLY: resolve a bet (there is no live settlement cron locally). The stake


### PR DESCRIPTION
Four leftover fixes, independent of #175 and #176.

## Fixes

| # | File | Issue | Severity |
|---|------|-------|----------|
| 1 | \server/services/vibe.js:121-144\ | **Bug #12:** Non-atomic read-modify-write in \pplySpDelta\ + no negative SP guard. Replaced with atomic \indOneAndUpdate\ using aggregation pipeline (\$inc\ + \$max\) and \$expr\ filter preventing negative balance. | Medium |
| 2 | \client/src/main.jsx:1967\ | Unencoded space in \?status=yet to onboard\ URL param — fragile with proxies/CDNs. Fixed with \encodeURIComponent(status)\. | Low |
| 3 | \server/server.js:808\ | Dead \ecordViewed\ property in live-viewers JSON — \liveViewers\ Map only stores \{ name, page, lastSeen }\. Removed. | Low |
| 4 | \client/src/main.jsx:1599,1967\ | Admin fetch calls passing \headers\ dict directly as fetch init instead of \{ headers }\ — admin auth headers never actually sent. Fixed to \{ headers }\. | Low |

## Verification

- \
ode --check\ passes on all modified .js/.cjs files
- Zero conflicts with current \origin/main\
- Each fix is independently verifiable

## Merge order
Independent — merge in any order after or alongside #174, #175, #176.