### PR TITLE
My Journey: live SPA/Projects/ViBe progress from Samagama mirrors

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1256,7 +1256,7 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
   if (!data) return <section className="panel">Loading your journey…</section>;
   if (!data.eligible) return <section className="panel empty">My Journey isn’t available for your cohort yet.</section>;
 
-  const { standups, vibe, goals } = data;
+  const { standups, vibe, spa, projects, goals } = data;
 
   const saveTarget = async (field, value) => {
     const r = await fetch(`${API}/journey/plan`, {
@@ -1311,17 +1311,24 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
           {canCommit && <div className="jr-cardfoot"><button className="jr-stake" onClick={() => goToCommitment('vibe')}>🎲 Stake SP →</button></div>}
         </section>
 
-        {/* SPA — goal (date) works now; progress data + commitment coming soon */}
+        {/* SPA — live progress from the rubric summary (same source as the SPA Points tab) */}
         <section className="jr-card phase-spa">
-          <div className="jr-head"><span className="jr-n">3</span><h3>SPA — Matrix Mystics</h3><span className="jr-soon">Data soon</span></div>
-          <p className="jr-sub">53-problem set · progress data coming soon</p>
+          <div className="jr-head"><span className="jr-n">3</span><h3>SPA — Matrix Mystics</h3><span className="jr-sp">+{spa.sp} SP</span></div>
+          <p className="jr-sub">{spa.solved}/{spa.total} problems solved · full breakdown in the SPA Points tab</p>
+          <div className="jr-stats">
+            <div><strong>{spa.solved}</strong><span>problems solved</span></div>
+            <div><strong>{spa.taught}</strong><span>peers taught</span></div>
+          </div>
           <PhaseGoal phaseKey="spa" field="spaBy" goal={goals.spa} targetText="solve all 53 problems" {...gp} />
         </section>
 
-        {/* Projects — goal (date) works now; progress data coming soon */}
+        {/* Projects — live from the PR submission + review mirrors; SP rule still TBD */}
         <section className="jr-card phase-project">
-          <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-soon">Data soon</span></div>
-          <p className="jr-sub">Pull requests · progress data coming soon</p>
+          <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-soon">SP soon</span></div>
+          <p className="jr-sub">{projects.submitted ? `${projects.prsRaised} PR${projects.prsRaised === 1 ? '' : 's'} submitted` : 'Pull requests — none submitted yet'}</p>
+          {projects.reviewStatus && (
+            <div className="jr-splits"><span className="jr-pill">Review: {projects.reviewStatus}</span></div>
+          )}
           <PhaseGoal phaseKey="project" field="projectBy" goal={goals.project} targetText="raise your first PR" {...gp} />
         </section>
       </div>

--- a/server/models/ActMirrors.js
+++ b/server/models/ActMirrors.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+
+// READ-ONLY views over the Samagama activity mirrors (`act_*` collections),
+// written by the admin-side 6-hourly sync — the app must never write them.
+// Schemas are intentionally loose (strict:false): the mirror owns the shape.
+
+const loose = extra => new mongoose.Schema(
+  { email: { type: String, lowercase: true, trim: true, index: true }, ...extra },
+  { strict: false, autoIndex: false }
+);
+
+// Per-student per-course ViBe completion, fetched from the live ViBe API
+// (source:'live_api'): courseKey 'onboarding'|'ai'|'mern', completionPct 0–100,
+// finished, exempt (credited from a prior program), _mirroredAt.
+export const ActVibeProgress = mongoose.model(
+  'ActVibeProgress', loose({ courseKey: String, completionPct: Number }), 'act_vibe_progress');
+
+// One doc per student: the project PR submission form (branchOrPrLinks free text,
+// GitHub commit links, reflection answers).
+export const ActPullRequest = mongoose.model(
+  'ActPullRequest', loose({ branchOrPrLinks: String }), 'act_pull_requests');
+
+// One doc per student: admin review of the PR submission
+// (reviewStatus e.g. 'completed', reviewedAt, resubmissionCount).
+export const ActPrReview = mongoose.model(
+  'ActPrReview', loose({ reviewStatus: String }), 'act_pr_reviews');

--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -5,15 +5,27 @@
 // SP attribution per phase:
 //   - Standups: ALREADY awarded (attendance + poll SPTransactions) — we just aggregate.
 //   - ViBe:     net SP from settled commitments (+ the weekly floor) — from the ViBe module.
-//   - SPA / Projects: rule TBD until Samagama data lands — shown as "coming soon" (sp = 0).
+//   - SPA:      ALREADY awarded by the pipeline rubric (category 'spa') — we aggregate;
+//               progress comes from the rubric's spaprogresses summary.
+//   - Projects: progress from the Samagama act_pull_requests / act_pr_reviews mirrors;
+//               SP rule still TBD (sp = 0 until decided).
 import AttendanceRecord from '../models/AttendanceRecord.js';
 import PollRecord from '../models/PollRecord.js';
 import SPTransaction from '../models/SPTransaction.js';
 import Commitment from '../models/Commitment.js';
 import JourneyPlan from '../models/JourneyPlan.js';
-import JourneyProgress from '../models/JourneyProgress.js';
 import Student from '../models/Student.js';
+import SpaProgress from '../models/SpaProgress.js';
+import { ActPullRequest, ActPrReview } from '../models/ActMirrors.js';
 import { buildVibeState, isVibeEligible } from './vibe.js';
+
+// Count distinct GitHub PR links in the free-text submission field; a submission
+// with no parseable link still counts as 1 (the form requires real PR work).
+export function countPrLinks(text) {
+  if (!text) return 0;
+  const m = String(text).match(/github\.com\/[^\s,]+\/pull\/\d+/gi);
+  return m ? new Set(m.map(s => s.toLowerCase())).size : 1;
+}
 
 export const SPA_TOTAL = 53;
 export const STANDUP_MINUTES_TARGET = 3600;   // cumulative Zoom minutes (~120 min/week)
@@ -58,30 +70,42 @@ export async function buildJourneyState(student) {
     sp: settled.reduce((a, b) => a + (b.resultDelta || 0), 0)  // net SP from settled commitments
   };
 
-  // --- Phase 3 & 4: SPA + Projects — PLACEHOLDER (Samagama data + SP rule TBD) ---
-  const jp = (await JourneyProgress.findOne({ email }).lean()) || {};
+  // --- Phase 3: SPA — live from the rubric's spaprogresses summary (same source
+  // as the SPA Points tab); SP = what the rubric actually credited in the ledger ---
+  const spaProg = await SpaProgress.findOne({ email }).lean();
   const spa = {
-    solved: jp.spaSolved || 0,
-    total: jp.spaTotal || SPA_TOTAL,
-    spaPoints: jp.spaPoints || 0,
-    sp: 0, pending: true              // SP rule decided once Samagama data arrives
+    solved: Math.min(spaProg?.learnValidated || 0, SPA_TOTAL),
+    total: SPA_TOTAL,
+    taught: spaProg?.teachValidated || 0,
+    sp: spByCat(['spa']),
+    pending: false
   };
+
+  // --- Phase 4: Projects — live from the Samagama PR-submission mirror.
+  // Progress is real; the SP rule for PRs is still TBD (sp stays 0 for now). ---
+  const [prSub, prRev] = await Promise.all([
+    ActPullRequest.findOne({ email }).lean(),
+    ActPrReview.findOne({ email }).lean()
+  ]);
   const projects = {
-    prsRaised: jp.prsRaised || 0,
-    prsMerged: jp.prsMerged || 0,
-    sp: 0, pending: true              // SP rule decided once Samagama data arrives
+    submitted: !!prSub,
+    prsRaised: prSub ? countPrLinks(prSub.branchOrPrLinks) : 0,
+    reviewStatus: prRev?.reviewStatus || null,
+    sp: 0, spRulePending: true,
+    pending: false
   };
 
   const plan = await JourneyPlan.findOne({ email }).lean();
 
-  // Per-phase goal status + pace toward the student's target date. ViBe has live
-  // completion %; SPA/Projects are pending (date countdown only until Samagama data).
+  // Per-phase goal status + pace toward the student's target date. All four phases
+  // now have live progress (ViBe from the API mirror, SPA from the rubric summary,
+  // Projects from the Samagama PR-submission mirror).
   const vibeOverall = Math.round(vibe.ladder.reduce((a, l) => a + l.pct, 0) / (vibe.ladder.length || 1));
   const goals = {
     standup: phaseGoal({ targetDate: plan?.standupBy, current: standups.zoomMinutes, target: STANDUP_MINUTES_TARGET, unit: 'min', daysPerWeek: STANDUP_DAYS_PER_WEEK }),
     vibe: phaseGoal({ targetDate: plan?.vibeBy, current: vibeOverall, target: 100, unit: '%' }),
-    spa: phaseGoal({ targetDate: plan?.spaBy, pending: true }),
-    project: phaseGoal({ targetDate: plan?.projectBy, pending: true })
+    spa: phaseGoal({ targetDate: plan?.spaBy, current: spa.solved, target: SPA_TOTAL, unit: 'solved' }),
+    project: phaseGoal({ targetDate: plan?.projectBy, current: projects.prsRaised, target: 1, unit: 'PR' })
   };
   // Attach realistic date bounds so a target can't be set too soon (superficial) or
   // too far out (delayed). Standups is pace-capped at ~60 min per working day.
@@ -201,10 +225,14 @@ export async function saveJourneyPlan(email, incoming = {}) {
       set['atSet.vibe'] = { remainingPct: Math.max(0, 100 - pct), at: now };
     }
   }
-  if (set.spaBy || set.projectBy) {
-    const jp = (await JourneyProgress.findOne({ email }).lean()) || {};
-    if (set.spaBy) set['atSet.spa'] = { remainingCount: Math.max(0, (jp.spaTotal || SPA_TOTAL) - (jp.spaSolved || 0)), at: now };
-    if (set.projectBy) set['atSet.project'] = { prsRaised: jp.prsRaised || 0, prsMerged: jp.prsMerged || 0, at: now };
+  if (set.spaBy) {
+    const prog = await SpaProgress.findOne({ email }).lean();
+    const solved = Math.min(prog?.learnValidated || 0, SPA_TOTAL);
+    set['atSet.spa'] = { remainingCount: Math.max(0, SPA_TOTAL - solved), at: now };
+  }
+  if (set.projectBy) {
+    const prSub = await ActPullRequest.findOne({ email }).lean();
+    set['atSet.project'] = { prsRaised: prSub ? countPrLinks(prSub.branchOrPrLinks) : 0, at: now };
   }
   if (Object.keys(set).length) await JourneyPlan.updateOne({ email }, { $set: set }, { upsert: true });
 }

--- a/server/services/vibe.js
+++ b/server/services/vibe.js
@@ -5,6 +5,7 @@ import Student from '../models/Student.js';
 import VibeProgress from '../models/VibeProgress.js';
 import Commitment from '../models/Commitment.js';
 import SPTransaction from '../models/SPTransaction.js';
+import { ActVibeProgress } from '../models/ActMirrors.js';
 
 export const ELIGIBILITY_CUTOFF = new Date('2026-07-16T00:00:00.000Z');
 
@@ -43,6 +44,13 @@ export async function buildVibeState(student) {
   const rows = await VibeProgress.find({ email }).lean();
   const prog = {};
   rows.forEach(r => { prog[r.course] = { pct: r.pct, week: r.weekHours, prior: !!r.priorCompleted }; });
+  // The live ViBe API mirror (act_vibe_progress, source:'live_api') overrides any
+  // local/dummy VibeProgress row — VibeProgress values were never real in prod.
+  const live = await ActVibeProgress.find({ email }).lean();
+  live.forEach(r => {
+    const pct = r.finished ? 100 : Math.max(0, Math.min(100, Math.round(r.completionPct || 0)));
+    prog[r.courseKey] = { pct, week: prog[r.courseKey]?.week ?? 0, prior: !!r.exempt };
+  });
 
   const ladder = COURSES.map(c => {
     const p = prog[c.key] || { pct: 0, week: 0, prior: false };


### PR DESCRIPTION
Students see no SPA/PR/ViBe progress on My Journey although the data exists in the act_* mirrors. SPA/Projects were pending:true placeholders reading the never-written journeyprogresses collection; ViBe read fabricated VibeProgress rows.

- ViBe: overlay act_vibe_progress (live_api mirror) in buildVibeState
- SPA phase: solved/taught from spaprogresses + ledger spa SP; goal target 53
- Projects phase: act_pull_requests submission + PR-link count, act_pr_reviews status; goal target 1 PR; SP rule still TBD
- Client journey cards show the live numbers

Read-only wiring — the app still never writes SP or the mirrors.