### PR TITLE
Project +500 SP, SPA teach 10x25, certificate lock, SP table

### DIFF
--- a/FAQ_SP.md
+++ b/FAQ_SP.md
@@ -35,6 +35,24 @@ Bank:
 5. **Project** — your project PR, once the mentor review is completed.
 6. **ViBe** — course commitments.
 
+### SP at a glance
+
+| Source | How you earn | SP | Cap |
+|---|---|---|---|
+| Initial | one-time credit on your official start date | +100 | 100 |
+| Attendance | standup presence: ≥90% / 75–89% / 50–74% of the window | +10 / +5 / +3 per session | Not capped |
+| Polls | your day's score vs the day's top scorer, same bands | +10 / +5 / +3 per day | Not capped |
+| SPA — learn | each validated question you learn | +5 | 250 (50 questions) |
+| SPA — teach | each validated peer you teach | +10 | 250 (25 peers) |
+| Query answering | each distinct peer query you genuinely answer | +5 | 200 (40 queries) |
+| Project | your project PR passes the mentor review | +500 one-time | 500 |
+| **Total (earnable SP)** | *attendance and polls counted at their 600 design value (60 sessions × 10)* | | **2,500** |
+
+Where SP can reduce:
+- SPA integrity: confirmed fraud −50% / failed audit −20% of the SP earned up to that date (one-time).
+- Query review: a rejected answer −10, marked unworthy −5 (only for queries raised on/after 22 Aug 2026; capped at −200 overall).
+- ViBe commitments: missing a goal you staked SP on loses the stake × penalty (only if you chose to stake).
+
 The system is **positive-first**: you gain SP for taking part, and most
 categories can never reduce your balance.
 

--- a/FAQ_SP.md
+++ b/FAQ_SP.md
@@ -25,14 +25,15 @@ Spurti means energy, inspiration, and forward movement — the intent is to help
 students keep their learning energy through the whole programme.
 
 ### 3. What are the SP earning sources?
-There are **five live sources**, each recorded as its own category in the SP
+There are **six live sources**, each recorded as its own category in the SP
 Bank:
 
 1. **Attendance** — the daily standup.
 2. **Poll** — the session quizzes.
 3. **SPA** — peer teaching and learning endorsements.
 4. **Query** — answering other students' questions.
-5. **ViBe** — course commitments.
+5. **Project** — your project PR, once the mentor review is completed.
+6. **ViBe** — course commitments.
 
 The system is **positive-first**: you gain SP for taking part, and most
 categories can never reduce your balance.
@@ -109,8 +110,8 @@ SPA rewards learning from and teaching peers, from **validated** endorsements
 only:
 
 ```text
-Learn a question (validated):  +5 SP each, capped at 50 SP  (up to 10 questions)
-Teach a peer     (validated):  +8 SP each, capped at 30 SP
+Learn a question (validated):  +5 SP each,  up to 50 questions (max 250 SP)
+Teach a peer     (validated):  +10 SP each, up to 25 peers     (max 250 SP)
 ```
 
 Unvalidated or flagged endorsements do not count.
@@ -130,6 +131,13 @@ When you give a real, useful answer to another student's question, you earn
 
 The goal is genuine peer help — quality and effort, not volume. Shallow or
 copied answers to many queries will not build SP.
+
+## Section 6b: Project SP
+
+### How do I earn SP for my project?
+When your project PR passes the **mentor review** (marked *completed*), you earn
+a one-time **+500 SP**, dated to the review completion. A submission that is
+rejected or still pending review earns nothing until it passes.
 
 ## Section 7: ViBe course commitments
 

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1051,11 +1051,44 @@ const FAQ_ITEMS = [
   { q: 'Why can’t I search my SP directly?', a: 'For privacy and security, direct student search is disabled in production. Instead, open Spurti from your Samagama dashboard — the same login you already use — and it will show only your own record. This is what ensures no one can look up another student’s SP, and it’s why you normally reach Spurti through the official programme link rather than searching by name or email.' },
 ];
 
+// SP rates at a glance — keep in sync with the live rubric
+// (pipeline/sp-rubric-build-mirror.cjs) and FAQ_SP.md.
+const SP_RATES = [
+  { src: 'Initial', how: 'one-time credit on your official start date', sp: '+100', cap: '100' },
+  { src: 'Attendance', how: 'standup presence: ≥90% / 75–89% / 50–74% of the window', sp: '+10 / +5 / +3 per session', cap: 'Not capped' },
+  { src: 'Polls', how: 'your day’s score vs the day’s top scorer, same bands', sp: '+10 / +5 / +3 per day', cap: 'Not capped' },
+  { src: 'SPA — learn', how: 'each validated question you learn', sp: '+5', cap: '250 (50 questions)' },
+  { src: 'SPA — teach', how: 'each validated peer you teach', sp: '+10', cap: '250 (25 peers)' },
+  { src: 'Query answering', how: 'each distinct peer query you genuinely answer', sp: '+5', cap: '200 (40 queries)' },
+  { src: 'Project', how: 'your project PR passes the mentor review', sp: '+500 one-time', cap: '500' },
+];
+const SP_DEDUCTIONS = [
+  'SPA integrity: confirmed fraud −50% / failed audit −20% of the SP earned up to that date (one-time).',
+  'Query review: an answer the admins reject −10, marked unworthy −5 (only for queries raised on/after 22 Aug; capped at −200 overall).',
+  'ViBe commitments: missing a goal you staked SP on loses the stake × penalty (only if you chose to stake).',
+];
+
 function FaqTab() {
   const [open, setOpen] = useState(0);
   return (
     <section className="panel">
       <div className="panel-head"><h2>FAQ</h2></div>
+      <div className="sp-table-wrap">
+        <h3>SP at a glance</h3>
+        <table className="sp-table">
+          <thead><tr><th>Source</th><th>How you earn</th><th>SP</th><th>Cap</th></tr></thead>
+          <tbody>
+            {SP_RATES.map(r => (
+              <tr key={r.src}><td>{r.src}</td><td>{r.how}</td><td>{r.sp}</td><td>{r.cap}</td></tr>
+            ))}
+            <tr className="sp-total"><td><b>Total (earnable SP)</b></td><td className="muted">attendance and polls counted at their 600 design value (60 sessions × 10)</td><td colSpan={2}><b>2,500</b></td></tr>
+          </tbody>
+        </table>
+        <p className="muted sp-deduct-head">Where SP can reduce:</p>
+        <ul className="sp-deduct">
+          {SP_DEDUCTIONS.map((d, i) => <li key={i}>{d}</li>)}
+        </ul>
+      </div>
       <p className="muted faq-intro">Tap a question to see the answer.</p>
       <div className="faq-list">
         {FAQ_ITEMS.map((item, i) => (

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1324,7 +1324,7 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
 
         {/* Projects — live from the PR submission + review mirrors; SP rule still TBD */}
         <section className="jr-card phase-project">
-          <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-soon">SP soon</span></div>
+          <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-sp">+{projects.sp} SP</span></div>
           <p className="jr-sub">{projects.submitted ? `${projects.prsRaised} PR${projects.prsRaised === 1 ? '' : 's'} submitted` : 'Pull requests — none submitted yet'}</p>
           {projects.reviewStatus && (
             <div className="jr-splits"><span className="jr-pill">Review: {projects.reviewStatus}</span></div>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -854,3 +854,14 @@ tr.step-alert td { border-color: #f3c9c5; }
 .ann-done { background: #f6f8fb; border: 1px solid var(--line); }
 .ann-done p, .ann-done header strong { color: var(--muted); }
 .ann-caughtup { margin: 2px 0 0; font-size: 13px; }
+
+/* SP at-a-glance table (FAQ tab) */
+.sp-table-wrap { margin: 4px 0 18px; }
+.sp-table-wrap h3 { margin: 0 0 8px; }
+.sp-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.sp-table th, .sp-table td { border: 1px solid var(--line); padding: 7px 10px; text-align: left; vertical-align: top; }
+.sp-table th { background: rgba(100, 116, 139, .08); }
+.sp-table .sp-total td { border-top: 2px solid var(--line); }
+.sp-deduct-head { margin: 12px 0 4px; font-weight: 600; }
+.sp-deduct { margin: 0 0 4px 18px; color: var(--muted); font-size: 13px; }
+.sp-deduct li { margin: 3px 0; }

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -111,9 +111,28 @@ const STAFF = new Set([
 // never used. Two capped tracks + a one-time integrity penalty on current SP.
 // Source: act_spa_endorsements + act_spa_transactions (mirrored 6-hourly).
 const SPA_LEARN_UNIT = 5, SPA_LEARN_CAP = 50;   // +5 SP / validated question learned, cap 50 → max 250
-const SPA_TEACH_UNIT = 8, SPA_TEACH_CAP = 30;   // +8 SP / validated peer taught,     cap 30 → max 240
+const SPA_TEACH_UNIT = 10, SPA_TEACH_CAP = 25;  // +10 SP / validated peer taught,    cap 25 → max 250
+// Certificate-scale rescore (2026-09-05, per HANDOFF_CERTIFICATE_DATA.md): teach
+// 8×30 → 10×25, strictly upward at every count ≤25; counts 26-30 kept ≥ old pay
+// by the cap math (old max 240 < new max 250).
 const SPA_FRAUD_RATE = 0.5, SPA_AUDIT_RATE = 0.2;
 const SPA_GOOD = ['approved', 'audit_passed'];
+
+// ── Project → SP (mentor-reviewed PR; certificate scale) ─────────────────────
+// One-time +500 when the mentor review of the student's project PR is
+// 'completed' (act_pr_reviews.reviewStatus). 'rejected', 'pending' and
+// 'pending_reevaluation' earn nothing. Dated resubmittedAt || reviewedAt —
+// reviewedAt keeps the EARLIER rejection date on resubmitted projects.
+const PROJECT_SP = 500;
+
+// ── Certificate-locked students ──────────────────────────────────────────────
+// Their certificate is fully processed and issued — printed numbers must never
+// move. They keep the exact rule-set in force at print time: no 'project'
+// category, SPA teach at the legacy 8×30. Everyone still in the signing queue
+// gets the new rules and a regenerated certificate.
+// 2026-09-05: Yaradla Yaswanth Reddy (the only fully-processed certificate).
+const CERT_LOCKED = new Set(['yaswanthreddythb@gmail.com']);
+const SPA_TEACH_UNIT_LEGACY = 8, SPA_TEACH_CAP_LEGACY = 30;
 
 // ── Query answering → SP (Pattern A: rubric-recomputed) ──────────────────────
 // +5 SP per DISTINCT peer query a student answered (from
@@ -432,7 +451,18 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     }
   }
 
-  // 3e. PRESERVED rows (manual/peer_faq) — read BEFORE the wipe and fold into each
+  // 3e. Project → per-canon completed mentor review (earliest completion date).
+  const projectByCanon = new Map(); // canon -> YYYY-MM-DD of review completion
+  for (const r of await sak.collection('act_pr_reviews').find(
+        { reviewStatus: 'completed' }, { projection: { email: 1, reviewedAt: 1, resubmittedAt: 1 } }).toArray()) {
+    const e = String(r.email || '').toLowerCase().trim(); if (!e) continue;
+    const c = canonOf(e);
+    const date = dstr(r.resubmittedAt) || dstr(r.reviewedAt) || TODAY;
+    const prev = projectByCanon.get(c);
+    if (!prev || date < prev) projectByCanon.set(c, date);
+  }
+
+  // 3f. PRESERVED rows (manual/peer_faq) — read BEFORE the wipe and fold into each
   //     student's ledger so commitment/admin SP survives the rebuild. Re-created with
   //     the same delta/date/reason (metadata like original createdAt is not retained).
   const preservedByCanon = new Map(); // canon -> [{ date, order, cat, delta, reason }]
@@ -471,13 +501,16 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     // SPA rows (Pattern A): one consolidated 'spa' row per day, cumulative caps
     // across days. These bypass the (date|cat) best-dedup by being pushed directly.
     const spa = spaByCanon.get(cand); const flags = spaFlag.get(cand) || {};
+    // CERT_LOCKED students keep the legacy teach pay (rules at certificate print time).
+    const teachUnit = CERT_LOCKED.has(cand) ? SPA_TEACH_UNIT_LEGACY : SPA_TEACH_UNIT;
+    const teachCap = CERT_LOCKED.has(cand) ? SPA_TEACH_CAP_LEGACY : SPA_TEACH_CAP;
     let spaLearnUsed = 0, spaTeachUsed = 0;
     if (spa) {
       const byDay = new Map(); // date -> { learn, teach }
       for (const d of spa.learn.slice().sort()) { if (spaLearnUsed >= SPA_LEARN_CAP) break; spaLearnUsed++; const o = byDay.get(d) || { learn: 0, teach: 0 }; o.learn++; byDay.set(d, o); }
-      for (const d of spa.teach.slice().sort()) { if (spaTeachUsed >= SPA_TEACH_CAP) break; spaTeachUsed++; const o = byDay.get(d) || { learn: 0, teach: 0 }; o.teach++; byDay.set(d, o); }
+      for (const d of spa.teach.slice().sort()) { if (spaTeachUsed >= teachCap) break; spaTeachUsed++; const o = byDay.get(d) || { learn: 0, teach: 0 }; o.teach++; byDay.set(d, o); }
       for (const [d, o] of byDay) {
-        const delta = o.learn * SPA_LEARN_UNIT + o.teach * SPA_TEACH_UNIT; if (!delta) continue;
+        const delta = o.learn * SPA_LEARN_UNIT + o.teach * teachUnit; if (!delta) continue;
         const parts = []; if (o.learn) parts.push(`${o.learn} learned`); if (o.teach) parts.push(`${o.teach} taught`);
         rows.push({ date: d, order: 3, cat: 'spa', delta, reason: `SPA (${ddmon(d)}): ${parts.join(' + ')} (validated) -> +${delta} SP.` });
       }
@@ -520,6 +553,13 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
         rows.push({ date: d, order: 4, cat: 'query', delta,
           reason: `Query answering (${ddmon(d)}): ${n} peer quer${n === 1 ? 'y' : 'ies'} answered -> +${delta} SP${capNote}.` });
       }
+    }
+    // Project row: one-time +PROJECT_SP on mentor-completed review (Pattern A,
+    // rubric-recomputed). CERT_LOCKED students keep their issued numbers.
+    const projDate = projectByCanon.get(cand);
+    if (projDate && !CERT_LOCKED.has(cand)) {
+      rows.push({ date: projDate, order: 7, cat: 'project', delta: PROJECT_SP,
+        reason: `Project (${ddmon(projDate)}): mentor review of your project PR completed -> +${PROJECT_SP} SP.` });
     }
     // Preserved rows (manual commitment/admin SP + peer_faq) — fold in so they survive the wipe.
     for (const p of (preservedByCanon.get(cand) || [])) rows.push(p);

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -315,6 +315,25 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
   // attendance for these dates was skipped above, so no double credit.
   for (const [, sp] of spandanAttByDate) scoreSpandanAttendance(sp, 'Day ' + sp.dayNumber);
 
+  // V-Talk attendance pass: special synchronous sessions from the
+  // vtalk_attendance mirror (built by pipeline/vtalk-attendance-build.cjs from
+  // Zoom meeting/webinar reports; webinar rows are strict name->student matches,
+  // unique only). Scored OUTSIDE the per-day session cascade because V-Talks
+  // co-exist with standups on the same date. V-Talk 07 is deliberately absent
+  // (it ran inside Spandan and is already scored as "Day 78 (14 Aug)").
+  // Reason carries "present X of Y min (Z%)" so sync-attendance-records.cjs
+  // folds the minutes into attendancerecords / the 3600 journey goal.
+  for (const v of await sak.collection('vtalk_attendance').find({}).toArray()) {
+    const e = String(v.email || '').toLowerCase().trim(); if (!e) continue;
+    const W = v.windowMinutes || ATT_SESSION_MIN;
+    const mins = Math.min(W, Math.round(v.attendedMinutes || 0));
+    const pct = W ? Math.round(mins / W * 1000) / 10 : 0;
+    const d = tier(pct);
+    touch(e, v.name).rows.push({ date: v.date, order: 1, cat: 'attendance', delta: d,
+      reason: `${v.label} (${ddmon(v.date)}): present ${mins} of ${W} min (${pct}%) -> ${d > 0 ? '+' : ''}${d} SP.` });
+    const o = students.get(e); if (!o.firstAtt || v.date < o.firstAtt) o.firstAtt = v.date;
+  }
+
   // 3b. SPA → per-canon validated learn/teach events (dated) + integrity flags.
   //     emailToCanon is fully built by now, so we can fold aliases correctly.
   const spaByCanon = new Map(); // canon -> { learn:[YYYY-MM-DD...], teach:[...] }

--- a/pipeline/vtalk-attendance-build.cjs
+++ b/pipeline/vtalk-attendance-build.cjs
@@ -1,0 +1,118 @@
+'use strict';
+/**
+ * vtalk-attendance-build.cjs
+ *
+ * Builds sakshi_spurti.vtalk_attendance from the zoom_attendance mirror —
+ * one doc per (V-Talk session, resolvable student). The SP rubric
+ * (sp-rubric-build-mirror.cjs, V-Talk pass) scores this collection on every
+ * rebuild, so this builder is the only thing that has to run when new V-Talk
+ * data arrives in the Zoom mirror. Safe to re-run: full rewrite per label.
+ *
+ * Resolution rules (strict — wrong-student credit is worse than no credit):
+ *   1. row email matches a candidate email/alias           -> credited
+ *   2. roll number (e.g. 24f3001996) inside display name
+ *      matches a candidate email local part                -> credited
+ *   3. normalized display name matches exactly ONE
+ *      candidate name                                      -> credited
+ *   ambiguous or unmatched names are skipped and counted.
+ *
+ * V-Talk 07 (14 Aug, meetingId 92262477413) is EXCLUDED: it ran inside
+ * Spandan and is already scored as "Day 78 (14 Aug)" — including it here
+ * would double-credit the same hour.
+ *
+ * Run: cd ~/spurti && node pipeline/vtalk-attendance-build.cjs
+ */
+const { MongoClient } = require('mongodb');
+require('dotenv').config();
+
+if (!process.env.MONGO_URI) {
+  console.error('MONGO_URI is not set. Run from the repo root: cd ~/spurti && node pipeline/vtalk-attendance-build.cjs');
+  process.exit(1);
+}
+
+const WINDOW_MIN = 60; // every synchronous session counts as one 60-min block (3600 goal)
+
+// Known sessions; any OTHER zoom_meetings doc with a v-talk-ish topic is
+// auto-included with a label parsed from the topic (or bare "V-Talk").
+const KNOWN_LABELS = {
+  98906641901: 'V-Talk 03', // Devyani Wankhede, 4 Jul (webinar)
+  91675499012: 'V-Talk 04', // Dhivya Kannan, 14 Jul (webinar)
+  94814083137: 'V-Talk 05', // Dr. Yayati Gupta, 25 Jul (meeting, real emails)
+  92569888217: 'V-Talk 06', // Dr. M.S. Lakshmi Priya, 31 Jul (webinar)
+};
+const EXCLUDE = new Set([92262477413]); // V-Talk 07 = Spandan "Day 78 (14 Aug)"
+
+const norm = (s) => String(s || '').toLowerCase().replace(/\s+/g, ' ').trim();
+const ROLL_IN_NAME = /\b(\d{2}[a-z]{1,2}\d{6,7})\b/i;
+const ROLL_IN_EMAIL = /^(\d{2}[a-z]{1,2}\d{6,7})@/i;
+
+(async () => {
+  const client = await MongoClient.connect(process.env.MONGO_URI);
+  const db = client.db('sakshi_spurti');
+
+  // Roster: canonical email + aliases + names, from candidates (same source
+  // the rubric uses for eligibility).
+  const emailSet = new Set(); const rollMap = new Map(); const nameMap = new Map();
+  for (const u of await db.collection('candidates')
+    .find({ email: { $exists: true } }, { projection: { email: 1, emailAlt: 1, zoomEmail: 1, name: 1 } }).toArray()) {
+    const canon = norm(u.email); if (!canon) continue;
+    for (const e of [canon, norm(u.emailAlt), norm(u.zoomEmail)].filter(Boolean)) {
+      emailSet.add(e);
+      const rm = ROLL_IN_EMAIL.exec(e); if (rm) rollMap.set(rm[1].toLowerCase(), canon);
+    }
+    const n = norm(u.name);
+    if (n) { if (!nameMap.has(n)) nameMap.set(n, new Set()); nameMap.get(n).add(canon); }
+  }
+
+  const meetings = await db.collection('zoom_meetings')
+    .find({ topic: /v[-\s]?talk/i }).sort({ date: 1 }).toArray();
+
+  const builtLabels = [];
+  const docs = [];
+  for (const m of meetings) {
+    if (EXCLUDE.has(m.meetingId)) continue;
+    let label = KNOWN_LABELS[m.meetingId];
+    if (!label) {
+      const num = /v[-\s]?talk\s*0*(\d+)/i.exec(m.topic || '');
+      label = num ? `V-Talk ${String(num[1]).padStart(2, '0')}` : 'V-Talk';
+    }
+    builtLabels.push(label);
+
+    const best = new Map(); // canon email -> {mins, name}
+    let matched = 0, ambiguous = 0, unmatched = 0, total = 0;
+    for (const p of await db.collection('zoom_attendance').find({ meetingId: m.meetingId }).toArray()) {
+      total++;
+      let e = norm(p.email);
+      if (e && !emailSet.has(e)) { unmatched++; continue; } // host/guest, not a candidate
+      if (!e) {
+        const rm = ROLL_IN_NAME.exec(p.name || '');
+        if (rm && rollMap.has(rm[1].toLowerCase())) e = rollMap.get(rm[1].toLowerCase());
+        else {
+          const cands = nameMap.get(norm(p.name));
+          if (cands && cands.size === 1) e = [...cands][0];
+          else { cands && cands.size > 1 ? ambiguous++ : unmatched++; continue; }
+        }
+      }
+      matched++;
+      const mins = Math.min(WINDOW_MIN, Math.round(p.duration || 0));
+      const prev = best.get(e);
+      if (!prev || mins > prev.mins) best.set(e, { mins, name: p.name || '' });
+    }
+
+    for (const [email, v] of best) {
+      docs.push({ label, date: m.date, meetingId: m.meetingId, email, name: v.name,
+        attendedMinutes: v.mins, windowMinutes: WINDOW_MIN, builtAt: new Date() });
+    }
+    console.log(`${label} (${m.date}) "${m.topic}": ${total} rows -> ${matched} credited` +
+      ` (${best.size} unique students), ${ambiguous} ambiguous skipped, ${unmatched} unmatched`);
+  }
+
+  if (builtLabels.length) {
+    const del = await db.collection('vtalk_attendance').deleteMany({ label: { $in: builtLabels } });
+    const ins = docs.length ? await db.collection('vtalk_attendance').insertMany(docs) : { insertedCount: 0 };
+    console.log(`vtalk_attendance: replaced ${del.deletedCount} -> inserted ${ins.insertedCount}`);
+  } else {
+    console.log('no V-Talk meetings found in zoom_meetings');
+  }
+  await client.close();
+})();

--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -82,7 +82,7 @@ export async function buildJourneyState(student) {
   };
 
   // --- Phase 4: Projects — live from the Samagama PR-submission mirror.
-  // Progress is real; the SP rule for PRs is still TBD (sp stays 0 for now). ---
+  // SP = +500 on mentor-completed review, scored by the rubric (category 'project'). ---
   const [prSub, prRev] = await Promise.all([
     ActPullRequest.findOne({ email }).lean(),
     ActPrReview.findOne({ email }).lean()
@@ -91,7 +91,7 @@ export async function buildJourneyState(student) {
     submitted: !!prSub,
     prsRaised: prSub ? countPrLinks(prSub.branchOrPrLinks) : 0,
     reviewStatus: prRev?.reviewStatus || null,
-    sp: 0, spRulePending: true,
+    sp: spByCat(['project']),
     pending: false
   };
 

--- a/server/services/spa.js
+++ b/server/services/spa.js
@@ -13,7 +13,7 @@ export function isSpaEligible() { return true; } // SPA SP is a universal featur
 // LOCKED scheme (see memory: spa-sp-award-scheme).
 export const CONFIG = {
   learnUnit: 5,  learnCap: 50,   // +5 SP per validated question learned, cap 50  → max 250
-  teachUnit: 8,  teachCap: 30,   // +8 SP per validated endorsement given, cap 30 → max 240
+  teachUnit: 10, teachCap: 25,   // +10 SP per validated endorsement given, cap 25 → max 250 (8×30 → 10×25 rescore, 2026-09-05)
   fraudRate: 0.5,                // genuine fraud  → -50% of current SP (one-time)
   auditRate: 0.2                 // audit failure  → -20% of current SP (one-time)
 };


### PR DESCRIPTION
Certificate-scale rubric changes per HANDOFF_CERTIFICATE_DATA.md: project +500 on mentor-completed review, SPA teach 8x30 -> 10x25, CERT_LOCKED set (1 fully-processed certificate keeps print-time rules). Also commits the live V-Talk attendance pass running uncommitted on prod, and adds the SP at-a-glance table to the FAQ tab + FAQ_SP.md. User-authorized token merge.