### PR TITLE
feat: dashboard announcements with Got-it read tracking + audience targeting

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -297,6 +297,7 @@ function StudentView({ profile, onBack }) {
         <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
       <LevelStatus student={student} />
+      <Announcements student={student} />
       <StudentPulse profile={profile} />
       <Tabs tab={tab} setTab={setTab} tabs={[['bank','SP Bank'],
         ['journey','My Journey'],
@@ -889,6 +890,61 @@ function TrajectoryModal({ student, onClose }) {
         )}
       </div>
     </div>
+  );
+}
+
+// Programme announcements with read-tracking. Unread notices render as a
+// highlighted card with a "Got it" button — that ack is the read signal the
+// team tracks. Read ones fold away behind a toggle so the page stays clean,
+// and the whole section disappears when there are no notices at all.
+function Announcements({ student }) {
+  const [data, setData] = useState(null);
+  const [showRead, setShowRead] = useState(false);
+  const load = async () => {
+    try {
+      const r = await fetch(`${API}/announcements?email=${encodeURIComponent(student.email)}`);
+      if (r.ok) setData(await r.json());
+    } catch { /* a failed notice fetch must never break the dashboard */ }
+  };
+  useEffect(() => { load(); }, [student.email]);
+  if (!data || !data.announcements?.length) return null;
+
+  const unread = data.announcements.filter(a => !a.acked);
+  const read = data.announcements.filter(a => a.acked);
+  const ack = async id => {
+    await fetch(`${API}/announcements/${id}/ack`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: student.email })
+    });
+    load();
+  };
+  const fmt = d => new Date(d).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
+
+  return (
+    <section className="panel announcements">
+      <div className="ann-head">
+        <h2>📣 Announcements{unread.length > 0 && <em className="ann-badge">{unread.length} new</em>}</h2>
+        {read.length > 0 && (
+          <button className="ann-toggle" onClick={() => setShowRead(s => !s)}>
+            {showRead ? 'Hide read' : `Read earlier (${read.length})`}
+          </button>
+        )}
+      </div>
+      {unread.map(a => (
+        <article key={a.id} className="ann-item ann-new">
+          <header><strong>{a.title}</strong><time>{fmt(a.postedAt)}</time></header>
+          <p>{a.body}</p>
+          <button className="primary ann-ack" onClick={() => ack(a.id)}>Got it ✓</button>
+        </article>
+      ))}
+      {unread.length === 0 && <p className="muted ann-caughtup">You’re all caught up.</p>}
+      {showRead && read.map(a => (
+        <article key={a.id} className="ann-item ann-done">
+          <header><strong>{a.title}</strong><time>{fmt(a.postedAt)} · read ✓</time></header>
+          <p>{a.body}</p>
+        </article>
+      ))}
+    </section>
   );
 }
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -793,3 +793,28 @@ tr.step-alert td { border-color: #f3c9c5; }
 /* The "artwork may change" note sits under the main blurb — quieter than it,
    so it reads as a footnote rather than a second announcement. */
 .ach-head .ach-note { font-size: 12px; margin-top: -2px; opacity: .8; }
+
+/* ── Announcements (programme notices with read-tracking) ─────────────────── */
+.announcements { margin-bottom: 16px; padding: 16px 18px; }
+.ann-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.ann-head h2 { margin: 0; font-size: 17px; display: flex; align-items: center; gap: 8px; }
+.ann-badge {
+  font-style: normal; font-size: 12px; font-weight: 700; color: #fff;
+  background: var(--amber); border-radius: 999px; padding: 2px 9px;
+}
+.ann-toggle {
+  background: none; border: none; color: var(--primary);
+  font-size: 13px; font-weight: 600; padding: 4px 6px;
+}
+.ann-toggle:hover { text-decoration: underline; }
+.ann-item { border-radius: 12px; padding: 12px 14px; margin-top: 8px; }
+.ann-item header { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
+.ann-item header strong { font-size: 15px; }
+.ann-item header time { font-size: 12px; color: var(--muted); white-space: nowrap; }
+.ann-item p { margin: 6px 0 0; font-size: 14px; line-height: 1.55; white-space: pre-line; }
+.ann-new { background: #fff8ec; border: 1px solid #f2d9a4; }
+.ann-new + .ann-new { margin-top: 10px; }
+.ann-ack { margin-top: 10px; padding: 7px 16px; font-size: 13px; }
+.ann-done { background: #f6f8fb; border: 1px solid var(--line); }
+.ann-done p, .ann-done header strong { color: var(--muted); }
+.ann-caughtup { margin: 2px 0 0; font-size: 13px; }

--- a/server/models/Announcement.js
+++ b/server/models/Announcement.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+// A programme notice shown on every student's dashboard until they press
+// "Got it". Created by the team (admin route or mongosh); students never write.
+const announcementSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  body: { type: String, required: true },
+  postedAt: { type: Date, default: Date.now, index: true },
+  // Deactivating hides the notice everywhere but keeps it and its acks for the
+  // record — announcements are never deleted, so read-rates stay auditable.
+  active: { type: Boolean, default: true, index: true }
+}, { timestamps: true });
+
+export default mongoose.model('Announcement', announcementSchema);

--- a/server/models/Announcement.js
+++ b/server/models/Announcement.js
@@ -6,6 +6,9 @@ const announcementSchema = new mongoose.Schema({
   title: { type: String, required: true },
   body: { type: String, required: true },
   postedAt: { type: Date, default: Date.now, index: true },
+  // Empty = broadcast to everyone. Non-empty = only these (lowercased) emails see
+  // the notice — the targeting that makes randomized-rollout experiments possible.
+  audience: { type: [String], default: [] },
   // Deactivating hides the notice everywhere but keeps it and its acks for the
   // record — announcements are never deleted, so read-rates stay auditable.
   active: { type: Boolean, default: true, index: true }

--- a/server/models/AnnouncementAck.js
+++ b/server/models/AnnouncementAck.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+// One row per student per announcement, written when they press "Got it".
+// This is the read-tracking the team looks at: acks ÷ active students.
+// An explicit button beats a passive "seen" stamp here — it distinguishes
+// "the dashboard rendered it" from "the student says they read it".
+const announcementAckSchema = new mongoose.Schema({
+  announcementId: { type: mongoose.Schema.Types.ObjectId, ref: 'Announcement', required: true },
+  email: { type: String, required: true },
+  ackedAt: { type: Date, default: Date.now }
+});
+
+announcementAckSchema.index({ announcementId: 1, email: 1 }, { unique: true });
+announcementAckSchema.index({ email: 1 });
+
+export default mongoose.model('AnnouncementAck', announcementAckSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -17,6 +17,8 @@ import Achievement from './models/Achievement.js';
 import ShareEvent from './models/ShareEvent.js';
 import AchievementView, { isBot, uaFamilyOf, viewerDayHash } from './models/AchievementView.js';
 import BoardReign from './models/BoardReign.js';
+import Announcement from './models/Announcement.js';
+import AnnouncementAck from './models/AnnouncementAck.js';
 import { buildAchievementState, verifyAchievement } from './services/achievements.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import Commitment from './models/Commitment.js';
@@ -509,6 +511,71 @@ api.get('/leaderboard/board', async (req, res) => {
 // A student's achievements, grouped one tile per board (plus milestones and the
 // nearest locked one). Podium places are awarded by the leaderboard build;
 // milestones are settled and persisted here on read.
+// ---- Announcements (programme notices with read-tracking) --------------------
+// Students see active notices on their dashboard; "Got it" writes one ack row
+// per student per notice, which is what the team reads to know who has read what.
+api.get('/announcements', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  const email = normalizeEmail(student.email);
+  const list = await Announcement.find({ active: true }).sort({ postedAt: -1 }).lean();
+  const acked = new Set((await AnnouncementAck.find({ email }).select('announcementId').lean())
+    .map(a => String(a.announcementId)));
+  res.json({
+    announcements: list.map(a => ({
+      id: String(a._id), title: a.title, body: a.body, postedAt: a.postedAt,
+      acked: acked.has(String(a._id))
+    })),
+    unread: list.filter(a => !acked.has(String(a._id))).length
+  });
+});
+
+api.post('/announcements/:id/ack', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  const ann = await Announcement.findOne({ _id: req.params.id, active: true }).lean();
+  if (!ann) return res.status(404).json({ error: 'Announcement not found' });
+  // Upsert so a double-tap (or a stale open tab) can never duplicate or error.
+  await AnnouncementAck.updateOne(
+    { announcementId: ann._id, email: normalizeEmail(student.email) },
+    { $setOnInsert: { ackedAt: new Date() } },
+    { upsert: true });
+  res.json({ ok: true });
+});
+
+// Admin: post a notice / toggle one / read the read-rates.
+api.post('/admin/announcements', adminGuard, async (req, res) => {
+  const title = String(req.body?.title || '').trim();
+  const body = String(req.body?.body || '').trim();
+  if (!title || !body) return res.status(400).json({ error: 'title and body are required' });
+  const ann = await Announcement.create({ title, body });
+  res.json({ ok: true, id: String(ann._id) });
+});
+
+api.post('/admin/announcements/:id', adminGuard, async (req, res) => {
+  const ann = await Announcement.findByIdAndUpdate(req.params.id,
+    { $set: { active: !!req.body?.active } }, { new: true }).lean();
+  if (!ann) return res.status(404).json({ error: 'Announcement not found' });
+  res.json({ ok: true, active: ann.active });
+});
+
+api.get('/admin/announcements', adminGuard, async (_req, res) => {
+  const [list, activeStudents, ackCounts] = await Promise.all([
+    Announcement.find({}).sort({ postedAt: -1 }).lean(),
+    Student.countDocuments({ status: 'active' }),
+    AnnouncementAck.aggregate([{ $group: { _id: '$announcementId', reads: { $sum: 1 } } }])
+  ]);
+  const readsBy = new Map(ackCounts.map(c => [String(c._id), c.reads]));
+  res.json({
+    activeStudents,
+    announcements: list.map(a => ({
+      id: String(a._id), title: a.title, postedAt: a.postedAt, active: a.active,
+      reads: readsBy.get(String(a._id)) || 0,
+      readPct: activeStudents ? Math.round((readsBy.get(String(a._id)) || 0) / activeStudents * 100) : 0
+    }))
+  });
+});
+
 api.get('/achievements', async (req, res) => {
   const student = await vibeStudent(req);
   if (!student) return res.status(404).json({ error: 'Student not found' });

--- a/server/server.js
+++ b/server/server.js
@@ -514,11 +514,20 @@ api.get('/leaderboard/board', async (req, res) => {
 // ---- Announcements (programme notices with read-tracking) --------------------
 // Students see active notices on their dashboard; "Got it" writes one ack row
 // per student per notice, which is what the team reads to know who has read what.
+// A notice is visible to a student when its audience is empty (broadcast) or
+// names either of their addresses. Centralized so list and ack can never disagree.
+function announcementVisibleTo(ann, student) {
+  if (!ann.audience || ann.audience.length === 0) return true;
+  const mine = new Set([normalizeEmail(student.email), normalizeEmail(student.alternateEmail || '')]);
+  return ann.audience.some(a => mine.has(normalizeEmail(a)));
+}
+
 api.get('/announcements', async (req, res) => {
   const student = await vibeStudent(req);
   if (!student) return res.status(404).json({ error: 'Student not found' });
   const email = normalizeEmail(student.email);
-  const list = await Announcement.find({ active: true }).sort({ postedAt: -1 }).lean();
+  const list = (await Announcement.find({ active: true }).sort({ postedAt: -1 }).lean())
+    .filter(a => announcementVisibleTo(a, student));
   const acked = new Set((await AnnouncementAck.find({ email }).select('announcementId').lean())
     .map(a => String(a.announcementId)));
   res.json({
@@ -534,7 +543,7 @@ api.post('/announcements/:id/ack', async (req, res) => {
   const student = await vibeStudent(req);
   if (!student) return res.status(404).json({ error: 'Student not found' });
   const ann = await Announcement.findOne({ _id: req.params.id, active: true }).lean();
-  if (!ann) return res.status(404).json({ error: 'Announcement not found' });
+  if (!ann || !announcementVisibleTo(ann, student)) return res.status(404).json({ error: 'Announcement not found' });
   // Upsert so a double-tap (or a stale open tab) can never duplicate or error.
   await AnnouncementAck.updateOne(
     { announcementId: ann._id, email: normalizeEmail(student.email) },
@@ -548,8 +557,11 @@ api.post('/admin/announcements', adminGuard, async (req, res) => {
   const title = String(req.body?.title || '').trim();
   const body = String(req.body?.body || '').trim();
   if (!title || !body) return res.status(400).json({ error: 'title and body are required' });
-  const ann = await Announcement.create({ title, body });
-  res.json({ ok: true, id: String(ann._id) });
+  // Optional targeting: audience = array of emails. Empty/omitted = broadcast.
+  const audience = Array.isArray(req.body?.audience)
+    ? [...new Set(req.body.audience.map(normalizeEmail).filter(Boolean))] : [];
+  const ann = await Announcement.create({ title, body, audience });
+  res.json({ ok: true, id: String(ann._id), audienceSize: audience.length || 'broadcast' });
 });
 
 api.post('/admin/announcements/:id', adminGuard, async (req, res) => {
@@ -568,11 +580,16 @@ api.get('/admin/announcements', adminGuard, async (_req, res) => {
   const readsBy = new Map(ackCounts.map(c => [String(c._id), c.reads]));
   res.json({
     activeStudents,
-    announcements: list.map(a => ({
-      id: String(a._id), title: a.title, postedAt: a.postedAt, active: a.active,
-      reads: readsBy.get(String(a._id)) || 0,
-      readPct: activeStudents ? Math.round((readsBy.get(String(a._id)) || 0) / activeStudents * 100) : 0
-    }))
+    announcements: list.map(a => {
+      // Read-rate denominator: the targeted audience when one is set, else all actives.
+      const denom = (a.audience && a.audience.length) ? a.audience.length : activeStudents;
+      const reads = readsBy.get(String(a._id)) || 0;
+      return {
+        id: String(a._id), title: a.title, postedAt: a.postedAt, active: a.active,
+        audienceSize: (a.audience && a.audience.length) || 'broadcast',
+        reads, readPct: denom ? Math.round(reads / denom * 100) : 0
+      };
+    })
   });
 });
 


### PR DESCRIPTION
Programme notices on the student dashboard, with explicit read-tracking and per-notice audience targeting.

- `Announcement` (title/body/postedAt/active/audience; deactivated, never deleted) + `AnnouncementAck` (unique per student x notice)
- Student: `GET /api/announcements` (visible notices + unread count), `POST /api/announcements/:id/ack` - the "Got it" button is the read signal (explicit ack, not a passive seen-stamp)
- Admin: `POST /api/admin/announcements` (post directly, no deploy; optional `audience` email list - empty = broadcast), active toggle, `GET` with reads/readPct (denominated by audience size when targeted)
- Client: amber unread card with "Got it" between LevelStatus and StudentPulse; read notices fold behind a toggle; section hides when empty
- Audience targeting is what enables randomized-rollout experiments on the channel (E1 goal-nudge launches Mon 24 Aug)

Note: this branch contains the `feat/achievements-unseen-badge` merge (prod already ran it; merging that PR first shrinks this diff to just the announcements feature).

**Already live on prod since 21 Aug**; first notice (query-penalty rule) posted to 4,407 active students.

🤖 Generated with [Claude Code](https://claude.com/claude-code)