### PR TITLE
fix(spa): correct the integrity penalty — fraud netting, offence dating, and the penalty base

### DIFF
--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -430,9 +430,14 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
       // on every sp-refresh (4x/day), so a TODAY stamp re-dated one old decision every
       // run — in a newest-first SP Bank that reads as a fresh punishment every morning.
       const penDate = (flags.fraud ? flags.fraudDate : flags.auditDate) || TODAY;
-      spaPenalty = Math.round(rows.reduce((a, r) => a + r.delta, 0) * penRate);
+      // Base is what the student had EARNED BY the offence date, not their whole
+      // accumulated total. Charging a July offence against August earnings meant the
+      // penalty kept growing after the fact, and a back-dated row computed from future
+      // rows made the running balance dip by more than was ever there at that point.
+      const penBase = rows.reduce((a, r) => a + (r.date <= penDate ? r.delta : 0), 0);
+      spaPenalty = Math.round(penBase * penRate);
       if (spaPenalty > 0) rows.push({ date: penDate, order: 9, cat: 'spa', delta: -spaPenalty,
-        reason: `SPA (${ddmon(penDate)}): ${flags.fraud ? 'fraud' : 'audit-failure'} penalty -${Math.round(penRate * 100)}% of SP earned from attendance, polls and SPA -> -${spaPenalty} SP.` });
+        reason: `SPA (${ddmon(penDate)}): ${flags.fraud ? 'fraud' : 'audit-failure'} penalty -${Math.round(penRate * 100)}% of the ${penBase} SP earned up to ${ddmon(penDate)} -> -${spaPenalty} SP.` });
     }
     // Query-answer rows: +5 per distinct peer query answered, one 'query' row per
     // day, oldest-first, capped at QUERY_CAP SP per student (excess days truncated).

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -313,10 +313,17 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   }
   // Genuine fraud = net teacher_fraud_penalty + fraud_penalty_reversal < 0, with
   // operator "Testing" rows excluded (they are demote-feature tests, all reversed).
+  // The /testing/i guard applies to the PENALTY side ONLY — a reversal always counts.
+  // A reversal's reason routinely quotes the penalty it undoes (e.g. '...was explicitly
+  // logged with reason "Testing purpose"'), so filtering both sides dropped the +credit
+  // and kept the -debit, flagging a net-zero account as fraud. That hit exactly one
+  // person: an auditor whose penalty had already been investigated and reversed.
   for (const f of await sak.collection('act_spa_transactions').aggregate([
-        { $match: { transactionType: { $in: ['teacher_fraud_penalty', 'fraud_penalty_reversal'] }, reason: { $not: /testing/i } } },
-        { $group: { _id: { $toLower: '$email' }, net: { $sum: '$deltaSPA' } } }]).toArray()) {
-    if (f.net < 0) { const c = canonOf(f._id); spaFlag.set(c, { ...(spaFlag.get(c) || {}), fraud: true }); }
+        { $match: { $or: [
+            { transactionType: 'teacher_fraud_penalty', reason: { $not: /testing/i } },
+            { transactionType: 'fraud_penalty_reversal' }] } },
+        { $group: { _id: { $toLower: '$email' }, net: { $sum: '$deltaSPA' }, when: { $max: '$createdAt' } } }]).toArray()) {
+    if (f.net < 0) { const c = canonOf(f._id); spaFlag.set(c, { ...(spaFlag.get(c) || {}), fraud: true, fraudDate: dstr(f.when) || null }); }
   }
   // Audit failures, EXCLUDING the collusion-pattern cleanup. That sweep de-endorsed
   // ~28k endorsements in bulk off a multi-signal detector, and its own rejectNote
@@ -326,7 +333,7 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   // who ALSO has a genuine audit failure still gets flagged, on that row's merit.
   const auditRows = await sak.collection('act_spa_transactions').find(
         { transactionType: { $in: ['audit_failure_learner_penalty', 'audit_failure_teacher_penalty'] } },
-        { projection: { email: 1, endorsementId: 1 } }).toArray();
+        { projection: { email: 1, endorsementId: 1, createdAt: 1 } }).toArray();
   const auditEids = [...new Set(auditRows.map((r) => r.endorsementId).filter(Boolean))];
   const cleanupEids = new Set((await sak.collection('act_spa_endorsements').find(
         { _id: { $in: auditEids }, rejectNote: /collusion-pattern cleanup/i },
@@ -334,7 +341,9 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   for (const a of auditRows) {
     if (a.endorsementId && cleanupEids.has(String(a.endorsementId))) continue;
     const c = canonOf(String(a.email || '').toLowerCase().trim());
-    spaFlag.set(c, { ...(spaFlag.get(c) || {}), auditFail: true });
+    const prev = spaFlag.get(c) || {};
+    const d = dstr(a.createdAt); // date of the offence, for dating the penalty row
+    spaFlag.set(c, { ...prev, auditFail: true, auditDate: (d && (!prev.auditDate || d > prev.auditDate)) ? d : prev.auditDate });
   }
 
   // 3d. Query answering → per-canon distinct queries answered (dated). Answerer =
@@ -417,9 +426,13 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     const penRate = flags.fraud ? SPA_FRAUD_RATE : (flags.auditFail ? SPA_AUDIT_RATE : 0);
     let spaPenalty = 0;
     if (penRate > 0) {
+      // Date the penalty to the offence, NOT to TODAY. The ledger is wiped and rebuilt
+      // on every sp-refresh (4x/day), so a TODAY stamp re-dated one old decision every
+      // run — in a newest-first SP Bank that reads as a fresh punishment every morning.
+      const penDate = (flags.fraud ? flags.fraudDate : flags.auditDate) || TODAY;
       spaPenalty = Math.round(rows.reduce((a, r) => a + r.delta, 0) * penRate);
-      if (spaPenalty > 0) rows.push({ date: TODAY, order: 9, cat: 'spa', delta: -spaPenalty,
-        reason: `SPA (${ddmon(TODAY)}): ${flags.fraud ? 'fraud' : 'audit-failure'} penalty -${Math.round(penRate * 100)}% of current SP -> -${spaPenalty} SP.` });
+      if (spaPenalty > 0) rows.push({ date: penDate, order: 9, cat: 'spa', delta: -spaPenalty,
+        reason: `SPA (${ddmon(penDate)}): ${flags.fraud ? 'fraud' : 'audit-failure'} penalty -${Math.round(penRate * 100)}% of SP earned from attendance, polls and SPA -> -${spaPenalty} SP.` });
     }
     // Query-answer rows: +5 per distinct peer query answered, one 'query' row per
     // day, oldest-first, capped at QUERY_CAP SP per student (excess days truncated).

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -318,10 +318,23 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
         { $group: { _id: { $toLower: '$email' }, net: { $sum: '$deltaSPA' } } }]).toArray()) {
     if (f.net < 0) { const c = canonOf(f._id); spaFlag.set(c, { ...(spaFlag.get(c) || {}), fraud: true }); }
   }
-  for (const a of await sak.collection('act_spa_transactions').aggregate([
-        { $match: { transactionType: { $in: ['audit_failure_learner_penalty', 'audit_failure_teacher_penalty'] } } },
-        { $group: { _id: { $toLower: '$email' } } }]).toArray()) {
-    const c = canonOf(a._id); spaFlag.set(c, { ...(spaFlag.get(c) || {}), auditFail: true });
+  // Audit failures, EXCLUDING the collusion-pattern cleanup. That sweep de-endorsed
+  // ~28k endorsements in bulk off a multi-signal detector, and its own rejectNote
+  // says the teacher's +10% reward was revoked and "no other penalty" — so it is
+  // not adjudicated misconduct and must not trigger the -20%. Same guard in spirit
+  // as the fraud netting above, which already drops operator test rows. A student
+  // who ALSO has a genuine audit failure still gets flagged, on that row's merit.
+  const auditRows = await sak.collection('act_spa_transactions').find(
+        { transactionType: { $in: ['audit_failure_learner_penalty', 'audit_failure_teacher_penalty'] } },
+        { projection: { email: 1, endorsementId: 1 } }).toArray();
+  const auditEids = [...new Set(auditRows.map((r) => r.endorsementId).filter(Boolean))];
+  const cleanupEids = new Set((await sak.collection('act_spa_endorsements').find(
+        { _id: { $in: auditEids }, rejectNote: /collusion-pattern cleanup/i },
+        { projection: { _id: 1 } }).toArray()).map((d) => String(d._id)));
+  for (const a of auditRows) {
+    if (a.endorsementId && cleanupEids.has(String(a.endorsementId))) continue;
+    const c = canonOf(String(a.email || '').toLowerCase().trim());
+    spaFlag.set(c, { ...(spaFlag.get(c) || {}), auditFail: true });
   }
 
   // 3d. Query answering → per-canon distinct queries answered (dated). Answerer =


### PR DESCRIPTION
Three commits. The trigger was 21 students seeing a fresh SP deduction every morning for one July decision.

### 1. The collusion cleanup is not an audit failure (`0590639`)
The 23 Jul sweep de-endorsed ~28k endorsements off a multi-signal detector; its own `rejectNote` says the teacher's +10% reward was revoked and "no other penalty". Not adjudicated misconduct, so it must not trigger the -20%. Clears 9 students.

### 2. Fraud netting dropped the credit and kept the debit (`820c93d`)
`reason: { $not: /testing/i }` was applied to `teacher_fraud_penalty` **and** `fraud_penalty_reversal`. But a reversal routinely quotes the penalty it undoes — one reads *'...was explicitly logged with reason "Testing purpose"'* — so the +95 credit was filtered out and the -95 debit kept. A reversed, net-zero account was read as net -95 and flagged as fraud, costing -50% of their SP.

The guard now applies to the penalty side only; a reversal always counts. Exactly one account was affected, verified across the whole collection. They keep an unrelated -20% audit penalty earned as a learner.

**Same commit:** the penalty row was stamped `date: TODAY`. The ledger is wiped and rebuilt on every `sp-refresh` (4x/day), so one old offence re-dated itself every run and read as new in a newest-first SP Bank. The offence date is now carried through `spaFlag` and stamped on the row.

Also corrected the reason text, which claimed "-20% of current SP" — the base never included query or preserved rows.

### 3. Charge the penalty against SP earned by the offence date (`affa61d`)
Policy decision. The base was the student's whole accumulated total, so a July offence was charged against August earnings and kept growing after the fact. Back-dating the row made that visible. The base is now the sum of rows dated on or before the offence, and the reason text states it so students can check the arithmetic.

### Dry run against live data (`APPLY` unset, no writes)

| | live now | after |
|---|---|---|
| rows / students | 21 / 21 | 21 / 21 |
| total | -5515 SP | **-4895 SP** |
| dates | all stamped today | 23 Jul x17, 27 Jul x2, 10 Aug x2 |
| kinds | 20 audit + 1 fraud | 21 audit, 0 fraud |

17 students softened, 4 unchanged, **0 harsher**. 620 SP returned in total. `reconcile: 0` — no student is cleared as a side effect.

### Not changed
Audits **were** genuinely run — every surviving endorsement carries `auditedBy`, `auditedAt` and `status: audit_failed`, confirmed with the auditor. All 21 penalties stand on their merits; only their dating and base change.

### Known issue, out of scope
One audited endorsement carries `teacherRewardSPA: 327897856512565250` (3.3e17, past `Number.MAX_SAFE_INTEGER`). Harmless today because the pipeline scores endorsement counts rather than `deltaSPA`, but worth a separate look.