### PR TITLE
fix(server): correct DB/port defaults, drop dead whatsapp platform, evict stale liveViewers

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
-export const PORT = Number(process.env.PORT || 5290);
-export const MONGO_URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/analysis_summership';
+export const PORT = Number(process.env.PORT || 5003);
+export const MONGO_URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/sakshi_spurti';
 export const ALLOW_STUDENT_SEARCH = process.env.ALLOW_STUDENT_SEARCH !== 'false';
 // Samagama validates the student's chatengine_token cookie. Spurti reads that
 // cookie and confirms the session against this internal endpoint (same host).

--- a/server/models/ShareEvent.js
+++ b/server/models/ShareEvent.js
@@ -32,7 +32,7 @@ const shareEventSchema = new mongoose.Schema({
   captionEdited: { type: Boolean, default: false },
   captionChars: { type: Number, default: 0 },
 
-  platform: { type: String, enum: ['linkedin', 'whatsapp', 'download', 'copy', 'native'], required: true },
+  platform: { type: String, enum: ['linkedin', 'download', 'copy', 'native'], required: true },
   at: { type: Date, default: Date.now, index: true }
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -699,7 +699,7 @@ api.post('/share/card', async (req, res) => {
 // and which achievements are actually worth posting.
 api.post('/share/track', async (req, res) => {
   const { achId, platform, captionEdited, captionChars } = req.body || {};
-  if (!achId || !['linkedin', 'whatsapp', 'download', 'copy', 'native'].includes(platform)) {
+  if (!achId || !['linkedin', 'download', 'copy', 'native'].includes(platform)) {
     return res.status(400).json({ error: 'achId and a valid platform required' });
   }
   const student = await vibeStudent(req);
@@ -732,6 +732,14 @@ api.post('/ping', async (req, res) => {
   }
   if (page === 'record' || page.startsWith('admin')) {
     liveViewers.set(normalized, { name, page, lastSeen: new Date() });
+  }
+  // The map is keyed by email and entries are only ever refreshed, never removed:
+  // a student who stops pinging leaves a row behind forever. Evict anything stale
+  // on every ping so the map tracks only genuinely-active viewers (bounded by the
+  // 60s "active now" window the admin screen reads).
+  const seen = Date.now() - 60_000;
+  for (const [k, v] of liveViewers.entries()) {
+    if (v.lastSeen.getTime() < seen) liveViewers.delete(k);
   }
   res.json({ ok: true });
 });


### PR DESCRIPTION
## Summary

3 config + telemetry correctness fixes:

### `server/config.js`
- **`MONGO_URI` default was wrong.** It defaulted to `mongodb://127.0.0.1:27017/analysis_summership`, but the app's database is `sakshi_spurti`. With a missing/partial `.env` the server would silently connect to an empty database and serve no data. Now defaults to `sakshi_spurti`.
- **`PORT` default was 5290**, but production runs on **5003**. Now defaults to 5003.

### `ShareEvent` platform enum + `/share/track` validation
The client never sends a `whatsapp` platform — it's a dead value in the schema enum and a dead branch in the route's allowlist. Removed it from **both** so the schema and the route agree (they were drifting apart).

### `/ping` liveViewers eviction
The `liveViewers` Map is keyed by email and entries were only ever **refreshed, never removed** — a student who stops pinging left a row behind forever, so the map grew without bound. Now, on every ping, anything older than the 60s "active now" window (the same window `/admin/active` reads) is evicted, so the map tracks only genuinely-active viewers.

## Files changed
- `server/config.js`
- `server/models/ShareEvent.js`
- `server/server.js`

## Verification
- `node --check` passes on all three files.
