### PR TITLE
feat(risk): SP Risk Predictor panel on the student record

### DIFF
--- a/client/src/SpRiskPanel.jsx
+++ b/client/src/SpRiskPanel.jsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from 'react';
+
+const BREAKDOWN_ROWS = [
+  ['attendance', 'Attendance'],
+  ['pollParticipation', 'Poll participation'],
+  ['pollQuality', 'Poll quality'],
+  ['queryActivity', 'Query activity']
+];
+
+export function SpRiskPanel({ api, email }) {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const r = await fetch(`${api}/risk/state?email=${encodeURIComponent(email)}`);
+        const j = await r.json().catch(() => ({}));
+        if (!r.ok) throw new Error(j.error || 'Could not load SP risk.');
+        if (active) { setData(j); setError(null); }
+      } catch (err) {
+        if (active) setError(err.message || 'Could not load SP risk.');
+      }
+    })();
+    return () => { active = false; };
+  }, [api, email]);
+
+  if (error) {
+    return (
+      <section className="sp-risk">
+        <p className="eyebrow">SP Risk</p>
+        <p className="error">{error}</p>
+      </section>
+    );
+  }
+  if (!data) {
+    return (
+      <section className="sp-risk">
+        <p className="muted">Loading your SP risk…</p>
+      </section>
+    );
+  }
+
+  const level = String(data.riskLevel || 'Low');
+  const suggestions = (data.recoverySuggestions || []).slice(0, 3);
+  const breakdown = data.breakdown || {};
+  const days = data.daysAnalyzed || 14;
+
+  // No sessions, polls or queries landed in the window, so the score would read
+  // High purely from absent data — say so instead of blaming the student.
+  if (!hasActivity(data)) {
+    return (
+      <section className="sp-risk">
+        <div className="sp-risk-head">
+          <div>
+            <p className="eyebrow">SP Risk Predictor</p>
+            <h2>Last {days} days</h2>
+          </div>
+          <span className="sp-risk-badge">Not enough data yet</span>
+        </div>
+        <p className="muted">
+          No attendance, poll or peer-query activity is recorded in this window yet, so there is
+          nothing to score. Your risk level appears once the next session, poll or credited query lands.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="sp-risk">
+      <div className="sp-risk-head">
+        <div>
+          <p className="eyebrow">SP Risk Predictor</p>
+          <h2>Last {days} days</h2>
+        </div>
+        <span className={`sp-risk-badge risk-${level.toLowerCase()}`}>{level} risk</span>
+      </div>
+
+      <div className="level-tiles sp-risk-tiles">
+        <div className="level-tile">
+          <span>Current SP</span>
+          <strong>{data.currentSp}</strong>
+          <em>live balance</em>
+        </div>
+        <div className={`level-tile league tier-${String(data.trophyLeague || 'Bronze').split(' ')[0].toLowerCase()}`}>
+          <span>Trophy League</span>
+          <strong>{data.trophyLeague || '—'}</strong>
+          <em>from current SP</em>
+        </div>
+        <div className="level-tile">
+          <span>Risk Level</span>
+          <strong>{level}</strong>
+          <em>Low / Medium / High</em>
+        </div>
+        <div className="level-tile">
+          <span>Risk Score</span>
+          <strong>{data.riskScore}</strong>
+          <em>0 is safest, 100 is highest risk</em>
+        </div>
+      </div>
+
+      <p className="muted sp-risk-meta">
+        Recovery outlook: <b>+{Number(data.projectedSpGain) || 0} SP</b> is realistically within reach
+        {data.projectedLeague && data.projectedLeague !== data.trophyLeague
+          ? <> — enough to reach <b>{data.projectedLeague}</b></>
+          : null}.
+        {data.nextLeague
+          ? ` ${data.spToNextLeague} SP more reaches ${data.nextLeague}.`
+          : ' You are in the top league.'}
+      </p>
+
+      <h3 className="sp-risk-sub">Why am I at risk?</h3>
+      <p className="muted sp-risk-meta">
+        Each bar is that factor’s share of the {data.riskScore} risk score
+        {data.sessionsConsidered != null ? ` · ${data.sessionsConsidered} session${data.sessionsConsidered === 1 ? '' : 's'}` : ''}
+        {data.pollsConsidered != null ? ` · ${data.pollsConsidered} poll${data.pollsConsidered === 1 ? '' : 's'}` : ''}
+        {data.queriesConsidered != null ? ` · ${data.queriesConsidered} quer${data.queriesConsidered === 1 ? 'y' : 'ies'}` : ''}
+        {' '}in this window.
+      </p>
+      <div className="bars sp-risk-bars">
+        {BREAKDOWN_ROWS.map(([key, label]) => {
+          const row = breakdown[key] || {};
+          const points = Number(row.points) || 0;
+          const metric = row.metric;
+          const width = Math.max(0, Math.min(100, points));
+          return (
+            <div className="bar-row" key={key}>
+              <span>{label}</span>
+              <div><i style={{ width: `${width}%` }} /></div>
+              <b>{points}</b>
+            </div>
+          );
+        })}
+      </div>
+      {Array.isArray(data.reasons) && data.reasons.length > 0 && (
+        <ul className="sp-risk-reasons">
+          {data.reasons.map((reason, i) => <li key={i}>{reason}</li>)}
+        </ul>
+      )}
+
+      <h3 className="sp-risk-sub">Recovery plan</h3>
+      {suggestions.length === 0 ? (
+        <p className="muted">No recovery actions right now.</p>
+      ) : (
+        <div className="sp-risk-plan">
+          {suggestions.map((s, i) => (
+            <article className={`sp-risk-action priority-${String(s.priority || 'medium').toLowerCase()}`} key={i}>
+              <header>
+                <span className={`jr-pill ${priorityPill(s.priority)}`}>{s.priority || 'medium'}</span>
+                <strong className="sp-risk-sp">+{Number(s.estimatedSp) || 0} SP</strong>
+              </header>
+              <p>{s.action}</p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function hasActivity(data) {
+  return (Number(data.sessionsConsidered) || 0) > 0
+    || (Number(data.pollsConsidered) || 0) > 0
+    || (Number(data.queriesConsidered) || 0) > 0;
+}
+
+function priorityPill(priority) {
+  const p = String(priority || '').toLowerCase();
+  if (p === 'high') return 'amber';
+  if (p === 'low') return 'green';
+  return '';
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles.css';
+import { SpRiskPanel } from './SpRiskPanel.jsx';
 
 const APP_BASE = window.location.pathname.startsWith('/spurti') ? '/spurti' : '';
 const API = `${APP_BASE}/api`;
@@ -300,6 +301,7 @@ function StudentView({ profile, onBack }) {
         <div className="score-card"><span>SP</span><strong>{student.totalSp}</strong><em>Rank {student.rank} of {student.cohortSize}</em></div>
       </header>
       <LevelStatus student={student} />
+      <SpRiskPanel api={API} email={student.email} />
       <Announcements student={student} />
       <StudentPulse
         profile={profile}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -257,6 +257,69 @@ input {
 .level-tile.league.tier-legend   { background: linear-gradient(135deg, #6d28d9, #c026d3); }
 .level-note { color: var(--muted); font-size: 13px; margin-top: 12px; line-height: 1.5; }
 @media (max-width: 720px) { .level-tiles { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+
+/* SP Risk Predictor (Phase 2) — sits under LevelStatus on the student record */
+.sp-risk {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: 16px;
+  margin-bottom: 18px;
+}
+.sp-risk-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.sp-risk-head h2 { margin: 0; font-size: 22px; }
+.sp-risk-tiles { margin-bottom: 8px; }
+.sp-risk-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.sp-risk-badge.risk-low { background: #e9f7ee; color: var(--green); }
+.sp-risk-badge.risk-medium { background: #fef3e2; color: var(--amber); }
+.sp-risk-badge.risk-high { background: #fde8e6; color: var(--red); }
+.sp-risk-sub { font-size: 15px; margin: 16px 0 8px; }
+.sp-risk-meta { margin: 0 0 10px; font-size: 13px; }
+.sp-risk-bars { margin-bottom: 10px; }
+.sp-risk-bars .bar-row { grid-template-columns: 140px minmax(0, 1fr) 42px; font-size: 13px; font-weight: 700; }
+.sp-risk-reasons {
+  margin: 0 0 4px;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.sp-risk-plan { display: grid; gap: 10px; }
+.sp-risk-action {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: #fafdff;
+}
+.sp-risk-action header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.sp-risk-action p { margin: 0; color: var(--text); font-size: 14px; line-height: 1.45; }
+.sp-risk-sp { color: var(--green); font-size: 14px; }
+.sp-risk-action.priority-high { border-color: #f5c9a8; background: #fff6ef; }
+.sp-risk-action.priority-low { border-color: #cdebd8; background: #f4fbf6; }
+
 .pulse-grid {
   display: grid;
   grid-template-columns: 1fr 2fr;

--- a/server/server.js
+++ b/server/server.js
@@ -27,6 +27,7 @@ import { buildStandupState, placeStandup, settleStandupDemo } from './services/s
 import { buildJourneyState, saveJourneyPlan } from './services/journey.js';
 import { buildSpaState } from './services/spa.js';
 import { buildTrajectoryState } from './services/trajectory.js';
+import { buildRiskState } from './services/spRisk.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -396,6 +397,13 @@ api.get('/trajectory/state', async (req, res) => {
   const student = await vibeStudent(req);
   if (!student) return res.status(404).json({ error: 'Student not found' });
   res.json(await buildTrajectoryState(student));
+});
+
+// ---- SP Risk (last 14 days; derived read — never writes SP) ------------------
+api.get('/risk/state', async (req, res) => {
+  const student = await vibeStudent(req);
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  res.json(await buildRiskState(student));
 });
 
 // ---- Standup commitments (weekly, attendance-only; keep-the-stake) -----------

--- a/server/services/spRisk.js
+++ b/server/services/spRisk.js
@@ -1,0 +1,415 @@
+// SP Risk Predictor — derived READ of the last 14 days of attendance, polls,
+// and query activity. Never writes SP, students, or transactions.
+//
+// Scoring is explainable (weighted gaps vs the live 10/5/3/0 attendance/poll
+// ladder and +5 query unit). Trophy League labels come from leagueBand() in
+// levels.js — the same function the student payload uses.
+
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import PollRecord from '../models/PollRecord.js';
+import SPTransaction from '../models/SPTransaction.js';
+import Session from '../models/Session.js';
+import { leagueBand } from './levels.js';
+
+export const WINDOW_DAYS = 14;
+export const ATT_POLL_BAND_MAX = 10;   // top rung of the live attendance/poll ladder
+export const QUERY_UNIT = 5;
+export const QUERY_HEALTHY = 3;        // ≥3 distinct credited queries in the window = full query score
+export const PROJECTED_GAIN_CAP = 80;  // do not over-promise recovery SP
+
+const DAY_MS = 86400000;
+const MONTHS = {
+  jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+  jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11
+};
+
+const WEIGHTS = {
+  attendance: 0.35,
+  pollParticipation: 0.25,
+  pollQuality: 0.25,
+  query: 0.15
+};
+
+export function windowBounds(now = new Date()) {
+  const end = new Date(now);
+  const start = new Date(end.getTime() - WINDOW_DAYS * DAY_MS);
+  return { start, end };
+}
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function clampPct(n) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+// Session labels look like "15 May Morning", "Day 10 (26 May)", "22 May Evening".
+export function parseSessionLabelDate(label, now = new Date()) {
+  const text = String(label || '');
+  let day, mon;
+  const paren = text.match(/\((\d{1,2})\s+([A-Za-z]+)\)/);
+  if (paren) { day = +paren[1]; mon = paren[2]; }
+  else {
+    const lead = text.match(/^(\d{1,2})\s+([A-Za-z]+)/);
+    if (lead) { day = +lead[1]; mon = lead[2]; }
+  }
+  const m = mon ? MONTHS[mon.slice(0, 3).toLowerCase()] : undefined;
+  if (m === undefined || !day) return null;
+  const year = now.getFullYear();
+  const d = new Date(Date.UTC(year, m, day));
+  // Labels omit the year; if the parsed date is far in the future, it was last year.
+  if (d.getTime() - now.getTime() > 60 * DAY_MS) d.setUTCFullYear(year - 1);
+  return d;
+}
+
+function firstTxnDate(txns, sessionLabel, category) {
+  const hit = txns.find(t => t.sessionLabel === sessionLabel && (!category || t.category === category));
+  return hit?.dateTime ? new Date(hit.dateTime) : null;
+}
+
+export function eventTime(record, { sessionsByLabel, txns, category, now }) {
+  const label = record.sessionLabel;
+  const sess = label ? sessionsByLabel.get(label) : null;
+  if (sess?.date) return new Date(sess.date);
+  if (sess?.endDateTime) return new Date(sess.endDateTime);
+  const fromTxn = firstTxnDate(txns, label, category);
+  if (fromTxn) return fromTxn;
+  if (record.dateTime) return new Date(record.dateTime);
+  const parsed = parseSessionLabelDate(label, now);
+  if (parsed) return parsed;
+  if (record.createdAt) return new Date(record.createdAt);
+  return null;
+}
+
+function inWindow(date, start, end) {
+  if (!date) return false;
+  const t = date.getTime();
+  return t >= start.getTime() && t <= end.getTime();
+}
+
+function bandMidpointPct(delta) {
+  const d = num(delta);
+  if (d >= 10) return 95;
+  if (d >= 5) return 82;
+  if (d >= 3) return 62;
+  return 25;
+}
+
+export function attendancePercentage(records, attendanceTxns) {
+  const withMinutes = records.filter(r => num(r.totalSessionMinutes) > 0);
+  if (withMinutes.length) {
+    const attended = withMinutes.reduce((a, r) => a + num(r.attendedMinutes), 0);
+    const total = withMinutes.reduce((a, r) => a + num(r.totalSessionMinutes), 0);
+    return total ? clampPct((attended / total) * 100) : 0;
+  }
+  if (records.length) {
+    return clampPct(records.reduce((a, r) => a + num(r.attendancePercentage), 0) / records.length);
+  }
+  if (attendanceTxns.length) {
+    return clampPct(attendanceTxns.reduce((a, t) => a + bandMidpointPct(t.appliedDelta), 0) / attendanceTxns.length);
+  }
+  return 0;
+}
+
+export function pollParticipationPercentage(polls) {
+  const attempted = polls.reduce((a, p) => a + num(p.attemptedQuestions), 0);
+  const total = polls.reduce((a, p) => a + num(p.totalQuestions), 0);
+  if (total > 0) return clampPct((attempted / total) * 100);
+  if (!polls.length) return 0;
+  return 0;
+}
+
+export function pollQualityScore(pollTxns) {
+  if (!pollTxns.length) return 0;
+  const avg = pollTxns.reduce((a, t) => a + Math.max(0, Math.min(ATT_POLL_BAND_MAX, num(t.appliedDelta))), 0)
+    / pollTxns.length;
+  return clampPct((avg / ATT_POLL_BAND_MAX) * 100);
+}
+
+export function queryActivityCount(queryTxns) {
+  return queryTxns.filter(t => num(t.appliedDelta) > 0).length;
+}
+
+function round1(n) {
+  return Math.round(n * 10) / 10;
+}
+
+function queryMetric(queryCount) {
+  return clampPct((Math.min(QUERY_HEALTHY, queryCount) / QUERY_HEALTHY) * 100);
+}
+
+// Each factor's `points` is its share of the 0–100 risk score:
+//   points = weight × (100 − metric)
+// The four `points` values sum to `riskScore` (after 0.1 rounding).
+export function riskBreakdown({ attendancePct, pollParticipationPct, pollQuality, queryCount }) {
+  const queryScore = queryMetric(queryCount);
+  const attendance = round1(WEIGHTS.attendance * (100 - attendancePct));
+  const pollParticipation = round1(WEIGHTS.pollParticipation * (100 - pollParticipationPct));
+  const pollQualityPoints = round1(WEIGHTS.pollQuality * (100 - pollQuality));
+  const queryActivity = round1(WEIGHTS.query * (100 - queryScore));
+  return {
+    attendance: { weight: WEIGHTS.attendance, metric: attendancePct, points: attendance },
+    pollParticipation: { weight: WEIGHTS.pollParticipation, metric: pollParticipationPct, points: pollParticipation },
+    pollQuality: { weight: WEIGHTS.pollQuality, metric: pollQuality, points: pollQualityPoints },
+    queryActivity: { weight: WEIGHTS.query, metric: queryScore, points: queryActivity }
+  };
+}
+
+export function overallRiskScore(input) {
+  const b = riskBreakdown(input);
+  return clampPct(b.attendance.points + b.pollParticipation.points + b.pollQuality.points + b.queryActivity.points);
+}
+
+export function riskLevelFor(score) {
+  if (score >= 65) return 'High';
+  if (score >= 35) return 'Medium';
+  return 'Low';
+}
+
+function uniqueLabels(rows) {
+  return new Set(rows.map(r => r.sessionLabel).filter(Boolean));
+}
+
+function spSum(txns) {
+  return txns.reduce((a, t) => a + num(t.appliedDelta), 0);
+}
+
+export function projectedSpParts({
+  attendanceSessions,
+  pollSessions,
+  attendanceSp,
+  pollSp,
+  queryCount
+}) {
+  const attCap = Math.max(attendanceSessions, 0) * ATT_POLL_BAND_MAX;
+  const pollCap = Math.max(pollSessions, 0) * ATT_POLL_BAND_MAX;
+  const attendance = Math.max(0, attCap - Math.max(0, attendanceSp));
+  const poll = Math.max(0, pollCap - Math.max(0, pollSp));
+  const query = Math.max(0, QUERY_HEALTHY - queryCount) * QUERY_UNIT;
+  const empty = (!attendanceSessions && !pollSessions && queryCount === 0);
+  const attendanceEst = attendance + (empty ? ATT_POLL_BAND_MAX : 0);
+  const pollEst = poll + (empty ? ATT_POLL_BAND_MAX : 0);
+  const queryEst = query + (empty && query === 0 ? QUERY_HEALTHY * QUERY_UNIT : 0);
+  const raw = attendanceEst + pollEst + queryEst;
+  const total = Math.min(PROJECTED_GAIN_CAP, Math.round(raw));
+  return { attendance: attendanceEst, poll: pollEst, query: queryEst, total };
+}
+
+export function projectedSpGain(input) {
+  return projectedSpParts(input).total;
+}
+
+export function leagueContext(currentSp, gain) {
+  const sp = Math.max(0, num(currentSp));
+  const trophyLeague = leagueBand(sp);
+  const projectedSp = sp + Math.max(0, num(gain));
+  const projectedLeague = leagueBand(projectedSp);
+  let spToNextLeague = 0;
+  let nextLeague = null;
+  if (trophyLeague !== 'Legend') {
+    for (let s = Math.floor(sp) + 1; s <= 1500; s++) {
+      if (leagueBand(s) !== trophyLeague) {
+        nextLeague = leagueBand(s);
+        spToNextLeague = s - sp;
+        break;
+      }
+    }
+  }
+  let spToLeagueFloor = 0;
+  if (sp > 0) {
+    let floor = Math.floor(sp);
+    while (floor > 0 && leagueBand(floor - 1) === trophyLeague) floor -= 1;
+    spToLeagueFloor = sp - floor;
+  }
+  return { trophyLeague, nextLeague, spToNextLeague, spToLeagueFloor, projectedLeague, projectedSp };
+}
+
+export function buildReasons({
+  attendancePct, pollParticipationPct, pollQuality, queryCount,
+  attendanceSessions, pollSessions, riskScore, riskLevel, league
+}) {
+  const reasons = [];
+  if (attendanceSessions === 0) {
+    reasons.push('No standup attendance is recorded in the last 14 days.');
+  } else if (attendancePct < 50) {
+    reasons.push(`Attendance is ${attendancePct}% over the last 14 days — below the 50% band, so those sessions earned 0 attendance SP.`);
+  } else if (attendancePct < 75) {
+    reasons.push(`Attendance is ${attendancePct}% over the last 14 days (50–74% band, +3 SP per session). Reaching 75% would lift that to +5.`);
+  } else if (attendancePct < 90) {
+    reasons.push(`Attendance is ${attendancePct}% over the last 14 days (75–89% band, +5 SP). 90%+ earns the full +10.`);
+  }
+
+  if (pollSessions === 0) {
+    reasons.push('No session poll activity is recorded in the last 14 days.');
+  } else {
+    if (pollParticipationPct < 60) {
+      reasons.push(`Poll participation is ${pollParticipationPct}% of questions in the window — missed questions cannot earn poll SP.`);
+    }
+    if (pollQuality < 50) {
+      reasons.push(`Poll quality (correctness vs the day's top scorer, banded 10/5/3/0) scored ${pollQuality}/100 in the last 14 days.`);
+    } else if (pollQuality < 80) {
+      reasons.push(`Poll quality scored ${pollQuality}/100 — mid-band, not yet matching the day's top scorer.`);
+    }
+  }
+
+  if (queryCount === 0) {
+    reasons.push('No credited peer-query answers in the last 14 days (+5 SP each, lifetime cap 200).');
+  } else if (queryCount < QUERY_HEALTHY) {
+    reasons.push(`Only ${queryCount} credited peer-query answer${queryCount === 1 ? '' : 's'} in 14 days — below a healthy pace of ${QUERY_HEALTHY}.`);
+  }
+
+  if (league.trophyLeague !== 'Legend' && league.spToLeagueFloor < 30 && riskScore >= 35) {
+    reasons.push(`You are ${league.spToLeagueFloor} SP above the floor of ${league.trophyLeague}; a quiet stretch can drop the Trophy League (Level never decreases).`);
+  }
+
+  if (!reasons.length) {
+    reasons.push(`Last 14 days look steady (${riskLevel} risk). Keep the same attendance, poll, and query pace to hold ${league.trophyLeague}.`);
+  }
+  return reasons;
+}
+
+function withPriority(items) {
+  const ranked = [...items].sort((a, b) => b.estimatedSp - a.estimatedSp || a.action.localeCompare(b.action));
+  const labels = ['high', 'medium', 'low'];
+  return items.map((item) => ({
+    action: item.action,
+    estimatedSp: item.estimatedSp,
+    priority: labels[Math.min(ranked.findIndex(r => r === item), 2)]
+  }));
+}
+
+export function buildRecoverySuggestions({
+  attendancePct, pollParticipationPct, pollQuality, queryCount, parts, league
+}) {
+  const suggestions = [];
+  if (attendancePct < 90) {
+    suggestions.push({
+      action: 'Join the next standups for the full official window (90%+ presence → +10 attendance SP each). Evening Spandan nights count attendance from poll correctness.',
+      estimatedSp: parts.attendance
+    });
+  }
+  if (pollParticipationPct < 90 || pollQuality < 80) {
+    suggestions.push({
+      action: 'Attempt every launched poll question and aim for correctness relative to that day’s top scorer (banded +10 / +5 / +3 / 0).',
+      estimatedSp: parts.poll
+    });
+  }
+  if (queryCount < QUERY_HEALTHY) {
+    const n = QUERY_HEALTHY - queryCount;
+    suggestions.push({
+      action: `Answer ${n} more distinct peer quer${n === 1 ? 'y' : 'ies'} with a real, useful reply (+${QUERY_UNIT} SP each; self-answers and rejected answers do not count).`,
+      estimatedSp: parts.query
+    });
+  }
+  if (!suggestions.length) {
+    suggestions.push({
+      action: league.nextLeague
+        ? `Stay at 90%+ attendance and top-band polls. ${league.spToNextLeague} SP more reaches ${league.nextLeague}.`
+        : 'Stay at 90%+ attendance and top-band polls. You are in Legend.',
+      estimatedSp: 0
+    });
+  }
+  return withPriority(suggestions);
+}
+
+function sliceWindow({ attendance, polls, transactions, sessions, now }) {
+  const { start, end } = windowBounds(now);
+  const sessionsByLabel = new Map((sessions || []).map(s => [s.label, s]));
+  const ctx = { sessionsByLabel, txns: transactions, now };
+
+  const attRecords = attendance.filter(r => inWindow(eventTime(r, { ...ctx, category: 'attendance' }), start, end));
+  const pollRecords = polls.filter(r => inWindow(eventTime(r, { ...ctx, category: 'poll' }), start, end));
+  const txIn = transactions.filter(t => t.dateTime && inWindow(new Date(t.dateTime), start, end));
+  const attendanceTxns = txIn.filter(t => t.category === 'attendance');
+  const pollTxns = txIn.filter(t => t.category === 'poll');
+  const queryTxns = txIn.filter(t => t.category === 'query');
+
+  return { start, end, attRecords, pollRecords, attendanceTxns, pollTxns, queryTxns };
+}
+
+// Pure: used by tests and by buildRiskState. Does not touch Mongo.
+export function computeRiskState({
+  student,
+  attendance = [],
+  polls = [],
+  transactions = [],
+  sessions = [],
+  now = new Date()
+}) {
+  const sliced = sliceWindow({ attendance, polls, transactions, sessions, now });
+  const attendancePct = attendancePercentage(sliced.attRecords, sliced.attendanceTxns);
+  const pollParticipationPct = pollParticipationPercentage(sliced.pollRecords);
+  const pollQuality = pollQualityScore(sliced.pollTxns);
+  const queryCount = queryActivityCount(sliced.queryTxns);
+  const attendanceSessions = Math.max(uniqueLabels(sliced.attRecords).size, uniqueLabels(sliced.attendanceTxns).size);
+  const pollSessions = Math.max(uniqueLabels(sliced.pollRecords).size, uniqueLabels(sliced.pollTxns).size);
+  const attendanceSp = spSum(sliced.attendanceTxns);
+  const pollSp = spSum(sliced.pollTxns);
+  const breakdown = riskBreakdown({ attendancePct, pollParticipationPct, pollQuality, queryCount });
+  const riskScore = overallRiskScore({ attendancePct, pollParticipationPct, pollQuality, queryCount });
+  const riskLevel = riskLevelFor(riskScore);
+  const parts = projectedSpParts({
+    attendanceSessions, pollSessions, attendanceSp, pollSp, queryCount
+  });
+  const gain = parts.total;
+  const currentSp = num(student.totalSp);
+  const league = leagueContext(currentSp, gain);
+  const reasons = buildReasons({
+    attendancePct, pollParticipationPct, pollQuality, queryCount,
+    attendanceSessions, pollSessions, riskScore, riskLevel, league
+  });
+  const recoverySuggestions = buildRecoverySuggestions({
+    attendancePct, pollParticipationPct, pollQuality, queryCount, parts, league
+  });
+
+  const internStart = student.internshipStartDate ? new Date(student.internshipStartDate) : null;
+  let daysAnalyzed = WINDOW_DAYS;
+  if (internStart && internStart.getTime() > sliced.start.getTime()) {
+    daysAnalyzed = Math.max(1, Math.ceil((sliced.end.getTime() - internStart.getTime()) / DAY_MS));
+  }
+
+  return {
+    windowDays: WINDOW_DAYS,
+    windowStart: sliced.start.toISOString(),
+    windowEnd: sliced.end.toISOString(),
+    currentSp,
+    trophyLeague: league.trophyLeague,
+    nextLeague: league.nextLeague,
+    spToNextLeague: league.spToNextLeague,
+    projectedLeague: league.projectedLeague,
+    attendancePercentage: attendancePct,
+    pollParticipationPercentage: pollParticipationPct,
+    pollQualityScore: pollQuality,
+    queryActivityCount: queryCount,
+    riskScore,
+    riskLevel,
+    breakdown,
+    daysAnalyzed,
+    sessionsConsidered: attendanceSessions,
+    pollsConsidered: pollSessions,
+    queriesConsidered: sliced.queryTxns.length,
+    reasons,
+    recoverySuggestions,
+    projectedSpGain: gain,
+    metrics: {
+      attendanceSessions,
+      pollSessions,
+      attendanceSp,
+      pollSp,
+      querySp: spSum(sliced.queryTxns.filter(t => num(t.appliedDelta) > 0))
+    }
+  };
+}
+
+export async function buildRiskState(student, now = new Date()) {
+  const email = student.email;
+  const [attendance, polls, transactions, sessions] = await Promise.all([
+    AttendanceRecord.find({ email }).lean(),
+    PollRecord.find({ email }).lean(),
+    SPTransaction.find({ email }).sort({ dateTime: 1, createdAt: 1 }).lean(),
+    Session.find().lean()
+  ]);
+  return computeRiskState({ student, attendance, polls, transactions, sessions, now });
+}

--- a/test/sp-risk.test.js
+++ b/test/sp-risk.test.js
@@ -1,0 +1,169 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { leagueBand } from '../server/services/levels.js';
+import {
+  WINDOW_DAYS,
+  attendancePercentage,
+  pollParticipationPercentage,
+  pollQualityScore,
+  queryActivityCount,
+  overallRiskScore,
+  riskLevelFor,
+  projectedSpGain,
+  computeRiskState,
+  parseSessionLabelDate
+} from '../server/services/spRisk.js';
+
+const now = new Date('2026-09-03T12:00:00.000Z');
+
+function daysAgo(n, extra = {}) {
+  return {
+    dateTime: new Date(now.getTime() - n * 86400000),
+    createdAt: new Date(now.getTime() - n * 86400000),
+    ...extra
+  };
+}
+
+describe('parseSessionLabelDate', () => {
+  test('reads leading and parenthetical labels', () => {
+    const a = parseSessionLabelDate('15 May Morning', now);
+    const b = parseSessionLabelDate('Day 10 (26 May)', now);
+    assert.equal(a.getUTCMonth(), 4);
+    assert.equal(a.getUTCDate(), 15);
+    assert.equal(b.getUTCDate(), 26);
+  });
+});
+
+describe('metric helpers', () => {
+  test('attendance percentage is minutes-weighted', () => {
+    assert.equal(attendancePercentage([
+      { attendedMinutes: 54, totalSessionMinutes: 60, attendancePercentage: 90 },
+      { attendedMinutes: 30, totalSessionMinutes: 60, attendancePercentage: 50 }
+    ], []), 70);
+  });
+
+  test('poll participation uses attempted/total', () => {
+    assert.equal(pollParticipationPercentage([
+      { attemptedQuestions: 8, totalQuestions: 10 },
+      { attemptedQuestions: 2, totalQuestions: 10 }
+    ]), 50);
+  });
+
+  test('poll quality is mean band / 10', () => {
+    assert.equal(pollQualityScore([
+      { appliedDelta: 10 },
+      { appliedDelta: 5 },
+      { appliedDelta: 0 }
+    ]), 50);
+  });
+
+  test('query count ignores non-positive deltas', () => {
+    assert.equal(queryActivityCount([
+      { appliedDelta: 5 },
+      { appliedDelta: 5 },
+      { appliedDelta: -10 }
+    ]), 2);
+  });
+});
+
+describe('risk score and level', () => {
+  test('perfect window is Low', () => {
+    const score = overallRiskScore({
+      attendancePct: 100, pollParticipationPct: 100, pollQuality: 100, queryCount: 3
+    });
+    assert.equal(score, 0);
+    assert.equal(riskLevelFor(score), 'Low');
+  });
+
+  test('empty window is High', () => {
+    const score = overallRiskScore({
+      attendancePct: 0, pollParticipationPct: 0, pollQuality: 0, queryCount: 0
+    });
+    assert.equal(score, 100);
+    assert.equal(riskLevelFor(score), 'High');
+  });
+
+  test('mid engagement is Medium', () => {
+    const score = overallRiskScore({
+      attendancePct: 70, pollParticipationPct: 60, pollQuality: 50, queryCount: 1
+    });
+    assert.equal(riskLevelFor(score), 'Medium');
+  });
+});
+
+describe('computeRiskState', () => {
+  test('returns the Phase 1 fields from last-14-day data only', () => {
+    const state = computeRiskState({
+      student: { totalSp: 420, email: 'a@test.com' },
+      now,
+      attendance: [
+        daysAgo(3, { sessionLabel: '1 Sep Evening', attendedMinutes: 20, totalSessionMinutes: 60, attendancePercentage: 33 }),
+        daysAgo(40, { sessionLabel: 'old', attendedMinutes: 60, totalSessionMinutes: 60, attendancePercentage: 100 })
+      ],
+      polls: [
+        daysAgo(3, { sessionLabel: '1 Sep Evening', attemptedQuestions: 2, totalQuestions: 10 })
+      ],
+      transactions: [
+        daysAgo(3, { category: 'attendance', sessionLabel: '1 Sep Evening', appliedDelta: 0 }),
+        daysAgo(3, { category: 'poll', sessionLabel: '1 Sep Evening', appliedDelta: 3 }),
+        daysAgo(2, { category: 'query', sessionLabel: '', appliedDelta: 5 }),
+        daysAgo(40, { category: 'poll', sessionLabel: 'old', appliedDelta: 10 })
+      ],
+      sessions: []
+    });
+
+    assert.equal(state.windowDays, WINDOW_DAYS);
+    assert.equal(state.attendancePercentage, 33);
+    assert.equal(state.pollParticipationPercentage, 20);
+    assert.equal(state.pollQualityScore, 30);
+    assert.equal(state.queryActivityCount, 1);
+    assert.ok(state.riskScore >= 0 && state.riskScore <= 100);
+    assert.equal(['Low', 'Medium', 'High'].includes(state.riskLevel), true);
+    assert.ok(Array.isArray(state.reasons) && state.reasons.length > 0);
+    assert.ok(Array.isArray(state.recoverySuggestions) && state.recoverySuggestions.length > 0);
+    for (const s of state.recoverySuggestions) {
+      assert.equal(typeof s.action, 'string');
+      assert.equal(typeof s.estimatedSp, 'number');
+      assert.equal(['high', 'medium', 'low'].includes(s.priority), true);
+    }
+    const b = state.breakdown;
+    assert.ok(b.attendance && b.pollParticipation && b.pollQuality && b.queryActivity);
+    const pointsSum = b.attendance.points + b.pollParticipation.points + b.pollQuality.points + b.queryActivity.points;
+    assert.equal(Math.round(pointsSum), state.riskScore);
+    assert.equal(state.daysAnalyzed, WINDOW_DAYS);
+    assert.equal(state.sessionsConsidered, 1);
+    assert.equal(state.pollsConsidered, 1);
+    assert.equal(state.queriesConsidered, 1);
+    assert.ok(state.projectedSpGain >= 0);
+    assert.equal(state.trophyLeague, leagueBand(420));
+    assert.equal(state.projectedLeague, leagueBand(420 + state.projectedSpGain));
+    assert.equal(state.metrics.pollSp, 3);
+  });
+
+  test('does not treat old-window activity as current', () => {
+    const state = computeRiskState({
+      student: { totalSp: 100 },
+      now,
+      attendance: [daysAgo(20, { sessionLabel: 'old', attendedMinutes: 60, totalSessionMinutes: 60, attendancePercentage: 100 })],
+      polls: [daysAgo(20, { sessionLabel: 'old', attemptedQuestions: 10, totalQuestions: 10 })],
+      transactions: [daysAgo(20, { category: 'query', appliedDelta: 5 })],
+      sessions: []
+    });
+    assert.equal(state.attendancePercentage, 0);
+    assert.equal(state.pollParticipationPercentage, 0);
+    assert.equal(state.queryActivityCount, 0);
+    assert.equal(state.riskLevel, 'High');
+    assert.equal(state.sessionsConsidered, 0);
+    assert.equal(state.pollsConsidered, 0);
+    assert.equal(state.queriesConsidered, 0);
+    assert.equal(state.daysAnalyzed, WINDOW_DAYS);
+  });
+});
+
+describe('projectedSpGain', () => {
+  test('is the shortfall vs top band plus missing query pace, capped', () => {
+    assert.equal(projectedSpGain({
+      attendanceSessions: 2, pollSessions: 2, attendanceSp: 10, pollSp: 10, queryCount: 1
+    }), 20 + 10);
+  });
+});


### PR DESCRIPTION
Adds the 14-day derived risk read (never writes SP), its /api/risk/state route, and the student-facing panel below LevelStatus. An empty window renders a neutral 'Not enough data yet' state instead of High risk.