### PR TITLE
fix(analytics): trust the proxy, and read req.ip before the await

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -150,6 +150,13 @@ function surveyPublic(cfg) {
 }
 
 const app = express();
+// One proxy hop (nginx) sits in front, so without this every request looks like
+// it came from 127.0.0.1 and `req.ip` is the proxy rather than the visitor. The
+// only thing that reads it is the verify-page viewer hash, which was therefore
+// counting browser families instead of people. If the proxy ever stops setting
+// X-Forwarded-For this falls back to the socket address, i.e. to today's
+// behaviour — it cannot make things worse.
+app.set('trust proxy', 1);
 const api = express.Router();
 const liveViewers = new Map();
 
@@ -536,6 +543,12 @@ function logAchievementView(req, code, result) {
   if (!VIEW_LOG_ON) return;
   const verifyId = String(code || '').trim().toUpperCase();
   const ua = req.get('user-agent') || '';
+  // Read synchronously, with everything else off the request. `req.ip` is a
+  // getter over the socket's remote address, and the socket is usually gone by
+  // the time the await below resolves — reading it in there returned undefined
+  // for 403 of the first 437 human views, so most of them recorded no hash at
+  // all. Nothing off `req` may be read after the first await.
+  const ip = req.ip;
   let ref = '';
   try { ref = req.get('referer') ? new URL(req.get('referer')).host : ''; } catch { ref = ''; }
   // The category is re-read here rather than added to verifyAchievement's
@@ -553,7 +566,7 @@ function logAchievementView(req, code, result) {
       ref,
       uaFamily: uaFamilyOf(ua),
       bot: isBot(ua),
-      viewerDay: viewerDayHash(req.ip, ua)
+      viewerDay: viewerDayHash(ip, ua)
     });
   })().catch(() => { /* never let logging break a credential page */ });
 }


### PR DESCRIPTION
The verify-page viewer hash (`achievementviews.viewerDay`) was empty on **403 of the first 437 human views**, so unique-visitor counts on shared achievement cards were meaningless. Two separate causes, and fixing only the obvious one would not have helped.

### 1. `req.ip` was read after an await — this is what emptied the field

`logAchievementView` captures `ua` and `ref` synchronously, but read `req.ip` *inside* the async IIFE, after `await Achievement.findOne(...)`. `req.ip` is a getter over the socket's remote address, and the socket is usually destroyed by the time that await resolves, so it returned `undefined` and `viewerDayHash` returned `''`.

That explains why it failed *intermittently* rather than always: only requests whose socket outlived the DB round-trip got a hash. `req.ip` is now read with the other synchronous reads, and nothing off `req` is touched after the first await.

### 2. `trust proxy` was never set

nginx proxies `/spurti` to `127.0.0.1:5003` and sets `X-Forwarded-For` (`sites-enabled/samagama.in:214-222`), but Express ignores that header by default. So the 34 hashes that *did* get written keyed on `127.0.0.1 + user-agent` — a browser family, not a person. 34 rows collapsed to 25 distinct values.

### Why `1` and not `true`

nginx uses `$proxy_add_x_forwarded_for`, which **appends** the real client after anything the visitor sent. Trusting exactly one hop takes the appended entry and ignores a forged prefix. `true` would trust the whole chain, i.e. whatever the visitor typed.

### Verification (against prod)

Two requests at the same nonexistent code with the same user-agent, the second carrying a forged header:

```
req A  plain                           -> viewerDay 83cec4598eefbc70
req B  -H "X-Forwarded-For: 1.2.3.4"   -> viewerDay 83cec4598eefbc70   IDENTICAL
```

The hash is populated (race fixed) and the forged prefix is ignored (`1` is correct). With `true`, req B would have hashed as `1.2.3.4`. Both test rows were deleted afterwards.

### Scope

No behaviour change beyond this. `req.ip` has exactly one reader in the codebase — the viewer hash — so `trust proxy` cannot affect anything else today. If nginx ever stops setting the header, Express falls back to the socket address, i.e. current behaviour.

### Not recoverable

79 of 927 existing view rows carry a hash. Nothing recorded before this can be counted by device; that is a stated limitation, not something this fixes.

### Note for whoever merges #175

#175 rewrites `server/server.js` heavily. This is a 14-line change in two places (`app.set` near line 152, and `logAchievementView`); expect to resolve it by hand rather than by taking either side wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)