### PR TITLE
feat(journey): snapshot remaining work when a goal is set

### DIFF
--- a/server/models/JourneyPlan.js
+++ b/server/models/JourneyPlan.js
@@ -8,7 +8,13 @@ const journeyPlanSchema = new mongoose.Schema({
   standupBy: { type: Date, default: null },   // reach 3600 cumulative Zoom minutes by
   vibeBy: { type: Date, default: null },      // finish all 3 ViBe courses by
   spaBy: { type: Date, default: null },       // solve all 53 SPA problems by
-  projectBy: { type: Date, default: null }    // first / target project PR by
+  projectBy: { type: Date, default: null },   // first / target project PR by
+  // How much work REMAINED at the moment each goal was set (written once per set;
+  // goals lock, so this is the state the commitment was made against). This is what
+  // lets a future goal-attainment reward tell a goal set at 40% done from one set
+  // at 95% done — without it, near-completion goal-setting is indistinguishable
+  // from a real commitment after the fact.
+  atSet: { type: mongoose.Schema.Types.Mixed, default: {} }
 }, { timestamps: true });
 
 export default mongoose.model('JourneyPlan', journeyPlanSchema);

--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -12,6 +12,7 @@ import SPTransaction from '../models/SPTransaction.js';
 import Commitment from '../models/Commitment.js';
 import JourneyPlan from '../models/JourneyPlan.js';
 import JourneyProgress from '../models/JourneyProgress.js';
+import Student from '../models/Student.js';
 import { buildVibeState, isVibeEligible } from './vibe.js';
 
 export const SPA_TOTAL = 53;
@@ -171,11 +172,12 @@ export async function saveJourneyPlan(email, incoming = {}) {
   const existing = await JourneyPlan.findOne({ email }).lean();
   const today = startOfToday();
   // Can't set a standup goal once the 3600-min target is already met (achieved).
-  let standupDone = false;
+  let minutes = null;
   if (incoming.standupBy) {
     const att = await AttendanceRecord.find({ email }).lean();
-    standupDone = att.reduce((a, r) => a + (r.attendedMinutes || 0), 0) >= STANDUP_MINUTES_TARGET;
+    minutes = att.reduce((a, r) => a + (r.attendedMinutes || 0), 0);
   }
+  const standupDone = minutes != null && minutes >= STANDUP_MINUTES_TARGET;
   const set = {};
   for (const f of ['standupBy', 'vibeBy', 'spaBy', 'projectBy']) {
     const cur = existing?.[f] ? new Date(existing[f]) : null;
@@ -183,6 +185,26 @@ export async function saveJourneyPlan(email, incoming = {}) {
     if (locked) continue;
     if (f === 'standupBy' && standupDone) continue;           // already achieved → not settable
     if (Object.prototype.hasOwnProperty.call(incoming, f)) set[f] = incoming[f] ? new Date(incoming[f]) : null;
+  }
+  // Snapshot the remaining work at set time (see JourneyPlan.atSet). Written only
+  // when a date is actually being SET (not cleared), once per lock cycle.
+  const now = new Date();
+  if (set.standupBy) {
+    set['atSet.standup'] = { remainingMin: Math.max(0, STANDUP_MINUTES_TARGET - (minutes ?? 0)), at: now };
+  }
+  if (set.vibeBy) {
+    const student = await Student.findOne({ email }).lean();
+    if (student) {
+      const v = await buildVibeState(student);
+      const ladder = isVibeEligible(student) ? v.ladder : v.ladder.filter(l => l.key !== 'onboarding');
+      const pct = Math.round(ladder.reduce((a, l) => a + (l.pct || 0), 0) / (ladder.length || 1));
+      set['atSet.vibe'] = { remainingPct: Math.max(0, 100 - pct), at: now };
+    }
+  }
+  if (set.spaBy || set.projectBy) {
+    const jp = (await JourneyProgress.findOne({ email }).lean()) || {};
+    if (set.spaBy) set['atSet.spa'] = { remainingCount: Math.max(0, (jp.spaTotal || SPA_TOTAL) - (jp.spaSolved || 0)), at: now };
+    if (set.projectBy) set['atSet.project'] = { prsRaised: jp.prsRaised || 0, prsMerged: jp.prsMerged || 0, at: now };
   }
   if (Object.keys(set).length) await JourneyPlan.updateOne({ email }, { $set: set }, { upsert: true });
 }


### PR DESCRIPTION
Writes `JourneyPlan.atSet.<phase>` (remaining minutes / pct / count + timestamp) at the moment a goal date is set - once per lock cycle, only on set, nothing user-visible.

Why now: a future goal-attainment reward (E2, planned after the E1 nudge experiment) is only honest if a goal set at 95% done is distinguishable from one set at 40% - and progress-at-set cannot be reconstructed later. Monday's E1 announcement will trigger the biggest goal-setting wave the module has seen, so the snapshot must be live before it.

Known caveat: ViBe pct comes from buildVibeState, whose progress feed is still absent - vibe snapshots will read ~100% remaining until the real feed exists; recorded honestly as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)