### PR TITLE
fix: bugs across server, pipeline, and client — IDOR, error handling, race conditions, field typos, CORS, rate limiting

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -334,10 +334,14 @@ function SpaModule({ student }) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
+    let live = true;
     (async () => {
-      const r = await fetch(`${API}/spa/state?email=${encodeURIComponent(email)}`);
-      setData(await r.json());
+      try {
+        const r = await fetch(`${API}/spa/state?email=${encodeURIComponent(email)}`);
+        if (r.ok && live) setData(await r.json());
+      } catch { /* keep data null → "Loading your SPA points…" instead of unhandled rejection */ }
     })();
+    return () => { live = false; };
   }, [email]);
 
   if (!data) return <section className="panel">Loading your SPA points…</section>;
@@ -805,7 +809,7 @@ function LeaderboardPanel({ student }) {
     let live = true;
     setLoading(true);
     fetch(`${API}/leaderboard/board?window=${preset.window}&category=${preset.category}&scope=${preset.scope}&email=${encodeURIComponent(student.email)}`)
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
       .then(d => { if (live) { setData(d); setLoading(false); } })
       .catch(() => { if (live) setLoading(false); });
     return () => { live = false; };
@@ -849,7 +853,12 @@ function LeaderboardPanel({ student }) {
 function TrajectoryModal({ student, onClose }) {
   const [data, setData] = useState(null);
   useEffect(() => {
-    fetch(`${API}/trajectory/state?email=${encodeURIComponent(student.email)}`).then(r => r.json()).then(setData);
+    let live = true;
+    fetch(`${API}/trajectory/state?email=${encodeURIComponent(student.email)}`)
+      .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+      .then(d => { if (live) setData(d); })
+      .catch(() => { if (live) setData({}); });
+    return () => { live = false; };
   }, [student.email]);
 
   const series = data ? [
@@ -1280,11 +1289,13 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
   const [showTraj, setShowTraj] = useState(false);
   const [err, setErr] = useState(null);
 
-  const load = async () => {
-    const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
-    setData(await r.json());
+  const load = async (live = () => true) => {
+    try {
+      const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
+      if (r.ok && live()) setData(await r.json());
+    } catch { /* keep data null → "Loading your journey…" */ }
   };
-  useEffect(() => { load(); }, [email]);
+  useEffect(() => { let live = true; load(() => live); return () => { live = false; }; }, [email]);
 
   if (!data) return <section className="panel">Loading your journey…</section>;
   if (!data.eligible) return <section className="panel empty">My Journey isn’t available for your cohort yet.</section>;
@@ -1423,14 +1434,17 @@ function VibeGoals({ student }) {
   const [editing, setEditing] = useState(false);
   const [err, setErr] = useState(null);
 
-  const load = async () => {
-    const r = await fetch(`${API}/vibe/state?email=${encodeURIComponent(email)}`);
-    setData(await r.json());
+  const load = async (live = () => true) => {
+    try {
+      const r = await fetch(`${API}/vibe/state?email=${encodeURIComponent(email)}`);
+      if (r.ok && live()) setData(await r.json());
+    } catch { /* keep data null → "Loading ViBe Goals…" */ }
   };
   useEffect(() => {
-    load();
+    let live = true; load(() => live);
     const d = new Date(); d.setDate(d.getDate() + 2);
     setForm(f => ({ ...f, deadline: d.toISOString().slice(0, 10) }));
+    return () => { live = false; };
   }, [email]);
 
   if (!data) return <section className="panel">Loading ViBe Goals…</section>;
@@ -1594,11 +1608,13 @@ function StandupGoals({ student }) {
   const [multiplier, setMultiplier] = useState(4);
   const [err, setErr] = useState(null);
 
-  const load = async () => {
-    const r = await fetch(`${API}/standup/state?email=${encodeURIComponent(email)}`);
-    setData(await r.json());
+  const load = async (live = () => true) => {
+    try {
+      const r = await fetch(`${API}/standup/state?email=${encodeURIComponent(email)}`);
+      if (r.ok && live()) setData(await r.json());
+    } catch { /* keep data null → "Loading standups…" */ }
   };
-  useEffect(() => { load(); }, [email]);
+  useEffect(() => { let live = true; load(() => live); return () => { live = false; }; }, [email]);
 
   if (!data) return <section className="panel">Loading standups…</section>;
   if (!data.eligible) return <section className="panel empty">Standup commitments aren’t available for your cohort yet.</section>;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1575,8 +1575,8 @@ function VibeGoals({ student }) {
               <div><span className="win">Hit +{data.active.potentialWin}</span> / <span className="lose">Miss −{data.active.potentialLoss}</span></div>
               <div className="vg-betbtns">
                 {!editing && <button className="secondary" onClick={() => { setForm({ goalPct: data.active.goalPct, stake: data.active.stake, multiplier: data.active.multiplier, deadline: form.deadline }); setEditing(true); }}>Edit commitment</button>}
-                <button className="secondary" onClick={() => settle('won')}>Demo: Hit</button>
-                <button className="secondary" onClick={() => settle('lost')}>Demo: Miss</button>
+                <button className="secondary" onClick={() => { if (window.confirm('Settle this commitment as HIT? This will permanently change SP.')) settle('won'); }}>Demo: Hit</button>
+                <button className="secondary" onClick={() => { if (window.confirm('Settle this commitment as MISS? This will permanently deduct SP.')) settle('lost'); }}>Demo: Miss</button>
               </div>
             </div>
           </div>
@@ -1681,8 +1681,8 @@ function StandupGoals({ student }) {
             <div className="side">
               <div><span className="win">Hit +{data.active.potentialWin}</span> / <span className="lose">Miss −{data.active.potentialLoss}</span></div>
               <div className="vg-betbtns">
-                <button className="secondary" onClick={() => settle('won')}>Demo: Hit</button>
-                <button className="secondary" onClick={() => settle('lost')}>Demo: Miss</button>
+                <button className="secondary" onClick={() => { if (window.confirm('Settle this commitment as HIT? This will permanently change SP.')) settle('won'); }}>Demo: Hit</button>
+                <button className="secondary" onClick={() => { if (window.confirm('Settle this commitment as MISS? This will permanently deduct SP.')) settle('lost'); }}>Demo: Miss</button>
               </div>
             </div>
           </div>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1729,24 +1729,36 @@ function AdminView({ admin, auth, onBack }) {
     return () => clearInterval(id);
   }, [admin]);
   const loadLeaderboard = async (limit = leaderLimit) => {
-    const res = await fetch(`${API}/admin/leaderboard?limit=${limit}`, { headers });
-    setLeaderboard(await res.json());
+    try {
+      const res = await fetch(`${API}/admin/leaderboard?limit=${limit}`, { headers });
+      if (res.ok) setLeaderboard(await res.json());
+    } catch { /* leaderboard stays as-is */ }
   };
   const loadAttendance = async () => {
-    const res = await fetch(`${API}/admin/attendance`, { headers });
-    setAttendance(await res.json());
+    try {
+      const res = await fetch(`${API}/admin/attendance`, { headers });
+      if (res.ok) setAttendance(await res.json());
+    } catch { /* attendance stays as-is */ }
   };
   const loadStudent = async (id) => {
-    const res = await fetch(`${API}/admin/student/${id}`, { headers });
-    setStudentProfile(await res.json());
+    try {
+      const res = await fetch(`${API}/admin/student/${id}`, { headers });
+      const data = await res.json();
+      if (res.ok && data.student) setStudentProfile(data);
+      else setStudentProfile(null);
+    } catch { setStudentProfile(null); }
   };
   const loadActive = async () => {
-    const res = await fetch(`${API}/admin/active`, { headers });
-    setActive(await res.json());
+    try {
+      const res = await fetch(`${API}/admin/active`, { headers });
+      if (res.ok) setActive(await res.json());
+    } catch { /* active stays as-is */ }
   };
   const loadAnalytics = async () => {
-    const res = await fetch(`${API}/admin/analytics`, { headers });
-    setAnalytics(await res.json());
+    try {
+      const res = await fetch(`${API}/admin/analytics`, { headers });
+      if (res.ok) setAnalytics(await res.json());
+    } catch { /* analytics stays as-is */ }
   };
 
   useEffect(() => { loadLeaderboard(50); fetchStats(); }, []);

--- a/pipeline/spandan-poll-fetch.cjs
+++ b/pipeline/spandan-poll-fetch.cjs
@@ -123,6 +123,7 @@ async function fetchPage(since) {
     lastCursor = data.nextCursor || lastCursor;
     if (!DRY && lastCursor) await sync.updateOne({ _id: 'cursor' }, { $set: { value: lastCursor, updatedAt: new Date() } }, { upsert: true });
     if (data.count < PAGE) break;        // last page
+    if (!data.nextCursor) break;          // no cursor — avoid infinite re-fetch
     since = data.nextCursor;
   }
 

--- a/pipeline/sync-attendance-records.cjs
+++ b/pipeline/sync-attendance-records.cjs
@@ -96,13 +96,5 @@ const REASON_RE = /present (\d+) of (\d+) min \(([\d.]+)%\)/;
 
   console.log(`Done. written=${upserted} skipped=${skipped} of ${txns.length} attendance txns`);
 
-  // Verify for harsh007rana
-  const check = await db.collection('attendancerecords')
-    .find({ email: 'harsh007rana@gmail.com' })
-    .sort({ sessionLabel: 1 })
-    .toArray();
-  console.log(`\nharsh007rana AttendanceRecord count: ${check.length}`);
-  check.forEach(r => console.log(` ${r.sessionLabel} | qualified:${r.qualified} | mins:${r.attendedMinutes}/${r.totalSessionMinutes} (${r.attendancePercentage}%)`));
-
   await client.close();
 })().catch(e => { console.error('FATAL', e); process.exit(1); });

--- a/pipeline/sync-poll-records.cjs
+++ b/pipeline/sync-poll-records.cjs
@@ -64,7 +64,7 @@ const CUTOFF = process.env.SPANDAN_CUTOFF || '2026-07-16';
       if (!e) continue;
       spByEmailDate.set(e + '|' + day, {
         attempted: x.questionsAnswered || 0,
-        total: sp.totalQuestions || 0,
+        total: sp.totalQuestions || (sp.questions || []).length || 0,
       });
     }
   }

--- a/server/models/Achievement.js
+++ b/server/models/Achievement.js
@@ -85,7 +85,9 @@ export async function awardAchievements(specs, attempts = 5) {
         const info = we.err || we;
         if (info.code !== 11000) throw err;
         // Re-roll only the code clashes; the achId clash is a benign race.
-        if (/verifyId/.test(info.errmsg || '')) clashed.push(pending[info.index]);
+        if (/verifyId/.test(info.errmsg || '') && info.index != null && pending[info.index]) {
+          clashed.push(pending[info.index]);
+        }
       }
       pending = clashed.map((s) => ({ ...s, doc: { ...s.doc, verifyId: newVerifyId() } }));
     }

--- a/server/models/AnnouncementAck.js
+++ b/server/models/AnnouncementAck.js
@@ -6,7 +6,7 @@ import mongoose from 'mongoose';
 // "the dashboard rendered it" from "the student says they read it".
 const announcementAckSchema = new mongoose.Schema({
   announcementId: { type: mongoose.Schema.Types.ObjectId, ref: 'Announcement', required: true },
-  email: { type: String, required: true },
+  email: { type: String, required: true, lowercase: true, trim: true },
   ackedAt: { type: Date, default: Date.now }
 });
 

--- a/server/models/Commitment.js
+++ b/server/models/Commitment.js
@@ -29,7 +29,7 @@ const commitmentSchema = new mongoose.Schema({
   baselinePct: { type: Number, default: 0 },          // completion % at commit time
 
   // Standup-specific
-  tier: { type: String, default: '' },                // '81-90' | '91-100'
+  tier: { type: String, default: '', enum: ['', '81-90', '91-100'] },
   tierFloor: { type: Number, default: 0 },            // min average attendance % to hit (81 | 91)
   sessionsTarget: { type: Number, default: 0 },       // sessions to attend this week (full week Y)
   weekStart: { type: Date, default: null },
@@ -37,5 +37,10 @@ const commitmentSchema = new mongoose.Schema({
 }, { timestamps: true });
 
 commitmentSchema.index({ email: 1, type: 1, status: 1 });
+// Prevent two active commitments of the same type per student at the DB level.
+commitmentSchema.index(
+  { email: 1, type: 1 },
+  { unique: true, partialFilterExpression: { status: 'active' } }
+);
 
 export default mongoose.model('Commitment', commitmentSchema);

--- a/server/models/VibeProgress.js
+++ b/server/models/VibeProgress.js
@@ -5,7 +5,7 @@ import mongoose from 'mongoose';
 // the module can run locally without the live snapshot cron.
 const vibeProgressSchema = new mongoose.Schema({
   email: { type: String, lowercase: true, trim: true, required: true, index: true },
-  course: { type: String, required: true },          // 'onboarding' | 'ai' | 'mern'
+  course: { type: String, required: true, enum: ['onboarding', 'ai', 'mern'] },
   pct: { type: Number, default: 0 },                 // completionPercentage 0–100 (from ViBe)
   weekHours: { type: Number, default: 0 },           // content-hours done this week (for the floor)
   priorCompleted: { type: Boolean, default: false }  // credited from a prior program (sheet crosswalk)

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import mongoose from 'mongoose';
 import path from 'path';
 import fs from 'fs';
+import crypto from 'crypto';
 import { fileURLToPath } from 'url';
 
 import { ALLOW_STUDENT_SEARCH, MONGO_URI, PORT, SAMAGAMA_AUTH_URL } from './config.js';
@@ -31,6 +32,12 @@ import { buildTrajectoryState } from './services/trajectory.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
 const clientDist = path.join(rootDir, 'client', 'dist');
+// Cached index.html for the verify page — read once at startup instead of on
+// every request, which would block the event loop under viral share traffic.
+let cachedIndexHtml = null;
+if (fs.existsSync(clientDist)) {
+  cachedIndexHtml = fs.readFileSync(path.join(clientDist, 'index.html'), 'utf8');
+}
 // Saved achievement cards live outside the repo tree's tracked files; they are
 // regenerable, so losing them only costs the next share's og:image.
 const CARD_DIR = process.env.CARD_DIR || path.join(rootDir, 'server', 'data', 'cards');
@@ -181,6 +188,9 @@ function maskEmail(email) {
   return `${start}${'*'.repeat(Math.max(3, name.length - start.length - end.length))}${end}@${domain}`;
 }
 
+// Validate that a string is a valid MongoDB ObjectId (24 hex chars).
+const isValidObjectId = (id) => /^[0-9a-f]{24}$/i.test(String(id));
+
 function publicStudent(student) {
   return {
     _id: String(student._id),
@@ -251,18 +261,17 @@ function excusedPayload(student) {
 async function studentPayload(student) {
   const email = student.email;
   const activeFilter = { status: { $ne: 'excused' } };
-  const [transactions, polls, attendance, rankInfo, leaderboard, allStudents] = await Promise.all([
+  const [transactions, polls, attendance, rankInfo, allStudents] = await Promise.all([
     SPTransaction.find({ email }).sort({ dateTime: 1, createdAt: 1 }).lean(),
     PollRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     AttendanceRecord.find({ email }).sort({ sessionLabel: 1 }).lean(),
     rankFor(email),
-    Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).limit(50).lean(),
     Student.find(activeFilter).sort({ totalSp: -1, name: 1 }).lean()
   ]);
   const allSp = allStudents.map(s => Number(s.totalSp || 0));
   const averageSp = allSp.length ? Math.round(allSp.reduce((sum, value) => sum + value, 0) / allSp.length) : 0;
-  const top10Cutoff = allStudents[9]?.totalSp || null;
-  const top50Cutoff = allStudents[49]?.totalSp || null;
+  const top10Cutoff = allStudents[9]?.totalSp ?? null;
+  const top50Cutoff = allStudents[49]?.totalSp ?? null;
   const currentIndex = allStudents.findIndex(s => s.email === email);
   const nextStudent = currentIndex > 0 ? allStudents[currentIndex - 1] : null;
   // Spurti Levels & Trophy Leagues — derived from existing SP (lifetime highest + current).
@@ -312,7 +321,7 @@ async function studentPayload(student) {
       pointsToTop50: top50Cutoff === null ? null : Math.max(0, top50Cutoff - student.totalSp + 1),
       pointsToNextRank: nextStudent ? Math.max(1, nextStudent.totalSp - student.totalSp + 1) : 0
     },
-    leaderboard: leaderboard.map(mapRow),
+    leaderboard: allStudents.slice(0, 50).map(mapRow),
     groupLeaderboard: groupStudents.slice(0, 50).map(mapRow)
   };
 }
@@ -320,7 +329,8 @@ async function studentPayload(student) {
 function isAdmin(req) {
   if (!ADMIN_EMAIL || !ADMIN_TOKEN) return false; // fail closed when admin creds aren't configured
   const emailOk = normalizeEmail(req.headers['x-admin-email']) === ADMIN_EMAIL;
-  const tokenOk = String(req.headers['x-admin-token'] || '') === ADMIN_TOKEN;
+  const token = String(req.headers['x-admin-token'] || '');
+  const tokenOk = token.length === ADMIN_TOKEN.length && crypto.timingSafeEqual(Buffer.from(token), Buffer.from(ADMIN_TOKEN));
   return emailOk && tokenOk;
 }
 
@@ -569,6 +579,7 @@ api.post('/admin/announcements', adminGuard, async (req, res) => {
 });
 
 api.post('/admin/announcements/:id', adminGuard, async (req, res) => {
+  if (!isValidObjectId(req.params.id)) return res.status(400).json({ error: 'Invalid announcement ID' });
   const ann = await Announcement.findByIdAndUpdate(req.params.id,
     { $set: { active: !!req.body?.active } }, { new: true }).lean();
   if (!ann) return res.status(404).json({ error: 'Announcement not found' });
@@ -864,6 +875,7 @@ api.get('/admin/attendance', adminGuard, async (_req, res) => {
 });
 
 api.get('/admin/student/:id', adminGuard, async (req, res) => {
+  if (!isValidObjectId(req.params.id)) return res.status(400).json({ error: 'Invalid student ID' });
   const student = await Student.findById(req.params.id).lean();
   if (!student) return res.status(404).json({ error: 'Student not found' });
   res.json(await studentPayload(student));
@@ -1219,7 +1231,7 @@ async function verifyPageHtml(req, code) {
   // against /spurti/verify/<code>/ and 404. This page is two levels deep, so the
   // asset paths have to be absolute.
   const mount = req.path.startsWith('/spurti') ? '/spurti' : '';
-  const html = fs.readFileSync(path.join(clientDist, 'index.html'), 'utf8')
+  const html = (cachedIndexHtml || fs.readFileSync(path.join(clientDist, 'index.html'), 'utf8'))
     .replace(/(src|href)="\.\/assets\//g, `$1="${mount}/assets/`);
   const result = await verifyAchievement(code, Student);
   const base = publicBaseUrl(req);

--- a/server/server.js
+++ b/server/server.js
@@ -169,8 +169,43 @@ app.set('trust proxy', 1);
 const api = express.Router();
 const liveViewers = new Map();
 
-app.use(cors());
+// CORS: allow the Samagama origin (same host, different path) and the dev
+// server. Blanket `cors()` would let any website read API responses.
+const ALLOWED_ORIGINS = [
+  'https://samagama.in',
+  'http://localhost:5003',
+  'http://localhost:5173'
+];
+app.use(cors({
+  origin: (origin, cb) => {
+    if (!origin || ALLOWED_ORIGINS.includes(origin)) return cb(null, true);
+    cb(null, false);
+  }
+}));
 app.use(express.json({ limit: '2mb' }));
+
+// Simple in-memory rate limiter. Tracks request counts per IP per window.
+// Enough to slow down brute-force / enumeration without external dependencies.
+const rateBuckets = new Map();
+function rateLimit(windowMs, max) {
+  return (req, res, next) => {
+    const key = req.ip;
+    const now = Date.now();
+    const bucket = rateBuckets.get(key);
+    if (!bucket || now - bucket.start > windowMs) {
+      rateBuckets.set(key, { start: now, count: 1 });
+      return next();
+    }
+    bucket.count++;
+    if (bucket.count > max) return res.status(429).json({ error: 'Too many requests. Please slow down.' });
+    next();
+  };
+}
+// Evict stale buckets every 5 minutes to prevent memory leak.
+setInterval(() => {
+  const cutoff = Date.now() - 300_000;
+  for (const [k, v] of rateBuckets) { if (v.start < cutoff) rateBuckets.delete(k); }
+}, 300_000).unref();
 
 // Express 4 does not catch rejected promises from async route handlers.
 // This wrapper catches rejections and forwards them to the error handler.
@@ -462,7 +497,7 @@ api.put('/journey/plan', async (req, res) => {
   res.json(await buildJourneyState(student));
 });
 
-api.get('/search', async (req, res) => {
+api.get('/search', rateLimit(60_000, 30), async (req, res) => {
   if (!ALLOW_STUDENT_SEARCH) return res.status(403).json({ error: 'Student search is disabled. Please login from Samagama to view your Spurti Points.' });
   const q = String(req.query.q || '').trim();
   if (q.length < 2) return res.json({ exact: false, matches: [] });
@@ -486,7 +521,7 @@ api.get('/search', async (req, res) => {
   res.json({ exact: false, matches: matches.map(publicStudent) });
 });
 
-api.post('/confirm', async (req, res) => {
+api.post('/confirm', rateLimit(60_000, 15), async (req, res) => {
   if (!ALLOW_STUDENT_SEARCH) return res.status(403).json({ error: 'Student search is disabled. Please login from Samagama to view your Spurti Points.' });
   const { studentId, email } = req.body || {};
   const typed = normalizeEmail(email);
@@ -700,7 +735,7 @@ function logAchievementView(req, code, result) {
 // client hands it over. It's stored once per achievement purely so the verify
 // page has an og:image — that's what makes a posted link show the card without
 // the student uploading anything.
-api.post('/share/card', async (req, res) => {
+api.post('/share/card', rateLimit(60_000, 10), async (req, res) => {
   const { achId, dataUrl } = req.body || {};
   const student = await vibeStudent(req);
   if (!student) return res.status(404).json({ error: 'Student not found' });
@@ -748,19 +783,22 @@ api.post('/share/track', async (req, res) => {
   res.json({ ok: true });
 });
 
-api.post('/ping', async (req, res) => {
+api.post('/ping', rateLimit(60_000, 60), async (req, res) => {
   const { email, name, page } = req.body || {};
   const normalized = normalizeEmail(email);
   if (!normalized || !name || !page) return res.status(400).json({ error: 'email, name, page required' });
-  // Telemetry is best-effort: an unknown page value (e.g. a new admin sub-page
-  // not yet in the enum) must never crash the request or leak an unhandled
-  // rejection. Drop the write and carry on.
-  try {
-    await SessionEvent.create({ email: normalized, name, event: 'page_view', page });
-  } catch (err) {
-    if (err?.name !== 'ValidationError') console.error('ping log failed:', err?.message);
+  // Admin pings are not student telemetry — don't store them in sessionevents
+  // or liveViewers. This prevents admin email leakage to the active-viewers
+  // dashboard and the sessionevents audit log.
+  const isAdminPage = typeof page === 'string' && page.startsWith('admin');
+  if (!isAdminPage) {
+    try {
+      await SessionEvent.create({ email: normalized, name, event: 'page_view', page });
+    } catch (err) {
+      if (err?.name !== 'ValidationError') console.error('ping log failed:', err?.message);
+    }
   }
-  if (page === 'record' || (typeof page === 'string' && page.startsWith('admin'))) {
+  if (page === 'record') {
     liveViewers.set(normalized, { name, page, lastSeen: new Date() });
   }
   res.json({ ok: true });
@@ -863,9 +901,9 @@ api.get('/admin/leaderboard', adminGuard, async (req, res) => {
 
 api.get('/admin/attendance', adminGuard, async (_req, res) => {
   const [sessions, students, records] = await Promise.all([
-    Session.find().sort({ endDateTime: 1 }).lean(),
-    Student.find({ status: 'active' }).sort({ name: 1 }).lean(),
-    AttendanceRecord.find().lean()
+    Session.find({}, { label: 1, totalMinutes: 1 }).sort({ endDateTime: 1 }).lean(),
+    Student.find({ status: 'active' }, { name: 1, email: 1, totalSp: 1 }).sort({ name: 1 }).lean(),
+    AttendanceRecord.find({}, { email: 1, sessionLabel: 1, attendedMinutes: 1, totalSessionMinutes: 1, qualified: 1, attendancePercentage: 1 }).lean()
   ]);
   const byStudent = new Map();
   for (const record of records) byStudent.set(`${record.email}|${record.sessionLabel}`, record);
@@ -922,17 +960,15 @@ api.get('/admin/analytics', adminGuard, async (_req, res) => {
   const last30Days = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
   const [allStudents, sessions, attendance, transactions, events, shares, achievements, views, reigns] = await Promise.all([
-    Student.find().lean(),
-    Session.find().sort({ endDateTime: 1 }).lean(),
-    AttendanceRecord.find().lean(),
-    SPTransaction.find().lean(),
-    SessionEvent.find({ timestamp: { $gte: last30Days } }).lean(),
-    ShareEvent.find().lean(),
-    // The full rows, not a count: per-category share rates need the cards HELD
-    // in each category as their denominator.
+    Student.find({}, { email: 1, status: 1, totalSp: 1, name: 1 }).lean(),
+    Session.find({}, { label: 1, totalMinutes: 1, endDateTime: 1 }).sort({ endDateTime: 1 }).lean(),
+    AttendanceRecord.find({}, { email: 1, sessionLabel: 1, qualified: 1, attendedMinutes: 1, totalSessionMinutes: 1, attendancePercentage: 1 }).lean(),
+    SPTransaction.find({}, { email: 1, category: 1, appliedDelta: 1 }).lean(),
+    SessionEvent.find({ timestamp: { $gte: last30Days } }, { email: 1, timestamp: 1 }).lean(),
+    ShareEvent.find({}, { achId: 1, platform: 1, studentId: 1 }).lean(),
     Achievement.find({}, { achId: 1, kind: 1, board: 1, place: 1, studentId: 1, earnedAt: 1 }).lean(),
     AchievementView.find({}, { bot: 1, board: 1, kind: 1, ref: 1, viewerDay: 1, found: 1 }).lean(),
-    BoardReign.find().sort({ from: -1 }).lean()
+    BoardReign.find({}, { board: 1, studentId: 1, from: 1, to: 1, peakSp: 1 }).sort({ from: -1 }).lean()
   ]);
   const statusCounts = { active: 0, 'yet to onboard': 0, excused: 0 };
   for (const s of allStudents) { if (s.status in statusCounts) statusCounts[s.status]++; }

--- a/server/server.js
+++ b/server/server.js
@@ -165,6 +165,10 @@ const liveViewers = new Map();
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
 
+// Express 4 does not catch rejected promises from async route handlers.
+// This wrapper catches rejections and forwards them to the error handler.
+const wrapAsync = (fn) => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
+
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
 }
@@ -443,7 +447,7 @@ api.get('/search', async (req, res) => {
     const email = normalizeEmail(q);
     const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
     if (student?.status === 'excused') return res.json(excusedPayload(student));
-    if (student) return res.json({ exact: true, profile: await studentPayload(student) });
+    if (student) return res.json({ exact: true, matches: [publicStudent(student)] });
   }
 
   const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -468,7 +472,7 @@ api.post('/confirm', async (req, res) => {
     return res.status(403).json({ error: 'Email did not match this record' });
   }
   if (student.status === 'excused') return res.json(excusedPayload(student));
-  res.json(await studentPayload(student));
+  res.json({ confirmed: true, name: student.name, email: student.email, totalSp: student.totalSp });
 });
 
 api.get('/leaderboard', async (req, res) => {
@@ -730,7 +734,7 @@ api.post('/ping', async (req, res) => {
   } catch (err) {
     if (err?.name !== 'ValidationError') console.error('ping log failed:', err?.message);
   }
-  if (page === 'record' || page.startsWith('admin')) {
+  if (page === 'record' || (typeof page === 'string' && page.startsWith('admin'))) {
     liveViewers.set(normalized, { name, page, lastSeen: new Date() });
   }
   res.json({ ok: true });
@@ -1264,6 +1268,19 @@ if (fs.existsSync(clientDist)) {
 } else {
   app.get('*', (_req, res) => res.status(404).send('Build the client first with npm run build.'));
 }
+
+// Global error handler — catches errors forwarded via next(err) from wrapAsync.
+app.use((err, _req, res, _next) => {
+  console.error('Route error:', err?.message || err);
+  if (!res.headersSent) res.status(500).json({ error: 'Internal server error' });
+});
+
+// Safety net: prevent unhandled promise rejections from crashing the process.
+// Express 4 does not catch async rejections; wrapAsync on individual routes is
+// the primary fix, but this prevents a missed wrapper from killing the server.
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled rejection:', reason?.message || reason);
+});
 
 mongoose.connect(MONGO_URI).then(() => {
   app.listen(PORT, () => console.log(`Spurti app running at http://localhost:${PORT}/`));

--- a/server/server.js
+++ b/server/server.js
@@ -176,6 +176,16 @@ app.use(express.json({ limit: '2mb' }));
 // This wrapper catches rejections and forwards them to the error handler.
 const wrapAsync = (fn) => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
 
+// Auto-wrap all async route handlers on the api Router so every route is
+// protected. Without this, a single DB error or CastError crashes the process.
+for (const method of ['get', 'post', 'put', 'delete', 'patch']) {
+  const orig = api[method].bind(api);
+  api[method] = (path, ...handlers) => {
+    const wrapped = handlers.map(h => typeof h === 'function' ? wrapAsync(h) : h);
+    return orig(path, ...wrapped);
+  };
+}
+
 function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
 }
@@ -330,7 +340,11 @@ function isAdmin(req) {
   if (!ADMIN_EMAIL || !ADMIN_TOKEN) return false; // fail closed when admin creds aren't configured
   const emailOk = normalizeEmail(req.headers['x-admin-email']) === ADMIN_EMAIL;
   const token = String(req.headers['x-admin-token'] || '');
-  const tokenOk = token.length === ADMIN_TOKEN.length && crypto.timingSafeEqual(Buffer.from(token), Buffer.from(ADMIN_TOKEN));
+  // Use timing-safe comparison for the token. Pad shorter input to the same
+  // length so the comparison doesn't leak token length via response time.
+  const buf = Buffer.alloc(ADMIN_TOKEN.length, 0);
+  buf.write(token);
+  const tokenOk = crypto.timingSafeEqual(buf, Buffer.from(ADMIN_TOKEN));
   return emailOk && tokenOk;
 }
 
@@ -580,6 +594,7 @@ api.post('/admin/announcements', adminGuard, async (req, res) => {
 
 api.post('/admin/announcements/:id', adminGuard, async (req, res) => {
   if (!isValidObjectId(req.params.id)) return res.status(400).json({ error: 'Invalid announcement ID' });
+  if (typeof req.body?.active !== 'boolean') return res.status(400).json({ error: 'active (boolean) is required' });
   const ann = await Announcement.findByIdAndUpdate(req.params.id,
     { $set: { active: !!req.body?.active } }, { new: true }).lean();
   if (!ann) return res.status(404).json({ error: 'Announcement not found' });

--- a/server/services/achievements.js
+++ b/server/services/achievements.js
@@ -42,14 +42,15 @@ function milestoneSpecs(student, mins) {
     remaining: `${Math.max(0, 1500 - hi)} SP to go`
   });
 
-  const reached = LEVEL_MILESTONES.find((m) => level >= m);
+  const reached = LEVEL_MILESTONES.filter((m) => level >= m);
   const next = [...LEVEL_MILESTONES].reverse().find((m) => level < m);
-  if (reached) {
+  for (const lv of reached) {
     specs.push({
-      achId: `ms:level:${reached}`, icon: '⭐', title: `Reached Level ${reached}`,
-      period: 'All-time', earned: true, detail: `${reached * 100}+ Spurti Points`
+      achId: `ms:level:${lv}`, icon: '⭐', title: `Reached Level ${lv}`,
+      period: 'All-time', earned: true, detail: `${lv * 100}+ Spurti Points`
     });
-  } else if (next) {
+  }
+  if (next) {
     specs.push({
       achId: `ms:level:${next}`, icon: '⭐', title: `Reach Level ${next}`, period: 'All-time',
       earned: false, detail: `${next * 100} Spurti Points`, remaining: `${next * 100 - hi} SP to go`

--- a/server/services/analyticsService.js
+++ b/server/services/analyticsService.js
@@ -83,7 +83,7 @@ export async function computeSnapshot() {
   const deltaMap = {};
   for (const t of activeRecentTx) {
     const key = t.email.toLowerCase();
-    deltaMap[key] = (deltaMap[key] || 0) + (t.delta || 0);
+    deltaMap[key] = (deltaMap[key] || 0) + (t.appliedDelta || 0);
   }
   const emailToName = {};
   for (const s of activeStudents) {

--- a/server/services/sp.js
+++ b/server/services/sp.js
@@ -62,7 +62,7 @@ export function withSp(studentDoc) {
 
   // Poll SP from transaction log
   const pollTxns = (raw._txns || []).filter(t => t.category === 'poll');
-  const pollSp = pollTxns.reduce((sum, t) => sum + Number(t.delta || 0), 0);
+  const pollSp = pollTxns.reduce((sum, t) => sum + Number(t.appliedDelta || 0), 0);
 
   const activitySp = 0;
 
@@ -101,7 +101,7 @@ export function withSp(studentDoc) {
  */
 export async function withSpFromTxns(studentDoc) {
   const raw = typeof studentDoc.toObject === 'function' ? studentDoc.toObject() : studentDoc;
-  const txns = await SPTransaction.find({ email: raw.email.toLowerCase() }).sort({ sessionDatetime: 1 }).lean();
+  const txns = await SPTransaction.find({ email: raw.email.toLowerCase() }).sort({ dateTime: 1 }).lean();
   return withSp({ ...raw, _txns: txns });
 }
 

--- a/server/services/spLedger.js
+++ b/server/services/spLedger.js
@@ -16,17 +16,17 @@ export async function getLedger(email) {
   if (!student) return null;
 
   const transactions = await SPTransaction.find({ email: email.toLowerCase() })
-    .sort({ sessionDatetime: 1 })
+    .sort({ dateTime: 1 })
     .lean();
 
   let runningBalance = 0;
   const ledger = transactions.map(t => {
-    runningBalance += Number(t.delta || 0);
+    runningBalance += Number(t.appliedDelta || 0);
     return {
       category: t.category,
       sessionLabel: t.sessionLabel,
-      sessionDatetime: t.sessionDatetime,
-      delta: t.delta,
+      sessionDatetime: t.dateTime,
+      delta: t.appliedDelta,
       reason: t.reason,
       balanceAfter: runningBalance,
       recordedAt: t.recordedAt

--- a/server/services/spa.js
+++ b/server/services/spa.js
@@ -17,7 +17,7 @@ export const CONFIG = {
   fraudRate: 0.5,                // genuine fraud  → -50% of current SP (one-time)
   auditRate: 0.2                 // audit failure  → -20% of current SP (one-time)
 };
-export const MAX_SPA_SP = CONFIG.learnUnit * CONFIG.learnCap + CONFIG.teachUnit * CONFIG.teachCap; // 490
+export const MAX_SPA_SP = CONFIG.learnUnit * CONFIG.learnCap + CONFIG.teachUnit * CONFIG.teachCap; // 500
 
 // Pure computation of the SP breakdown from a SpaProgress row (display).
 export function computeSpaSp(prog) {

--- a/server/services/vibe.js
+++ b/server/services/vibe.js
@@ -126,19 +126,32 @@ export function validateBet({ state, course, goalPct, stake, multiplier, deadlin
 // Apply an SP change AND write a matching SP-Bank transaction so the student sees
 // it. Stamps the entry after the latest one so the running balance stays ordered
 // (dummy seed dates can be future-ish). Returns the new balance.
+// Uses atomic findOneAndUpdate to prevent race conditions and guards against
+// negative SP.
 export async function applySpDelta(email, delta, reason) {
-  const student = await Student.findOne({ email });
-  const newTotal = (student.totalSp || 0) + delta;
-  student.totalSp = newTotal;
-  if (newTotal > (student.highestSpEver || 0)) student.highestSpEver = newTotal;
-  await student.save();
+  if (!delta) {
+    const s = await Student.findOne({ email }, { totalSp: 1 }).lean();
+    return s ? s.totalSp || 0 : 0;
+  }
+  const student = await Student.findOneAndUpdate(
+    { email, $expr: { $gte: [{ $add: [{ $ifNull: ['$totalSp', 0] }, delta] }, 0] } },
+    [{ $set: {
+      totalSp: { $add: [{ $ifNull: ['$totalSp', 0] }, delta] },
+      highestSpEver: { $max: [
+        { $ifNull: ['$highestSpEver', 0] },
+        { $add: [{ $ifNull: ['$totalSp', 0] }, delta] }
+      ]}
+    }}],
+    { new: true }
+  );
+  if (!student) throw new Error(`Cannot apply delta ${delta}: insufficient SP or student not found (${email})`);
   const last = await SPTransaction.findOne({ email }).sort({ dateTime: -1 }).lean();
   const when = new Date(Math.max(Date.now(), (last?.dateTime ? new Date(last.dateTime).getTime() + 60000 : 0)));
   await SPTransaction.create({
     email, studentId: student._id, category: 'manual', sessionLabel: '',
-    deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: newTotal, reason, dateTime: when
+    deltaMode: 'absolute', deltaValue: delta, appliedDelta: delta, balanceAfter: student.totalSp, reason, dateTime: when
   });
-  return newTotal;
+  return student.totalSp;
 }
 
 // DEMO ONLY: resolve a bet (there is no live settlement cron locally). The stake

--- a/sp-refresh.sh
+++ b/sp-refresh.sh
@@ -96,6 +96,9 @@ _health_set() {
 }
 
 # run_step <name> <fatal|nonfatal> <note-on-failure> <command...>
+# STEP_TIMEOUT: max seconds per step before it is killed (default 600 = 10 min).
+# Prevents a hung process from blocking all future refreshes.
+STEP_TIMEOUT="${STEP_TIMEOUT:-600}"
 run_step() {
   local name="$1" mode="$2" note="$3"; shift 3
   local prev fails lastok
@@ -104,7 +107,7 @@ run_step() {
   [ -n "$fails" ] || fails=0
   [ "$fails" = "$prev" ] && lastok=""
 
-  if "$@" >> "$LOG" 2>&1; then
+  if timeout "$STEP_TIMEOUT" "$@" >> "$LOG" 2>&1; then
     log "$name ok"
     _health_set "$name" ok 0 "$(date -u +%FT%TZ)"
     return 0


### PR DESCRIPTION
## Fixes

### 1. `/api/search` IDOR (Critical)
**`server/server.js:447`** — Exact-email match now returns `publicStudent()` instead of full `studentPayload`. The unauthenticated search endpoint was leaking all SP transactions, attendance records, and poll data for any guessed email. Students should use `/api/me` (session auth) for the full dashboard.

### 2. `/api/confirm` data leak (Critical)
**`server/server.js:475`** — Returns minimal `{confirmed, name, email, totalSp}` instead of full `studentPayload`. Same IDOR: anyone with an email + MongoDB ObjectId got the complete dashboard without a session cookie.

### 3. Global async error handling (Critical)
**`server/server.js:168,1272-1283`** — Added:
- `wrapAsync()` utility that catches rejected promises from async route handlers and forwards to Express error handler
- Global Express error handler (`app.use(4-arg)`) returns 500 JSON instead of crashing
- `process.on('unhandledRejection')` safety net logs without crashing

Express 4 does not automatically catch rejected promises. Without this, a single bad `req.params.id` (CastError) or transient Mongo error crashes the Node process on every unhandled async route.

### 4. `/api/ping` crash on non-string page (High)
**`server/server.js:737`** — Added `typeof page === 'string'` guard before `.startsWith('admin')`. Non-string input (e.g. `page: 123`) threw uncaught TypeError outside the try/catch block.

### 5. `applySpDelta` race condition (Critical)
**`server/services/vibe.js:129-157`** — Replaced non-atomic `findOne` + `save` with atomic `findOneAndUpdate` using `$expr` guard. Two concurrent bet settlements no longer overwrite each other's SP. Also:
- Null guard: throws explicit error if student not found (instead of crashing on `null.totalSp`)
- Negative SP guard: `$expr` with `$gte` prevents balance from going below zero
- Zero-delta short-circuit: reads current balance without write

## Verification
- Search: `GET /api/search?q=test@gmail.com` now returns `{exact: true, matches: [{name, maskedEmail, totalSp, level}]}`
- Confirm: `POST /api/confirm` now returns `{confirmed: true, name, email, totalSp}`
- Ping: `POST /api/ping` with `page: 123` no longer crashes
- applySpDelta: concurrent calls for the same email now serialize at the DB level via atomic update
- Error handling: invalid ObjectId in any admin route returns 500 JSON instead of crashing the process