### PR TITLE
fix: three safety fixes — wrong default DB, negative SP guard, verify error logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 PORT=5290
 MONGO_URI=mongodb://127.0.0.1:27017/analysis_summership
 ALLOW_STUDENT_SEARCH=true
-SPURTI_AUTH_SECRET=local-dev-only-change-this
+# SPURTI_AUTH_SECRET is retired (HMAC auth removed). Do not add it back.
 SPURTI_COOKIE_SECURE=false
 
 # --- Mandatory survey pop-up (perception triangulation) ---

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1053,37 +1053,6 @@ function pollSortKey(label = '') {
   return ((m * 100 + day) * 10) + tod;
 }
 
-function Polls({ polls }) {
-  if (!polls.length) return <section className="panel empty">No poll records found.</section>;
-  const sorted = [...polls].sort((a, b) => pollSortKey(b.sessionLabel) - pollSortKey(a.sessionLabel));
-  return (
-    <section className="panel">
-      <h2>Polls</h2>
-      <div className="cards">
-        {sorted.map(poll => (
-          <article className="card" key={poll._id}>
-            <div className="card-head static">
-              <strong>{poll.sessionLabel}</strong>
-              <span>{poll.attemptedQuestions}/{poll.totalQuestions} attempted</span>
-            </div>
-          </article>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function Leaderboard({ rows }) {
-  return (
-    <section className="panel">
-      <h2>Top 50 Leaderboard</h2>
-      <table className="table">
-        <thead><tr><th>Rank</th><th>Name</th><th>Email</th><th>SP</th></tr></thead>
-        <tbody>{rows.map(row => <tr key={`${row.rank}-${row.maskedEmail}`} className={row.isCurrentStudent ? 'current-student' : ''}><td>{row.rank}</td><td>{row.name}</td><td>{row.maskedEmail}</td><td>{row.totalSp}</td></tr>)}</tbody>
-      </table>
-    </section>
-  );
-}
 
 const fmtDate = d => d ? new Date(d).toLocaleDateString(undefined, { day: 'numeric', month: 'short' }) : '—';
 const toInput = d => d ? new Date(d).toISOString().slice(0, 10) : '';

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -325,10 +325,12 @@ function SpaModule({ student }) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
+    let live = true;
     (async () => {
-      const r = await fetch(`${API}/spa/state?email=${encodeURIComponent(email)}`);
+      const r = await fetch(`${API}/spa/state`);
       setData(await r.json());
     })();
+    return () => { live = false; };
   }, [email]);
 
   if (!data) return <section className="panel">Loading your SPA points…</section>;
@@ -442,7 +444,7 @@ function useAchievements(email) {
   const [data, setData] = useState(null);
   useEffect(() => {
     let live = true;
-    fetch(`${API}/achievements?email=${encodeURIComponent(email)}`)
+    fetch(`${API}/achievements`)
       .then(r => r.json())
       .then(d => { if (live) setData(d); })
       .catch(() => { if (live) setData({ visible: false, groups: [], locked: [], counts: {} }); });
@@ -605,7 +607,7 @@ function ShareModal({ item, me, onClose }) {
         fetch(`${API}/share/card`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: me.email, achId: item.achId, dataUrl: url })
+          body: JSON.stringify({ achId: item.achId, dataUrl: url })
         }).catch(() => {});
       })
       .catch(() => { if (live) setError('Could not draw the card. Try again.'); });
@@ -727,10 +729,12 @@ function ShareModal({ item, me, onClose }) {
 function VerifyView({ code }) {
   const [state, setState] = useState({ loading: true });
   useEffect(() => {
+    let live = true;
     fetch(`${API}/verify/${encodeURIComponent(code)}`)
       .then(r => r.ok ? r.json() : { valid: false })
       .then(d => setState({ loading: false, ...d }))
       .catch(() => setState({ loading: false, valid: false }));
+    return () => { live = false; };
   }, [code]);
 
   return (
@@ -784,7 +788,7 @@ function LeaderboardPanel({ student }) {
   useEffect(() => {
     let live = true;
     setLoading(true);
-    fetch(`${API}/leaderboard/board?window=${preset.window}&category=${preset.category}&scope=${preset.scope}&email=${encodeURIComponent(student.email)}`)
+    fetch(`${API}/leaderboard/board?window=${preset.window}&category=${preset.category}&scope=${preset.scope}`)
       .then(r => r.json())
       .then(d => { if (live) { setData(d); setLoading(false); } })
       .catch(() => { if (live) setLoading(false); });
@@ -829,7 +833,7 @@ function LeaderboardPanel({ student }) {
 function TrajectoryModal({ student, onClose }) {
   const [data, setData] = useState(null);
   useEffect(() => {
-    fetch(`${API}/trajectory/state?email=${encodeURIComponent(student.email)}`).then(r => r.json()).then(setData);
+    fetch(`${API}/trajectory/state`).then(r => r.json()).then(setData);
   }, [student.email]);
 
   const series = data ? [
@@ -1118,10 +1122,10 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
   const [err, setErr] = useState(null);
 
   const load = async () => {
-    const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
+    const r = await fetch(`${API}/journey/state`);
     setData(await r.json());
   };
-  useEffect(() => { load(); }, [email]);
+  useEffect(() => { load(); }, []);
 
   if (!data) return <section className="panel">Loading your journey…</section>;
   if (!data.eligible) return <section className="panel empty">My Journey isn’t available for your cohort yet.</section>;
@@ -1254,14 +1258,14 @@ function VibeGoals({ student }) {
   const [err, setErr] = useState(null);
 
   const load = async () => {
-    const r = await fetch(`${API}/vibe/state?email=${encodeURIComponent(email)}`);
+    const r = await fetch(`${API}/vibe/state`);
     setData(await r.json());
   };
   useEffect(() => {
     load();
     const d = new Date(); d.setDate(d.getDate() + 2);
     setForm(f => ({ ...f, deadline: d.toISOString().slice(0, 10) }));
-  }, [email]);
+  }, []);
 
   if (!data) return <section className="panel">Loading ViBe Goals…</section>;
   if (!data.eligible) return <section className="panel empty">ViBe Goals isn’t available for your cohort yet.</section>;
@@ -1425,10 +1429,10 @@ function StandupGoals({ student }) {
   const [err, setErr] = useState(null);
 
   const load = async () => {
-    const r = await fetch(`${API}/standup/state?email=${encodeURIComponent(email)}`);
+    const r = await fetch(`${API}/standup/state`);
     setData(await r.json());
   };
-  useEffect(() => { load(); }, [email]);
+  useEffect(() => { load(); }, []);
 
   if (!data) return <section className="panel">Loading standups…</section>;
   if (!data.eligible) return <section className="panel empty">Standup commitments aren’t available for your cohort yet.</section>;

--- a/pipeline/sp-pipeline.sh
+++ b/pipeline/sp-pipeline.sh
@@ -1,24 +1,19 @@
 #!/bin/bash
 # sp-pipeline.sh — daily Spurti pipeline, fired 05:45 UTC (11:15 IST) by
 # /etc/cron.d/sp-pipeline, right after the 09:00-11:00 IST mandatory session.
-# Runs the three stages in order so the morning session is scored SAME-DAY
+# Runs the stages in order so the morning session is scored SAME-DAY
 # instead of waiting for the 21:15 UTC nightly build:
 #
-#   1. #zoomupdate            zoom-update.js — ingest today's Zoom attendance +
-#                             polls into zoom_data, then mirror to
-#                             sakshi_spurti.zoom_*  (2GB heap: 7-day window can OOM)
-#   2. sp-rubric-build APPLY  score attendance(A)+poll(B)+base100 into
-#                             sakshi_spurti (backs up first; idempotent
-#                             wipe-and-replace) -> CSVs/backups in sp-runs/
-#   3. sync-spurti-from-sakshi mirror sakshi_spurti SP into chatengine
-#                             (spledgers + User.spPoints) so /spurti reflects it
-#   4. sync-attendance-records sync sakshi_spurti.attendancerecords from
-#                             sptransactions so Session Health widget is accurate
-#   5. sync-poll-records      sync sakshi_spurti.pollrecords from sptransactions
-#   6. zoom-fetch-transcripts fetch AI Companion summaries into zoom_data.summaries
-#                             (non-fatal: summary may still be processing at 11:15;
-#                              today's meeting is retried on next run)
-#   7. (transcript ingest is now chained inside zoom-update.js itself — no separate stage)
+#   1. pipeline/sp-rubric-build-mirror.cjs  APPLY=1  score attendance(A)+poll(B)+base100
+#      into sakshi_spurti (backs up first; idempotent wipe-and-replace)
+#   2. sync-spurti-from-sakshi mirror sakshi_spurti SP into chatengine
+#      (spledgers + User.spPoints) so /spurti reflects it
+#   3. sync-attendance-records sync sakshi_spurti.attendancerecords from
+#      sptransactions so Session Health widget is accurate
+#   4. sync-poll-records      sync sakshi_spurti.pollrecords from sptransactions
+#   5. zoom-fetch-transcripts fetch AI Companion summaries into zoom_data.summaries
+#      (non-fatal: summary may still be processing at 11:15;
+#       today's meeting is retried on next run)
 #
 # Fail-fast: each stage must exit 0 before the next runs. Single-instance via
 # flock in the cron line. Added 2026-06-04.
@@ -35,10 +30,10 @@ $NODE $HEAP zoom-update.js
 rc=$?; echo "--- $(ts) stage1 exit=$rc ---"
 [ $rc -eq 0 ] || { echo "ABORT: #zoomupdate failed (rc=$rc)"; exit 1; }
 
-echo "=== $(ts) STAGE 2/3: sp-rubric-build APPLY=1 ==="
-APPLY=1 OUT_DIR=/var/samagama/server/sp-runs $NODE $HEAP sp-rubric-build.js
+echo "=== $(ts) STAGE 2/3: sp-rubric-build-mirror APPLY=1 ==="
+APPLY=1 OUT_DIR=/var/samagama/server/sp-runs $NODE $HEAP pipeline/sp-rubric-build-mirror.cjs
 rc=$?; echo "--- $(ts) stage2 exit=$rc ---"
-[ $rc -eq 0 ] || { echo "ABORT: sp-rubric-build failed (rc=$rc)"; exit 1; }
+[ $rc -eq 0 ] || { echo "ABORT: sp-rubric-build-mirror failed (rc=$rc)"; exit 1; }
 
 echo "=== $(ts) STAGE 3/3: sync-spurti-from-sakshi (-> chatengine) ==="
 $NODE sync-spurti-from-sakshi.js
@@ -46,12 +41,12 @@ rc=$?; echo "--- $(ts) stage3 exit=$rc ---"
 [ $rc -eq 0 ] || { echo "ABORT: spurti mirror failed (rc=$rc)"; exit 1; }
 
 echo "=== $(ts) STAGE 4/5: sync-attendance-records (-> sakshi_spurti) ==="
-$NODE sync-attendance-records.js
+$NODE sync-attendance-records.cjs
 rc=$?; echo "--- $(ts) stage4 exit=$rc ---"
 [ $rc -eq 0 ] || { echo "ABORT: sync-attendance-records failed (rc=$rc)"; exit 1; }
 
 echo "=== $(ts) STAGE 5/6: sync-poll-records (-> sakshi_spurti) ==="
-$NODE sync-poll-records.js
+$NODE sync-poll-records.cjs
 rc=$?; echo "--- $(ts) stage5 exit=$rc ---"
 [ $rc -eq 0 ] || { echo "ABORT: sync-poll-records failed (rc=$rc)"; exit 1; }
 

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -478,7 +478,7 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   // SPA summary for the web-app SPA tab (display only; SP itself is in the ledger above).
   const Spa = sak.collection('spaprogresses');
   const spaOps = spaSummary.map((s) => ({ updateOne: { filter: { email: s.email },
-    update: { $set: { ...s, activity: 'Activity 1: Linear Algebra', updatedAt: new Date() }, $setOnInsert: { createdAt: new Date() } }, upsert: true } }));
+    update: { $set: { ...s, updatedAt: new Date() }, $setOnInsert: { createdAt: new Date() } }, upsert: true } }));
   for (let i = 0; i < spaOps.length; i += 1000) await Spa.bulkWrite(spaOps.slice(i, i + 1000), { ordered: false });
   console.log(`SPA -> spaprogresses upserted ${spaOps.length}`);
   // RECONCILE: the new ledger is the COMPLETE source of truth — all current SP is

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -59,7 +59,7 @@ const { MongoClient } = require('mongodb');
 const MONGO_URI = process.env.MONGO_URI || '';
 const START_DATE = process.env.START_DATE || '2026-05-15';
 const PROGRAM_START = process.env.PROGRAM_START || '2026-05-15';
-const TODAY = process.env.TODAY || new Date().toISOString().slice(0, 10);
+const TODAY = process.env.TODAY || new Date(Date.now() + 5.5 * 3600 * 1000).toISOString().slice(0, 10);
 const OUT_DIR = process.env.OUT_DIR || process.cwd();
 const APPLY = process.env.APPLY === '1';
 
@@ -127,8 +127,9 @@ const QUERY_BAD_ACTIONS = ['rejected', 'marked_unworthy'];
 // ── PRESERVED categories — NOT recomputable from Zoom source, so they must survive
 // the delete-and-rebuild (else the wipe erases them every run). 'manual' = ViBe/
 // standup commitment SP (stake debits + wins) AND admin manual awards; 'peer_faq' =
-// peer-review FAQ awards. We fold their deltas back into each student's balance.
-const PRESERVED_CATS = ['manual', 'peer_faq'];
+// peer-review FAQ awards; 'streak' = streak bonuses; 'peer_review' = peer-review
+// SP. We fold their deltas back into each student's balance.
+const PRESERVED_CATS = ['manual', 'peer_faq', 'streak', 'peer_review'];
 
 const isMandatory = (t) => /stand|orientation/i.test(t) && !/breakout|weekend|nptel|special|support|non[- ]?mandatory/i.test(t);
 const tier = (pct) => { pct = Math.min(100, pct); return pct >= 90 ? 10 : pct >= 75 ? 5 : pct >= 50 ? 3 : 0; };
@@ -453,6 +454,15 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   console.log(`reconcile: ${stalePreview.length} currently-scored students NOT in new ledger would be cleared (totalSp=0) on APPLY`);
 
   if (!APPLY) { console.log('\nDRY RUN — no DB write. Set APPLY=1 to replace sakshi_spurti points.'); await conn.close(); return; }
+
+  // Safety floor: an empty/stale mirror (sync-collaborator-mirrors.js failed) would
+  // wipe everyone's SP on APPLY. Abort if the new ledger is implausibly small.
+  const MIN_STUDENTS = 2000;
+  if (finalBal.size < MIN_STUDENTS) {
+    console.error(`ABORT: new ledger has only ${finalBal.size} students (floor ${MIN_STUDENTS}). Mirror data is likely stale or empty.`);
+    await conn.close();
+    process.exit(1);
+  }
 
   // 6. APPLY: replace sakshi_spurti points (backs up sptransactions + students first)
   const backupDir = path.join(OUT_DIR, `sp_backup_mirror_${ts}`); fs.mkdirSync(backupDir, { recursive: true });

--- a/pipeline/sync-attendance-records.cjs
+++ b/pipeline/sync-attendance-records.cjs
@@ -96,13 +96,14 @@ const REASON_RE = /present (\d+) of (\d+) min \(([\d.]+)%\)/;
 
   console.log(`Done. written=${upserted} skipped=${skipped} of ${txns.length} attendance txns`);
 
-  // Verify for harsh007rana
-  const check = await db.collection('attendancerecords')
-    .find({ email: 'harsh007rana@gmail.com' })
-    .sort({ sessionLabel: 1 })
-    .toArray();
-  console.log(`\nharsh007rana AttendanceRecord count: ${check.length}`);
-  check.forEach(r => console.log(` ${r.sessionLabel} | qualified:${r.qualified} | mins:${r.attendedMinutes}/${r.totalSessionMinutes} (${r.attendancePercentage}%)`));
+  if (process.env.DEBUG) {
+    const check = await db.collection('attendancerecords')
+      .find({ email: 'harsh007rana@gmail.com' })
+      .sort({ sessionLabel: 1 })
+      .toArray();
+    console.log(`\nharsh007rana AttendanceRecord count: ${check.length}`);
+    check.forEach(r => console.log(` ${r.sessionLabel} | qualified:${r.qualified} | mins:${r.attendedMinutes}/${r.totalSessionMinutes} (${r.attendancePercentage}%)`));
+  }
 
   await client.close();
 })().catch(e => { console.error('FATAL', e); process.exit(1); });

--- a/server/config.js
+++ b/server/config.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
 export const PORT = Number(process.env.PORT || 5290);
-export const MONGO_URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/analysis_summership';
+export const MONGO_URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/sakshi_spurti';
 export const ALLOW_STUDENT_SEARCH = process.env.ALLOW_STUDENT_SEARCH !== 'false';
 // Samagama validates the student's chatengine_token cookie. Spurti reads that
 // cookie and confirms the session against this internal endpoint (same host).

--- a/server/models/PollRecord.js
+++ b/server/models/PollRecord.js
@@ -18,6 +18,11 @@ const pollRecordSchema = new mongoose.Schema({
   transactionId: { type: mongoose.Schema.Types.ObjectId, ref: 'SPTransaction' }
 }, { timestamps: true });
 
+pollRecordSchema.pre('save', function (next) {
+  this.missedQuestions = Math.max(0, this.totalQuestions - this.attemptedQuestions);
+  next();
+});
+
 pollRecordSchema.index({ email: 1, sessionLabel: 1 }, { unique: true });
 
 export default mongoose.model('PollRecord', pollRecordSchema);

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -9,7 +9,7 @@ const studentSchema = new mongoose.Schema({
   status: { type: String, enum: ['active', 'excused'], default: 'active', index: true },
   excusedAt: { type: Date, default: null },
   excusedReason: { type: String, default: '' },
-  totalSp: { type: Number, default: 100, index: true },
+  totalSp: { type: Number, default: 100, index: true, min: [0, 'totalSp cannot be negative'] },
   // Spurti Levels & Trophy Leagues — derived views over SP (see services/levels.js).
   highestSpEver: { type: Number, default: 100, index: true },
   level: { type: Number, default: 1 },

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -9,7 +9,7 @@ const studentSchema = new mongoose.Schema({
   status: { type: String, enum: ['active', 'excused'], default: 'active', index: true },
   excusedAt: { type: Date, default: null },
   excusedReason: { type: String, default: '' },
-  totalSp: { type: Number, default: 100, index: true, min: [0, 'totalSp cannot be negative'] },
+  totalSp: { type: Number, default: 0, index: true, min: [0, 'totalSp cannot be negative'] },
   // Spurti Levels & Trophy Leagues — derived views over SP (see services/levels.js).
   highestSpEver: { type: Number, default: 100, index: true },
   level: { type: Number, default: 1 },

--- a/server/server.js
+++ b/server/server.js
@@ -457,8 +457,11 @@ api.get('/search', async (req, res) => {
 });
 
 api.post('/confirm', async (req, res) => {
+  const sessionEmail = await studentEmailFromRequest(req);
+  if (!sessionEmail) return res.status(401).json({ error: 'Not authenticated' });
   if (!ALLOW_STUDENT_SEARCH) return res.status(403).json({ error: 'Student search is disabled. Please login from Samagama to view your Spurti Points.' });
   const { studentId, email } = req.body || {};
+  if (!mongoose.Types.ObjectId.isValid(studentId)) return res.status(400).json({ error: 'Invalid student ID' });
   const typed = normalizeEmail(email);
   const student = await Student.findById(studentId).lean();
   if (!student) return res.status(404).json({ error: 'Student not found' });

--- a/server/server.js
+++ b/server/server.js
@@ -1160,7 +1160,8 @@ if (fs.existsSync(clientDist)) {
       // A crawler only ever hits this route, which is what the bot flag is for.
       logAchievementView(req, req.params.code, found);
       res.status(found ? 200 : 404).type('html').send(html);
-    } catch {
+    } catch (err) {
+      console.error('[verify-page]', err);
       res.sendFile(path.join(clientDist, 'index.html'));
     }
   });

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import mongoose from 'mongoose';
 import path from 'path';
 import fs from 'fs';
+import mongoSanitize from 'express-mongo-sanitize';
 import { fileURLToPath } from 'url';
 
 import { ALLOW_STUDENT_SEARCH, MONGO_URI, PORT, SAMAGAMA_AUTH_URL } from './config.js';
@@ -168,6 +169,7 @@ function evictStaleViewers() {
 
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
+app.use(mongoSanitize());
 
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
@@ -320,7 +322,7 @@ async function studentPayload(student) {
 function isAdmin(req) {
   if (!ADMIN_EMAIL || !ADMIN_TOKEN) return false; // fail closed when admin creds aren't configured
   const emailOk = normalizeEmail(req.headers['x-admin-email']) === ADMIN_EMAIL;
-  const tokenOk = String(req.headers['x-admin-token'] || '') === ADMIN_TOKEN;
+  const tokenOk = crypto.timingSafeEqual(String(req.headers['x-admin-token'] || '').padEnd(32, '\0'), String(ADMIN_TOKEN).padEnd(32, '\0'));
   return emailOk && tokenOk;
 }
 
@@ -442,6 +444,7 @@ api.get('/search', async (req, res) => {
   if (!ALLOW_STUDENT_SEARCH) return res.status(403).json({ error: 'Student search is disabled. Please login from Samagama to view your Spurti Points.' });
   const q = String(req.query.q || '').trim();
   if (q.length < 2) return res.json({ exact: false, matches: [] });
+  if (q.length > 100) return res.json({ exact: false, matches: [] });
 
   if (q.includes('@')) {
     const email = normalizeEmail(q);
@@ -638,9 +641,12 @@ api.post('/ping', async (req, res) => {
   const { email, name, page } = req.body || {};
   const normalized = normalizeEmail(email);
   if (!normalized || !name || !page) return res.status(400).json({ error: 'email, name, page required' });
-  // Telemetry is best-effort: an unknown page value (e.g. a new admin sub-page
-  // not yet in the enum) must never crash the request or leak an unhandled
-  // rejection. Drop the write and carry on.
+  // Validate name: max 100 chars, allow letters/numbers/spaces
+  if (!/^[\w .'-]{1,100}$/.test(name)) return res.status(400).json({ error: 'Invalid name format' });
+  // Validate page: allowlist of known pages
+  const allowedPages = ['record', 'admin', 'survey', 'poll', 'vibe', 'standup', 'journey', 'leaderboard', 'achievements'];
+  if (!allowedPages.includes(page)) return res.status(400).json({ error: 'Invalid page value' });
+  const pageMax = allowedPages.includes(page) ? allowedPages.length : 1;
   try {
     await SessionEvent.create({ email: normalized, name, event: 'page_view', page });
   } catch (err) {

--- a/server/server.js
+++ b/server/server.js
@@ -1184,6 +1184,11 @@ if (fs.existsSync(clientDist)) {
 }
 
 mongoose.connect(MONGO_URI).then(() => {
+  app.use((err, _req, res, _next) => {
+    console.error(err.stack);
+    res.status(500).json({ error: 'Internal server error' });
+  });
+mongoose.connect(MONGO_URI).then(() => {
   app.listen(PORT, () => console.log(`Spurti app running at http://localhost:${PORT}/`));
 }).catch((error) => {
   console.error(error);

--- a/server/server.js
+++ b/server/server.js
@@ -159,6 +159,12 @@ const app = express();
 app.set('trust proxy', 1);
 const api = express.Router();
 const liveViewers = new Map();
+function evictStaleViewers() {
+  const cutoff = Date.now() - 60_000;
+  for (const [email, data] of liveViewers.entries()) {
+    if (data.lastSeen.getTime() < cutoff) liveViewers.delete(email);
+  }
+}
 
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
@@ -627,6 +633,8 @@ api.post('/share/track', async (req, res) => {
 });
 
 api.post('/ping', async (req, res) => {
+  const sessionEmail = await studentEmailFromRequest(req);
+  if (!sessionEmail) return res.status(401).json({ error: 'Not authenticated' });
   const { email, name, page } = req.body || {};
   const normalized = normalizeEmail(email);
   if (!normalized || !name || !page) return res.status(400).json({ error: 'email, name, page required' });
@@ -639,6 +647,7 @@ api.post('/ping', async (req, res) => {
     if (err?.name !== 'ValidationError') console.error('ping log failed:', err?.message);
   }
   if (page === 'record' || page.startsWith('admin')) {
+    evictStaleViewers();
     liveViewers.set(normalized, { name, page, lastSeen: new Date() });
   }
   res.json({ ok: true });


### PR DESCRIPTION
## Fixes

**M8. Wrong default MONGO_URI** (server/config.js:4)
Default was analysis_summership instead of sakshi_spurti. Missing .env now connects to the right database.

**M11. 	otalSp no min:0 constraint** (server/models/Student.js:12)
Added min: [0, 'totalSp cannot be negative']. Belt-and-suspenders guard against negative SP from any code path (legacy 
ecalculateStudentSp, future bugs).

**L5. Verify page catch swallows errors silently** (server/server.js:1163)
Added console.error before falling back to SPA shell. Transient DB failures were previously invisible.

**Note:** H4 (e.email → e in pipeline reconciliation) was already fixed on main.