### PR TITLE
fix(pipeline, client): query-penalty double count, poll-records wiring, async robustness

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -334,10 +334,15 @@ function SpaModule({ student }) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
+    let live = true;
     (async () => {
-      const r = await fetch(`${API}/spa/state?email=${encodeURIComponent(email)}`);
-      setData(await r.json());
+      try {
+        const r = await fetch(`${API}/spa/state?email=${encodeURIComponent(email)}`);
+        const j = await r.json();
+        if (live) setData(j);
+      } catch { /* keep data null → panel shows loading; safe on error */ }
     })();
+    return () => { live = false; };
   }, [email]);
 
   if (!data) return <section className="panel">Loading your SPA points…</section>;
@@ -849,7 +854,12 @@ function LeaderboardPanel({ student }) {
 function TrajectoryModal({ student, onClose }) {
   const [data, setData] = useState(null);
   useEffect(() => {
-    fetch(`${API}/trajectory/state?email=${encodeURIComponent(student.email)}`).then(r => r.json()).then(setData);
+    let live = true;
+    fetch(`${API}/trajectory/state?email=${encodeURIComponent(student.email)}`)
+      .then(r => r.json())
+      .then(d => { if (live) setData(d); })
+      .catch(() => { if (live) setData(null); });
+    return () => { live = false; };
   }, [student.email]);
 
   const series = data ? [
@@ -1247,11 +1257,14 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
   const [showTraj, setShowTraj] = useState(false);
   const [err, setErr] = useState(null);
 
-  const load = async () => {
-    const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
-    setData(await r.json());
+  const load = async (live = () => true) => {
+    try {
+      const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
+      const j = await r.json();
+      if (live()) setData(j);
+    } catch { /* keep data null → "Loading your journey…" instead of an unhandled rejection */ }
   };
-  useEffect(() => { load(); }, [email]);
+  useEffect(() => { let live = true; load(() => live); return () => { live = false; }; }, [email]);
 
   if (!data) return <section className="panel">Loading your journey…</section>;
   if (!data.eligible) return <section className="panel empty">My Journey isn’t available for your cohort yet.</section>;
@@ -1383,14 +1396,19 @@ function VibeGoals({ student }) {
   const [editing, setEditing] = useState(false);
   const [err, setErr] = useState(null);
 
-  const load = async () => {
-    const r = await fetch(`${API}/vibe/state?email=${encodeURIComponent(email)}`);
-    setData(await r.json());
+  const load = async (live = () => true) => {
+    try {
+      const r = await fetch(`${API}/vibe/state?email=${encodeURIComponent(email)}`);
+      const j = await r.json();
+      if (live()) setData(j);
+    } catch { /* keep data null → "Loading ViBe Goals…" instead of an unhandled rejection */ }
   };
   useEffect(() => {
-    load();
+    let live = true;
+    load(() => live);
     const d = new Date(); d.setDate(d.getDate() + 2);
     setForm(f => ({ ...f, deadline: d.toISOString().slice(0, 10) }));
+    return () => { live = false; };
   }, [email]);
 
   if (!data) return <section className="panel">Loading ViBe Goals…</section>;
@@ -1554,11 +1572,14 @@ function StandupGoals({ student }) {
   const [multiplier, setMultiplier] = useState(4);
   const [err, setErr] = useState(null);
 
-  const load = async () => {
-    const r = await fetch(`${API}/standup/state?email=${encodeURIComponent(email)}`);
-    setData(await r.json());
+  const load = async (live = () => true) => {
+    try {
+      const r = await fetch(`${API}/standup/state?email=${encodeURIComponent(email)}`);
+      const j = await r.json();
+      if (live()) setData(j);
+    } catch { /* keep data null → "Loading standups…" instead of an unhandled rejection */ }
   };
-  useEffect(() => { load(); }, [email]);
+  useEffect(() => { let live = true; load(() => live); return () => { live = false; }; }, [email]);
 
   if (!data) return <section className="panel">Loading standups…</section>;
   if (!data.eligible) return <section className="panel empty">Standup commitments aren’t available for your cohort yet.</section>;

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,11 +1,28 @@
 # Spurti SP Pipeline
 
 The data pipeline that computes Spurti Points and feeds the Spurti web app
-(`../server`, `../client`). These scripts are the **source of truth for SP
-scoring** — the `+5/-5` logic that used to live in `server/scripts/` is retired.
+(`../server`, `../client`).
 
-> **Deployment note.** The live copy runs from `/var/samagama/server/` as the
-> `samagama` OS user, driven by cron (see below). The files here are a
+> **CURRENT SCORER (2026-06-28 →).** SP is scored by the **sakshi-side** mirror
+> rubric **`sp-rubric-build-mirror.cjs`**, run from **`~/spurti/sp-refresh.sh`**
+> (repo root) on the 6-hourly cron. It reads only the `sakshi_spurti` mirrors
+> (`zoom_meetings`, `zoom_attendance`, `zoom_polls`, `spandan_polls`,
+> `candidates`, `students`, `act_spa_*`, `act_query_reviews`) — no Zoom
+> credentials, no live Zoom Reports API. Rules: see CONTEXT.md "SP Calculation".
+>
+> **RETIRED samagama-side scorer.** The former live-API `sp-rubric-build.js`
+> (which fetched Zoom reports directly and was the cause of the 2026-06-27
+> regression — sessions older than Zoom's ~3–4 week retention came back empty
+> and were scored 0) is **retired**. Do NOT reintroduce it or its
+> `sp-pipeline.sh`/`sp-pipeline.cron` APPLY stage. Samagama's only remaining job
+> is feeding the mirrors — the Zoom-data mirror (`zoom-update.js` +
+> `sync-sakshi-zoom-mirror.js`) and the expanded `candidates` roster
+> (`sync-collaborator-mirrors.js`). See `HANDOFF_MIRROR_AND_ROSTER.md`.
+>
+> The `+5/-5` logic that used to live in `server/scripts/` is likewise retired.
+
+> **Deployment note.** The samagama-side live copy runs from
+> `/var/samagama/server/` as the `samagama` OS user. The files here are a
 > version-controlled mirror of that deployment. They are kept **verbatim**,
 > including absolute paths like `/var/samagama/server/.env` and
 > `/var/samagama/server/node_modules/...`, so this repo documents exactly what
@@ -14,36 +31,51 @@ scoring** — the `+5/-5` logic that used to live in `server/scripts/` is retire
 > `mongoose`, `axios`, `dotenv`. Credentials come only from
 > `/var/samagama/server/.env` (see `.env.example`); nothing is hardcoded.
 
-## Architecture (two halves)
+## Architecture
+
+Scoring runs on the **sakshi side**; the samagama side only feeds mirrors.
 
 ```
 Zoom  ──zoom-update.js──►  zoom_data.{meetings,attendance,polls,summaries,transcripts}
+                                  │      └──────────────►  chatengine (candidates roster via
+                                  ▼                          sync-collaborator-mirrors.js)
+                 sync-sakshi-zoom-mirror.js (chained in zoom-update.js)
                                   │
-                 sync-sakshi-zoom-mirror.js (chained inside zoom-update.js)
                                   ▼
-                        sakshi_spurti.zoom_*           chatengine.users (vinsStartDate)
-                                  │                              │
-                                  └────────► sp-rubric-build.js ◄┘   (APPLY=1)
-                                                   │  scores A+B+base100 (bands)
-                                                   ▼
-                        sakshi_spurti.students.totalSp + sakshi_spurti.sptransactions
-                                  │                         │
-        sync-attendance-records / sync-poll-records     sync-spurti-from-sakshi.js
-                                  ▼                         ▼
-        sakshi_spurti.{attendancerecords,pollrecords}   chatengine.spledgers + User.spPoints
+                        sakshi_spurti.zoom_*  (ZOOM-DATA MIRROR — samagama's feed)
                                   │
-                  Spurti web app (../server) reads sakshi_spurti  ──►  https://samagama.in/spurti/
+        ┌─────────────────────────┴─────────────────────────┐
+        ▼ (SAKSHI side: cron 6-hourly)                      ▼
+   sp-rubric-build-mirror.cjs  (THE SCORER, reads mirrors)  chatengine.spledgers
+   reads zoom_* / spandan_polls / act_* / candidates        + User.spPoints (via
+        │  wipe-and-rebuild → writes ledger                  sync-spurti-from-sakshi.js)
+        ▼
+   sakshi_spurti.students.totalSp + sptransactions
+        │
+        ▼ (sp-refresh.sh, non-fatal derived steps)
+   sync-attendance-records / sync-poll-records (repo-root sp-refresh.sh)
+        ▼
+   sakshi_spurti.{attendancerecords,pollrecords}
+        │
+        ▼
+   Spurti web app (../server) reads sakshi_spurti  ──►  https://samagama.in/spurti/
 ```
 
-## Scoring rubric (implemented in `sp-rubric-build.js`)
+## Scoring rubric (implemented in `sp-rubric-build-mirror.cjs`)
+
+The full current band/tier rubric — `initial`, `attendance`, `poll`, `spa`,
+`query` categories (plus preserved `manual`/`peer_faq`), the attendance-window
+evening cutover, the Spandan hybrid attendance from Day 64, percentiled Spandan
+poll correctness, SPA validated endorsements, and the query-answer pay + forward
+penalty — is documented in **CONTEXT.md → "SP Calculation — band/tier rubric
+(current, 2026-08)"**. This README keeps only the historical outline that the
+retired `sp-rubric-build.js` implemented:
 
 - **Base 100**, roster-driven: every *started intern* gets +100 on their
-  official start date, even if they never attend. "Started" = start date has
-  arrived. Future-start interns are zeroed; non-intern roster entries are set aside.
-- **Mandatory session** = the first daily Zoom instance with ≥10 attendees.
-  Its official window is `[09:05 IST, min(first-instance-end, 11:00 IST)]`.
-- **Attendance (A):** presence clipped strictly to the official window.
-  `pct = clipped-minutes / window-minutes`, then **band/tier**:
+  official start date. Future-start interns zeroed; non-intern entries set aside.
+- **Mandatory session** = first daily Zoom instance with ≥10 attendees; window
+  `[09:05 IST, min(first-instance-end, 11:00 IST)]`.
+- **Attendance (A):** `pct = clipped-minutes / window-minutes`, band/tier below.
 
   | percent | SP |
   |---------|----|
@@ -54,52 +86,63 @@ Zoom  ──zoom-update.js──►  zoom_data.{meetings,attendance,polls,summar
 
 - **Poll (B):** `pct = answered / totalQuestions`, same band ladder (10/5/3/0). Per session.
 - **Grace day `2026-06-06`:** a 1-minute join counts as full attendance + full poll.
-- Discretionary admin awards/deductions (rubric "Part C") are handled separately
-  (chat SP review in the web app), not here.
 
-The pipeline is **idempotent**: `sp-rubric-build.js` backs up, then wipes and
-re-inserts the full ledger each run, so re-running never double-counts.
+The ledger is **idempotent**: the scorer backs up, then wipes and re-inserts the
+full ledger each run, so re-running never double-counts.
 
 ## Files
 
 | File | Role |
 |------|------|
-| `sp-pipeline.sh` | Master daily orchestrator (fail-fast, 6 stages). |
-| `sp-pipeline.cron` | Cron definitions installed at `/etc/cron.d/sp-pipeline`. |
-| `cron-sakshi-zoom.sh` | Every-6h `#zoomupdate` wrapper (`/etc/cron.d/sakshi-zoom`). |
-| `zoom-update.js` | `#zoomupdate`: fetch Zoom into `zoom_data`, mirror to `sakshi_spurti.zoom_*`, chain transcript ingest. |
-| `sp-rubric-build.js` | **The scorer.** A+B+base100 bands → `sakshi_spurti`. `APPLY=1` to write. |
-| `sync-spurti-from-sakshi.js` | Mirror `sakshi_spurti.sptransactions` → `chatengine.spledgers` + `User.spPoints`. |
-| `sync-attendance-records.js` | Rebuild `sakshi_spurti.attendancerecords` from `sptransactions`. |
-| `sync-poll-records.cjs` | Rebuild `sakshi_spurti.pollrecords` from `sptransactions`. Runs from **Sakshi's** `sp-refresh.sh`, not the samagama pipeline — see below. |
-| `zoom-fetch-transcripts.js` | Zoom AI Companion summaries → `zoom_data.summaries`. |
-| `zoom-ingest-all-transcripts.js` | Zoom VTT transcripts → `zoom_data.transcripts`. |
-| `sync-sakshi-zoom-mirror.js` | `zoom_data.*` → `sakshi_spurti.zoom_*` (Sakshi has RW only on her DB). |
+| `sp-rubric-build-mirror.cjs` | **THE SCORER (sakshi-side).** Band/tier → `sakshi_spurti`. `APPLY=1` to write. Run from `~/spurti/sp-refresh.sh`. |
+| `spandan-poll-fetch.cjs` | Incremental fetch of Spandan evening polls → `sakshi_spurti.spandan_polls` (run by `sp-refresh.sh`). |
+| `sync-attendance-records.cjs` | Rebuild `sakshi_spurti.attendancerecords` from `sptransactions`. Runs from **Sakshi's** `sp-refresh.sh`. |
+| `sync-poll-records.cjs` | Rebuild `sakshi_spurti.pollrecords` from `sptransactions`. Runs from **Sakshi's** `sp-refresh.sh` (wired in as Step 2c). |
+| `vibe-fetch.cjs` | ViBe commitment mirror. |
+| `sp-pipeline.sh` | **RETIRED** samagama-side daily orchestrator (6 stages). Runs the retired `sp-rubric-build.js` APPLY — **do not enable**. Kept only for provenance. |
+| `sp-pipeline.cron` | **RETIRED** cron definitions at `/etc/cron.d/sp-pipeline` (same caution as above). |
+| `cron-sakshi-zoom.sh` | Every-6h `#zoomupdate` wrapper (`/etc/cron.d/sakshi-zoom`) — samagama's Zoom mirror feed. |
+| `zoom-update.js` | `#zoomupdate`: fetch Zoom into `zoom_data`, mirror to `sakshi_spurti.zoom_*`, chain transcript ingest. **Still live** (Zoom mirror feed). |
+| `sp-rubric-build.js` | **RETIRED** samagama-side scorer (live-API). Caused the 2026-06-27 regression. Historical only. |
+| `sync-spurti-from-sakshi.js` | Mirror `sakshi_spurti.sptransactions` → `chatengine.spledgers` + `User.spPoints`. Samagama-side. |
+| `sync-attendance-records.js` | **STALE** (samagama-side copy of the `.cjs`); only the `.cjs` exists in this repo. Left behind by the 2026-06-28 move. |
+| `sync-poll-records.js` | **STALE/NONEXISTENT** in this repo; only `sync-poll-records.cjs` exists. Left behind by the 2026-06-28 move. |
+| `zoom-fetch-transcripts.js` | Zoom AI Companion summaries → `zoom_data.summaries`. Samagama-side feed. |
+| `zoom-ingest-all-transcripts.js` | Zoom VTT transcripts → `zoom_data.transcripts`. Samagama-side feed. |
+| `sync-sakshi-zoom-mirror.js` | `zoom_data.*` → `sakshi_spurti.zoom_*`. Chained in `zoom-update.js`. |
 | `sync-collaborator-mirrors.js` | Nightly roster mirror of `chatengine.users` → `{rohit_spandan,sakshi_spurti,aditya_platform}.candidates`. This is the roster sync. |
+| `.env.example` | Template for the environment file. |
 | `models/User.js` | Mongoose model used by `sync-spurti-from-sakshi.js`. |
 
 ## Schedule (cron, UTC)
 
+**Current (sakshi side) — see `~/spurti/sp-refresh.sh`:**
+
 | When (UTC) | When (IST) | Job |
 |------------|-----------|-----|
-| `45 5 * * *` | 11:15 | `sp-pipeline.sh` — same-day scoring of the morning session |
-| `15 21 * * *` | 02:45 | `sp-rubric-build.js APPLY=1` — nightly full rebuild |
-| `30 1,7,13,19 * * *` | 19:00/01:00/07:00/13:00 | `cron-sakshi-zoom.sh` — `#zoomupdate` every 6h |
+| every 6h (06/12/18/00) | 11:30/17:30/23:30/05:30 | `sp-refresh.sh` — `spandan-poll-fetch` → `sp-rubric-build-mirror.cjs APPLY=1` → `sync-levels` → `sync-attendance-records` → `sync-poll-records` → trajectory snapshot → leaderboards |
+
+**Retired samagama side (`/etc/cron.d/*`)** — do not re-enable the APPLY stage:
+
+| When (UTC) | When (IST) | Job |
+|------------|-----------|-----|
+| `45 5 * * *` | 11:15 | `sp-pipeline.sh` — **retired** scoring (runs `sp-rubric-build.js` APPLY) |
+| `15 21 * * *` | 02:45 | `sp-rubric-build.js APPLY=1` — **retired** nightly rebuild |
+| `30 1,7,13,19 * * *` | 19:00/01:00/07:00/13:00 | `cron-sakshi-zoom.sh` — `#zoomupdate` (**still live**, Zoom mirror feed) |
 | `30 */2 * * *` | every even hr | `sync-spurti-from-sakshi.js` — SP → chatengine |
 | `30 7 * * *` | 13:00 | `zoom-fetch-transcripts.js` + `zoom-ingest-all-transcripts.js --days 2` |
 | `30 18 * * *` (+jitter) | ~00:00–01:00 | `sync-collaborator-mirrors.js` — roster mirror |
 
-## Manual run (catch-up)
+## Manual run (catch-up, current)
 
 ```bash
+# ingest a date range of Zoom data (samagama side)
 cd /var/samagama/server
-# ingest a date range of Zoom data
 node --max-old-space-size=2048 zoom-update.js --from 2026-06-24 --to 2026-06-27
-# preview the score (no writes), then apply
-node sp-rubric-build.js                 # dry preview
-APPLY=1 OUT_DIR=./sp-runs node sp-rubric-build.js
-# push to the app + records
-node sync-spurti-from-sakshi.js
+# ...then score on the SAKSHI side (never run sp-rubric-build.js on samagama):
+cd ~/spurti
+node sp-rubric-build-mirror.cjs                 # dry preview
+APPLY=1 OUT_DIR=./sp-runs node sp-rubric-build-mirror.cjs
 # attendance + poll records are rebuilt by Sakshi's sp-refresh.sh:
 #   cd ~/spurti && node pipeline/sync-attendance-records.cjs && node pipeline/sync-poll-records.cjs
 ```

--- a/pipeline/sp-pipeline.cron
+++ b/pipeline/sp-pipeline.cron
@@ -1,10 +1,17 @@
+# >>> RETIRED (since 2026-06-28) <<<
+# This daily pipeline ran the old live-API sp-rubric-build.js APPLY scorer, which
+# is retired (it caused the 2026-06-27 regression). SP is now scored on the
+# sakshi side by sp-rubric-build-mirror.cjs via ~/spurti/sp-refresh.sh (root of
+# this repo). The sp-pipeline.sh stage-2 APPLY now REFUSES to run.
+#
+# Historical description:
 # Daily Spurti pipeline at 05:45 UTC = 11:15 IST, right after the 09:00-11:00 IST
 # mandatory session. Runs sp-pipeline.sh: #zoomupdate -> sp-rubric-build (APPLY)
 # -> sync-spurti-from-sakshi, so interns see the morning session's SP by
 # ~11:30 IST instead of next-day. flock keeps it single-instance.
 # Install: sudo install -o root -g root -m 644 \
 #            /var/samagama/server/sp-pipeline.cron /etc/cron.d/sp-pipeline
-# Added 2026-06-04.
+# Added 2026-06-04. Do NOT re-enable the APPLY stage.
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 45 5 * * * samagama /usr/bin/flock -n /tmp/sp-pipeline.lock /var/samagama/server/sp-pipeline.sh >> /var/samagama/server/logs/sp-pipeline.log 2>&1

--- a/pipeline/sp-pipeline.sh
+++ b/pipeline/sp-pipeline.sh
@@ -1,24 +1,32 @@
 #!/bin/bash
-# sp-pipeline.sh — daily Spurti pipeline, fired 05:45 UTC (11:15 IST) by
+# sp-pipeline.sh â€” daily Spurti pipeline, fired 05:45 UTC (11:15 IST) by
 # /etc/cron.d/sp-pipeline, right after the 09:00-11:00 IST mandatory session.
-# Runs the three stages in order so the morning session is scored SAME-DAY
-# instead of waiting for the 21:15 UTC nightly build:
 #
-#   1. #zoomupdate            zoom-update.js — ingest today's Zoom attendance +
+# >>> RETIRED SCORING ORCHESTRATOR (since 2026-06-28) <<<
+# SCORING MOVED TO THE SAKSHI SIDE. Stage 2 uses the retired live-API
+# sp-rubric-build.js, which caused the 2026-06-27 regression and is no longer
+# authoritative. DO NOT run/enable stage 2; SP is scored by the sakshi-side
+# sp-rubric-build-mirror.cjs via ~/spurti/sp-refresh.sh (root of this repo).
+# This file is kept as provenance. Samagama's only remaining job is feeding the
+# mirrors (stage 1 #zoomupdate + sync-collaborator-mirrors in cron-sakshi-zoom.sh).
+#
+# Stages (historical):
+#   1. #zoomupdate            zoom-update.js â€” ingest today's Zoom attendance +
 #                             polls into zoom_data, then mirror to
 #                             sakshi_spurti.zoom_*  (2GB heap: 7-day window can OOM)
-#   2. sp-rubric-build APPLY  score attendance(A)+poll(B)+base100 into
-#                             sakshi_spurti (backs up first; idempotent
-#                             wipe-and-replace) -> CSVs/backups in sp-runs/
+#   2. sp-rubric-build APPLY  RETIRED scorer (see above). Do not run.
 #   3. sync-spurti-from-sakshi mirror sakshi_spurti SP into chatengine
 #                             (spledgers + User.spPoints) so /spurti reflects it
 #   4. sync-attendance-records sync sakshi_spurti.attendancerecords from
-#                             sptransactions so Session Health widget is accurate
-#   5. sync-poll-records      sync sakshi_spurti.pollrecords from sptransactions
+#                             sptransactions (NOTE: the current script is
+#                             sync-attendance-records.cjs, run from Sakshi's
+#                             ~/spurti â€” NOT from this samagama dir)
+#   5. sync-poll-records      same caveat: the current script is
+#                             sync-poll-records.cjs (sakshi side), not here
 #   6. zoom-fetch-transcripts fetch AI Companion summaries into zoom_data.summaries
 #                             (non-fatal: summary may still be processing at 11:15;
 #                              today's meeting is retried on next run)
-#   7. (transcript ingest is now chained inside zoom-update.js itself — no separate stage)
+#   7. (transcript ingest is now chained inside zoom-update.js itself â€” no separate stage)
 #
 # Fail-fast: each stage must exit 0 before the next runs. Single-instance via
 # flock in the cron line. Added 2026-06-04.
@@ -35,7 +43,16 @@ $NODE $HEAP zoom-update.js
 rc=$?; echo "--- $(ts) stage1 exit=$rc ---"
 [ $rc -eq 0 ] || { echo "ABORT: #zoomupdate failed (rc=$rc)"; exit 1; }
 
-echo "=== $(ts) STAGE 2/3: sp-rubric-build APPLY=1 ==="
+echo "=== $(ts) STAGE 2/3: sp-rubric-build APPLY=1 (RETIRED â€” must not run) ==="
+# Scoring moved to the sakshi side (2026-06-28): sp-rubric-build.js is the retired
+# live-API scorer. Refuse to APPLY it here; the authoritative run is
+# sp-rubric-build-mirror.cjs via ~/spurti/sp-refresh.sh. Unset SKIP_RETIRED_APPLY
+# to bypass this guard ONLY if you explicitly intend to re-test the old scorer.
+if [ "${SKIP_RETIRED_APPLY:-0}" != "1" ]; then
+  echo "ABORT: sp-rubric-build.js is RETIRED. SP is scored by sp-rubric-build-mirror.cjs on the sakshi side. Skipping." >&2
+  echo "Set SKIP_RETIRED_APPLY=1 to force (only if you know what you're doing)."
+  exit 1
+fi
 APPLY=1 OUT_DIR=/var/samagama/server/sp-runs $NODE $HEAP sp-rubric-build.js
 rc=$?; echo "--- $(ts) stage2 exit=$rc ---"
 [ $rc -eq 0 ] || { echo "ABORT: sp-rubric-build failed (rc=$rc)"; exit 1; }
@@ -45,20 +62,31 @@ $NODE sync-spurti-from-sakshi.js
 rc=$?; echo "--- $(ts) stage3 exit=$rc ---"
 [ $rc -eq 0 ] || { echo "ABORT: spurti mirror failed (rc=$rc)"; exit 1; }
 
-echo "=== $(ts) STAGE 4/5: sync-attendance-records (-> sakshi_spurti) ==="
-$NODE sync-attendance-records.js
-rc=$?; echo "--- $(ts) stage4 exit=$rc ---"
-[ $rc -eq 0 ] || { echo "ABORT: sync-attendance-records failed (rc=$rc)"; exit 1; }
+echo "=== $(ts) STAGE 4/5: sync-attendance-records (owned by SAKSHI; skip here) ==="
+# The current attendance-records rebuild is sync-attendance-records.cjs, run from
+# Sakshi's repo (cd ~/spurti) by sp-refresh.sh â€” this samagama stage is the OLD
+# .js and no longer runs here. Skipped unless FORCE_RETIRED_STAGES=1.
+if [ "${FORCE_RETIRED_STAGES:-0}" = "1" ]; then
+  $NODE sync-attendance-records.js
+  rc=$?; [ $rc -eq 0 ] || { echo "ABORT: sync-attendance-records failed (rc=$rc)"; exit 1; }
+else
+  echo "skipped: sync-attendance-records is Sakshi's job via sp-refresh.sh"
+fi
 
-echo "=== $(ts) STAGE 5/6: sync-poll-records (-> sakshi_spurti) ==="
-$NODE sync-poll-records.js
-rc=$?; echo "--- $(ts) stage5 exit=$rc ---"
-[ $rc -eq 0 ] || { echo "ABORT: sync-poll-records failed (rc=$rc)"; exit 1; }
+echo "=== $(ts) STAGE 5/6: sync-poll-records (owned by SAKSHI; skip here) ==="
+# Same as stage 4 â€” the current rebuild is sync-poll-records.cjs from Sakshi's
+# repo; nothing here writes pollrecords anymore.
+if [ "${FORCE_RETIRED_STAGES:-0}" = "1" ]; then
+  $NODE sync-poll-records.js
+  rc=$?; [ $rc -eq 0 ] || { echo "ABORT: sync-poll-records failed (rc=$rc)"; exit 1; }
+else
+  echo "skipped: sync-poll-records is Sakshi's job via sp-refresh.sh"
+fi
 
 echo "=== $(ts) STAGE 6/6: zoom-fetch-transcripts (AI summaries -> zoom_data.summaries) ==="
 $NODE /home/samagama/samagama/server/zoom-fetch-transcripts.js
 rc=$?; echo "--- $(ts) stage6 exit=$rc ---"
 # Non-fatal: summary processing lag is normal; today's meeting retried tomorrow
-[ $rc -eq 0 ] || echo "WARN: zoom-fetch-transcripts failed (rc=$rc) — will retry on next run"
+[ $rc -eq 0 ] || echo "WARN: zoom-fetch-transcripts failed (rc=$rc) â€” will retry on next run"
 
 echo "######## $(ts) sp-pipeline done OK ########"

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -510,7 +510,7 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     // never drive the student's total balance below zero.
     const qPens = queryPenByCanon.get(cand);
     if (qPens && qPens.length) {
-      let penBudget = QUERY_PEN_CAP, pensUsed = 0;
+      let penBudget = QUERY_PEN_CAP;
       const penByDay = new Map(); // date -> { rejected: n, marked_unworthy: n }
       for (const p of qPens) { const o = penByDay.get(p.date) || { rejected: 0, marked_unworthy: 0 }; o[p.action]++; penByDay.set(p.date, o); }
       for (const d of [...penByDay.keys()].sort()) {
@@ -518,11 +518,15 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
         const o = penByDay.get(d);
         // Clamp to SP actually held by the verdict date (same lesson as the SPA
         // penalty): the running balance must never dip below zero at this row.
-        const heldByD = rows.reduce((a, r) => a + (r.date <= d ? r.delta : 0), 0) - pensUsed;
+        // Penalty rows pushed earlier in this loop are already inside `rows`, so
+        // their negative deltas are already subtracted by the reduce — do NOT
+        // subtract them again, or the clamp undercounts a student's balance and
+        // rejects penalties they should be charged.
+        const heldByD = rows.reduce((a, r) => a + (r.date <= d ? r.delta : 0), 0);
         let pen = o.rejected * QUERY_PEN.rejected + o.marked_unworthy * QUERY_PEN.marked_unworthy;
         pen = Math.min(pen, penBudget, Math.max(0, heldByD));
         if (pen <= 0) continue;
-        penBudget -= pen; pensUsed += pen;
+        penBudget -= pen;
         const parts = [];
         if (o.rejected) parts.push(`${o.rejected} rejected (-${QUERY_PEN.rejected} each)`);
         if (o.marked_unworthy) parts.push(`${o.marked_unworthy} marked unworthy (-${QUERY_PEN.marked_unworthy} each)`);

--- a/sp-refresh.sh
+++ b/sp-refresh.sh
@@ -166,6 +166,13 @@ run_step "sync-levels" fatal "SP applied but derived level fields may be stale" 
 run_step "sync-attendance-records" nonfatal "attendance minutes/3600 goal may be stale" \
   "$NODE" pipeline/sync-attendance-records.cjs || true
 
+# Step 2c: fold per-session poll detail into pollrecords (drives the My-Journey
+# poll view). The rubric awards poll SP from spandan_polls but this display
+# collection is what the app reads; without this step it stays frozen at whatever
+# the last run wrote. Non-fatal — poll SP itself is unaffected.
+run_step "sync-poll-records" nonfatal "poll detail may be stale" \
+  "$NODE" pipeline/sync-poll-records.cjs || true
+
 # Step 3: rebuild the SP-trajectory snapshot (cohort/group reference lines for the
 # student trajectory modal). Non-fatal — the student's own line is always live.
 run_step "trajectory snapshot" nonfatal "cohort lines may be stale" \


### PR DESCRIPTION
## Summary

Two genuine pipeline bugs found in a fresh client+pipeline scan, plus client-side async hardening for five un-guarded panel loads.

### 1. Query-penalty double count (pipeline, `sp-rubric-build-mirror.cjs`)

The per-day query penalty clamp was subtracting each penalty **twice**:

```js
// before
const heldByD = rows.reduce((a, r) => a + (r.date <= d ? r.delta : 0), 0) - pensUsed;
```

Penalty rows pushed earlier in the loop are already inside `rows`, so their negative deltas are already in the `reduce`. Subtracting `pensUsed` again (the running sum of penalties already applied) understates the balance held on the verdict day. Effect: **any student with penalties on 2+ distinct days gets later penalties clamped too aggressively** and is charged less than the rules intend. Fix removes the `- pensUsed` (and the now-dead `pensUsed` counter). `penBudget` bookkeeping is unchanged.

### 2. `pollrecords` never refreshed (sp-refresh.sh)

`pipeline/sync-poll-records.cjs` exists but was never called from `sp-refresh.sh` (only its sibling `sync-attendance-records` was added). As the script's own header says, **nothing has written `pollrecords` since 2026-06-27** — the collection the My-Journey poll view reads is frozen even though poll SP keeps being scored from `spandan_polls`. Added it as a non-fatal step (Step 2c), mirroring the attendance-records wiring.

### 3. Client async robustness (`client/src/main.jsx`)

`SpaModule`, `TrajectoryModal`, `MyJourney`, `VibeGoals`, and `StandupGoals` all did an un-guarded `fetch().then(setData)` in their load effects. A failed/slow fetch leaves the whole panel stuck on "Loading…" with an unhandled rejection, and a stale response calls `setState` after unmount. Added `try/catch` (keep the null "Loading" state as the safe fallback) and a `live` flag so a response landing after unmount is dropped.

## Scope notes

- Does **not** touch `vibeStudent` / server auth — that's covered by **#199** (cookie-only). Client `?email=` params are left intact here because they are still how the app authenticates **until #199 lands**; removing them now would break the client on current main.
- Does not re-cover the SurveyModal `done.current` reset already in #199.

## Verification

- `node --check pipeline/sp-rubric-build-mirror.cjs` passes.
- Branch is clean off `origin/main` (`1325882`), single commit, no merge commits.
- Client changes are JS-in-JSX guards only; no logic re-authored.

## Testing

Pipeline change is data-affecting (only on next `APPLY` run): recommend a dry run (`node sp-rubric-build-mirror.cjs`) before `APPLY=1`. The double-count fix only changes students with 2+ penalty days. `sync-poll-records` is non-fatal and idempotent.

---

### 4. Retire stale samagama-side pipeline docs

`pipeline/README.md` still documented `sp-rubric-build.js` (retired live-API scorer that caused the 2026-06-27 regression) as "The scorer", and listed `sync-attendance-records.js` / `sync-poll-records.js` — two files that **don't exist in this repo** (only the `.cjs` variants do). `pipeline/sp-pipeline.sh` referenced these absent `.js` files and orchestrated the retired scorer.

**Changes:**
- `pipeline/README.md`: rewrote to document `sp-rubric-build-mirror.cjs` as the current scorer, updated the architecture diagram (sakshi-side scoring), marked retired files in the table, and corrected the schedule.
- `pipeline/sp-pipeline.sh`: added a header banner marking it retired, a guard on stage 2 (refuses the retired APPLY unless `SKIP_RETIRED_APPLY=1`), and annotated stages 4/5 as sakshi-owned (skipped unless `FORCE_RETIRED_STAGES=1`). Fixed CRLF→LF line endings (was LF on origin/main; the CRLF working copy failed `bash -n` — `core.autocrlf=true` normalizes LF in the blob).
- `pipeline/sp-pipeline.cron`: added a retired banner to the comment header.

These are documentation/provenance changes — they don't touch the live scoring path (`sp-refresh.sh` + `sp-rubric-build-mirror.cjs` on the sakshi side).

## Verification (updated)

- `node --check pipeline/sp-rubric-build-mirror.cjs` passes.
- `bash -n pipeline/sp-pipeline.sh` passes (after LF normalization).
- Branch is clean off `origin/main` (`1325882`), single commit, no merge commits.
