### PR TITLE
feat(achievements): tell students when a new card is waiting

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -285,7 +285,10 @@ function StudentView({ profile, onBack }) {
   const goToCommitment = ph => { setCommitPhase(ph); setTab('vibe'); };
   // Fetched up here rather than inside the panel because the server decides who
   // gets the tab at all — until it answers `visible`, the tab strip omits it.
-  const ach = useAchievements(student.email);
+  const [ach, markAchievementsSeen] = useAchievements(student.email);
+  const unseenAchievements = ach?.counts?.unseen || 0;
+  // Opening the tab is what counts as seeing them, wherever it is opened from.
+  const selectTab = key => { setTab(key); if (key === 'achievements') markAchievementsSeen(); };
   return (
     <main className="page compact">
       <header className="topbar">
@@ -297,12 +300,17 @@ function StudentView({ profile, onBack }) {
         <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
       <LevelStatus student={student} />
-      <StudentPulse profile={profile} />
-      <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'],
+      <StudentPulse
+        profile={profile}
+        newAchievements={unseenAchievements}
+        canShareAchievements={!!ach?.sharing}
+        onOpenAchievements={() => selectTab('achievements')}
+      />
+      <Tabs tab={tab} setTab={selectTab} tabs={[['bank','SP Bank'],
         ['journey','My Journey'],
         ...(student.eligibleForVibeGoals ? [['vibe','Commitments']] : []),
         ['spa','SPA Points'],
-        ...(ach?.visible ? [['achievements','Achievements']] : []),
+        ...(ach?.visible ? [['achievements','Achievements', unseenAchievements]] : []),
         ['leaderboard','Leaderboard'],
         ['faq','FAQ']]} />
       {tab === 'bank' && <SpBank transactions={profile.transactions} />}
@@ -448,7 +456,18 @@ function useAchievements(email) {
       .catch(() => { if (live) setData({ visible: false, groups: [], locked: [], counts: {} }); });
     return () => { live = false; };
   }, [email]);
-  return data;
+  // Clearing the badge is optimistic: the student HAS looked, so it should go
+  // the moment they click rather than after a round trip. If the POST fails the
+  // count simply comes back on the next load — nothing is lost either way.
+  const markSeen = () => {
+    setData(d => (d?.counts?.unseen ? { ...d, counts: { ...d.counts, unseen: 0 } } : d));
+    fetch(`${API}/achievements/seen`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    }).catch(() => {});
+  };
+  return [data, markSeen];
 }
 
 function AchievementsPanel({ student, data }) {
@@ -892,12 +911,29 @@ function TrajectoryModal({ student, onClose }) {
   );
 }
 
-function StudentPulse({ profile }) {
+function StudentPulse({ profile, newAchievements = 0, canShareAchievements = false, onOpenAchievements }) {
   const { student, cohort, transactions } = profile;
   const [showTraj, setShowTraj] = useState(false);
   const trend = transactions.map(tx => ({ label: tx.sessionLabel || 'Start', value: tx.balanceAfter }));
+  const many = newAchievements > 1;
   return (
     <>
+      {/* Milestones are settled on read, so a card can come into existence during
+          the very page load the student is looking at. Nothing else on the page
+          would tell them: the tab strip sits lower and reads identically whether
+          or not something new is waiting. */}
+      {newAchievements > 0 && onOpenAchievements && (
+        <button className="ach-nudge" onClick={onOpenAchievements}>
+          <span className="ach-nudge-icon" aria-hidden="true">🎖️</span>
+          <span className="ach-nudge-text">
+            <strong>{newAchievements} new achievement{many ? 's' : ''}</strong>
+            <em>{canShareAchievements
+              ? `See ${many ? 'them' : 'it'} and share ${many ? 'them' : 'it'}`
+              : `See ${many ? 'them' : 'it'} in your Achievements tab`}</em>
+          </span>
+          <span className="ach-nudge-go" aria-hidden="true">→</span>
+        </button>
+      )}
       <section className="pulse-grid">
         <div className="pulse-card progress-card">
           <span>Standing</span>
@@ -979,8 +1015,15 @@ function FaqTab() {
   );
 }
 
+// A tab entry is [key, label] or [key, label, badge]; the badge is only drawn
+// when it is a positive number, so existing callers are untouched.
 function Tabs({ tab, setTab, tabs }) {
-  return <nav className="tabs">{tabs.map(([key, label]) => <button key={key} className={tab === key ? 'active' : ''} onClick={() => setTab(key)}>{label}</button>)}</nav>;
+  return <nav className="tabs">{tabs.map(([key, label, badge]) => (
+    <button key={key} className={tab === key ? 'active' : ''} onClick={() => setTab(key)}>
+      {label}
+      {badge > 0 && <span className="tab-badge" aria-label={`${badge} new`}>{badge}</span>}
+    </button>
+  ))}</nav>;
 }
 
 function SpBank({ transactions }) {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -183,6 +183,42 @@ input {
   white-space: nowrap;
 }
 .tabs button.active { background: var(--primary); border-color: var(--primary); color: #fff; }
+/* Unseen-achievement count. Sits on the tab itself so the strip stops reading
+   identically whether or not something new is waiting. */
+.tab-badge {
+  display: inline-block;
+  min-width: 18px;
+  margin-left: 7px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: #c2410c;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 850;
+  line-height: 18px;
+  text-align: center;
+}
+.tabs button.active .tab-badge { background: #fff; color: var(--primary-dark); }
+/* The same signal, above the tab strip, where it cannot be scrolled past. */
+.ach-nudge {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-bottom: 14px;
+  padding: 12px 16px;
+  border: 1px solid #f5c9a8;
+  border-radius: 10px;
+  background: #fff6ef;
+  text-align: left;
+  cursor: pointer;
+}
+.ach-nudge:hover { background: #ffeee1; border-color: #e8a877; }
+.ach-nudge-icon { font-size: 22px; line-height: 1; }
+.ach-nudge-text { display: flex; flex-direction: column; gap: 2px; }
+.ach-nudge-text strong { color: #9a3412; font-size: 15px; }
+.ach-nudge-text em { color: var(--muted); font-style: normal; font-size: 13px; }
+.ach-nudge-go { margin-left: auto; color: #9a3412; font-size: 18px; font-weight: 850; }
 .panel {
   padding: 20px;
   margin-bottom: 18px;

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -27,7 +27,11 @@ const studentSchema = new mongoose.Schema({
   poll2CompletedAt: { type: Date, default: null },
   // Third pop-up ("poll3") — dashboard usability survey. Same mechanism, own flag.
   poll3Completed: { type: Boolean, default: false, index: true },
-  poll3CompletedAt: { type: Date, default: null }
+  poll3CompletedAt: { type: Date, default: null },
+  // The last time the student actually OPENED the Achievements tab. Anything
+  // earned after this is still new to them, which is what the tab badge counts.
+  // Null means never opened, so everything they hold is unseen.
+  achievementsSeenAt: { type: Date, default: null }
 }, { timestamps: true });
 
 studentSchema.index({ name: 'text', email: 'text', alternateEmail: 'text' });

--- a/server/server.js
+++ b/server/server.js
@@ -523,6 +523,17 @@ api.get('/achievements', async (req, res) => {
   });
 });
 
+// Marks the tab as read. Deliberately NOT folded into GET /achievements: that
+// fires on every dashboard load, whatever tab is showing, so letting it stamp
+// would mean nothing was ever unseen and the badge could never appear.
+api.post('/achievements/seen', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  if (!achievementsAccess(student).visible) return res.status(403).json({ error: 'Achievements are off' });
+  await Student.updateOne({ _id: student._id }, { $set: { achievementsSeenAt: new Date() } });
+  res.json({ ok: true });
+});
+
 // Public — this is what the QR on a shared card opens. No login, no PII beyond
 // the recipient's name and what they won.
 api.get('/verify/:code', async (req, res) => {

--- a/server/services/achievements.js
+++ b/server/services/achievements.js
@@ -122,13 +122,18 @@ export async function buildAchievementState(student) {
   const all = [...groups.values()];
   const earnedCount = rows.length;
   const weekAgo = new Date(Date.now() - 7 * 86400000);
+  // "Unseen" is measured against the last time the tab was actually opened, not
+  // a rolling window: a card stays flagged until the student has looked at it,
+  // and stops the moment they do. Never opened means everything they hold is new.
+  const seenAt = student.achievementsSeenAt ? new Date(student.achievementsSeenAt) : null;
   return {
     groups: all,
     locked,
     counts: {
       earned: earnedCount,
       thisWeek: rows.filter((a) => new Date(a.earnedAt) >= weekAgo).length,
-      boards: all.filter((g) => g.kind === 'rank').length
+      boards: all.filter((g) => g.kind === 'rank').length,
+      unseen: rows.filter((a) => !seenAt || new Date(a.earnedAt) > seenAt).length
     }
   };
 }


### PR DESCRIPTION
Adds an unseen-achievements signal so newly minted cards get noticed (sharing collapsed to ~10/day because discovery was 100% pull):

- `Student.achievementsSeenAt` + `counts.unseen` in `GET /api/achievements`
- `POST /api/achievements/seen` stamps on tab open (own POST, since GET fires on every dashboard load)
- unseen count on the Achievements tab + clickable nudge line in StudentPulse

Deliberately not a rolling `thisWeek` window: it stays lit after the student looks, and goes dark for old cards nobody opened.

**Already live on prod since 20 Aug** (scp + rebuild + PM2 restart) - this PR reconciles main with what is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)