### PR TITLE
E2 goal-card experiment: login card (arms B/C) + telemetry + arm-C +10 SP

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -76,9 +76,17 @@ function AppShell() {
     return <main className="page login-page"><section className="panel auth-card"><p className="eyebrow">Spurti</p><h1>Loading</h1></section></main>;
   }
   if (view === 'student' && profile) {
+    // The E2 goal card must never stack on top of a mandatory survey pop-up —
+    // same gate conditions the three SurveyModals use below.
+    const surveyBlocking = [
+      [config.survey, 'surveyCompleted'],
+      [config.poll2, 'poll2Completed'],
+      [config.poll3, 'poll3Completed']
+    ].some(([cfg, key]) => cfg?.enabled && cfg.formUrl && profile.student && !profile.student[key]);
     return (
       <>
         <StudentView profile={profile} onBack={config.allowStudentSearch ? () => setView('landing') : null} />
+        <GoalCardModal student={profile.student} surveyBlocking={surveyBlocking} />
         <SurveyModal
           survey={config.survey}
           student={profile.student}
@@ -2132,6 +2140,137 @@ function AllStudentsPanel({ stats, onStudent, auth }) {
   );
 }
 
+
+// ── E2 goal-card (experiment, pre-reg 2026-09-07) ────────────────────────────
+// Pop-up shown to arms B/C at login while the experiment window is open and the
+// student has no journey goal yet (all gated server-side via student.e2Card).
+// Asks for ONE date — the student's current active phase — settable in one tap,
+// skippable in one tap. Shown at most once per calendar day (localStorage),
+// permanently gone once any goal is set. Every impression/skip/set is logged
+// server-side; the log write never blocks the UI.
+const E2_PHASES = [
+  ['standup', 'standupBy', 'your Stand-ups'],
+  ['vibe', 'vibeBy', 'your ViBe courses'],
+  ['spa', 'spaBy', 'your SPA practice'],
+  ['project', 'projectBy', 'your Project']
+];
+
+function GoalCardModal({ student, surveyBlocking }) {
+  const e2 = student?.e2Card;
+  const [state, setState] = useState('idle'); // idle | open | done | closed
+  const [pick, setPick] = useState(null);
+  const [date, setDate] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+
+  const logEvent = (event, extra = {}) => {
+    fetch(`${API}/e2/card-event`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event, phase: pick?.phaseKey, ...extra })
+    }).catch(() => {});
+  };
+
+  useEffect(() => {
+    if (!e2 || surveyBlocking) return;
+    const todayKey = `e2CardShown:${new Date().toISOString().slice(0, 10)}`;
+    if (localStorage.getItem('e2CardDone') || localStorage.getItem(todayKey)) return;
+    let active = true;
+    (async () => {
+      try {
+        const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(student.email)}`);
+        const j = await r.json();
+        if (!active || !j?.eligible) return;
+        // First phase with no goal yet and still settable (not achieved/active).
+        const next = E2_PHASES
+          .map(([phaseKey, field, label]) => ({ phaseKey, field, label, goal: j.goals?.[phaseKey] }))
+          .find(p => p.goal && !j.plan?.[p.field] && p.goal.status !== 'achieved' && p.goal.status !== 'active');
+        if (!next) { localStorage.setItem('e2CardDone', '1'); return; }
+        setPick(next);
+        setState('open');
+        localStorage.setItem(todayKey, '1');
+        fetch(`${API}/e2/card-event`, {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ event: 'impression', phase: next.phaseKey })
+        }).catch(() => {});
+      } catch { /* any failure -> no card today */ }
+    })();
+    return () => { active = false; };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (state !== 'open' && state !== 'done') return null;
+
+  const save = async () => {
+    if (!pick || !date) return;
+    setBusy(true); setErr(null);
+    try {
+      const r = await fetch(`${API}/journey/plan`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: student.email, [pick.field]: date })
+      });
+      const j = await r.json();
+      if (!r.ok) { setErr(j.error || 'Could not save that date — please try another.'); setBusy(false); return; }
+      logEvent('set', { value: date });
+      localStorage.setItem('e2CardDone', '1');
+      setState('done');
+    } catch {
+      setErr('Network error — please try again.'); setBusy(false);
+    }
+  };
+
+  const skip = () => { logEvent('skip'); setState('closed'); };
+
+  return (
+    <div className="survey-overlay" role="dialog" aria-modal="true" aria-labelledby="e2-title">
+      <div className="survey-modal e2-card">
+        {state === 'done' ? (
+          <>
+            <div className="survey-head">
+              <h2 id="e2-title">Goal set 🎯</h2>
+              <p>
+                Your target date is saved{e2.sp > 0 ? ` and your +${e2.sp} SP will appear with the next points refresh` : ''}.
+                Track your pace any time in the <strong>My Journey</strong> tab.
+              </p>
+            </div>
+            <div className="survey-actions">
+              <button type="button" className="survey-primary" onClick={() => setState('closed')}>Done</button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="survey-head">
+              <h2 id="e2-title">Set your goal 🎯</h2>
+              <p>
+                Pick your own target date for {pick.label}. The pace bar in
+                <strong> My Journey</strong> will then show exactly what "on track"
+                means for you each week.
+              </p>
+              {e2.sp > 0 && (
+                <p className="e2-sp">Set it now and earn a one-time <strong>+{e2.sp} SP</strong>.</p>
+              )}
+            </div>
+            <div className="e2-row">
+              <input
+                type="date"
+                min={pick.goal.minDate || undefined}
+                max={pick.goal.maxDate || undefined}
+                value={date}
+                onChange={e => setDate(e.target.value)}
+              />
+              <button type="button" className="survey-primary" disabled={!date || busy} onClick={save}>
+                {busy ? 'Saving…' : 'Set my goal'}
+              </button>
+            </div>
+            {pick.goal.minDate && <span className="jr-goal-hint">Earliest realistic: {fmtDate(pick.goal.minDate)}</span>}
+            {err && <p className="survey-note">{err}</p>}
+            <div className="survey-actions">
+              <button type="button" className="survey-ghost" onClick={skip}>Skip for now</button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function SurveyModal({ survey, student, onDone, statusPath = '/survey/status', completedKey = 'surveyCompleted' }) {
   const [checking, setChecking] = useState(false);

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2201,6 +2201,12 @@ function GoalCardModal({ student, surveyBlocking }) {
 
   const save = async () => {
     if (!pick || !date) return;
+    // The picker's min already blocks earlier dates, but a typed date can slip
+    // past it on some browsers — enforce the realistic minimum here too.
+    if (pick.goal.minDate && date < pick.goal.minDate) {
+      setErr(`That date is earlier than realistically possible — the earliest is ${fmtDate(pick.goal.minDate)}.`);
+      return;
+    }
     setBusy(true); setErr(null);
     try {
       const r = await fetch(`${API}/journey/plan`, {
@@ -2248,6 +2254,16 @@ function GoalCardModal({ student, surveyBlocking }) {
                 <p className="e2-sp">Set it now and earn a one-time <strong>+{e2.sp} SP</strong>.</p>
               )}
             </div>
+            {pick.goal.progressPct != null && (
+              <div className="e2-progress">
+                <span className="jr-goal-meta">
+                  {pick.goal.unit === '%'
+                    ? `You're at ${pick.goal.progressPct}% — ${pick.goal.remainingPct}% to go.`
+                    : `You have ${pick.goal.current} of ${pick.goal.target} ${pick.goal.unit} — ${pick.goal.remaining} ${pick.goal.unit} to go.`}
+                </span>
+                <div className="jr-progress"><i style={{ width: `${pick.goal.progressPct}%` }} /></div>
+              </div>
+            )}
             <div className="e2-row">
               <input
                 type="date"
@@ -2260,7 +2276,12 @@ function GoalCardModal({ student, surveyBlocking }) {
                 {busy ? 'Saving…' : 'Set my goal'}
               </button>
             </div>
-            {pick.goal.minDate && <span className="jr-goal-hint">Earliest realistic: {fmtDate(pick.goal.minDate)}</span>}
+            {pick.goal.minDate && (
+              <span className="jr-goal-hint">
+                Earliest realistic finish: {fmtDate(pick.goal.minDate)} — earlier dates can't be picked.
+                {pick.goal.paceHint ? ` ${pick.goal.paceHint}` : ''}
+              </span>
+            )}
             {err && <p className="survey-note">{err}</p>}
             <div className="survey-actions">
               <button type="button" className="survey-ghost" onClick={skip}>Skip for now</button>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -865,3 +865,10 @@ tr.step-alert td { border-color: #f3c9c5; }
 .sp-deduct-head { margin: 12px 0 4px; font-weight: 600; }
 .sp-deduct { margin: 0 0 4px 18px; color: var(--muted); font-size: 13px; }
 .sp-deduct li { margin: 3px 0; }
+
+/* E2 goal card (experiment, pre-reg 2026-09-07) — reuses the survey modal shell */
+.survey-modal.e2-card { max-width: 440px; }
+.e2-card .e2-row { display: flex; gap: 10px; align-items: center; margin: 14px 0 6px; }
+.e2-card .e2-row input[type="date"] { flex: 1; min-width: 0; padding: 10px; border-radius: 8px; border: 1px solid rgba(127,127,127,.35); background: transparent; color: inherit; font: inherit; }
+.e2-card .e2-sp { font-weight: 600; }
+.e2-card .jr-goal-hint { display: block; margin-top: 4px; opacity: .75; font-size: .85em; }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -872,3 +872,5 @@ tr.step-alert td { border-color: #f3c9c5; }
 .e2-card .e2-row input[type="date"] { flex: 1; min-width: 0; padding: 10px; border-radius: 8px; border: 1px solid rgba(127,127,127,.35); background: transparent; color: inherit; font: inherit; }
 .e2-card .e2-sp { font-weight: 600; }
 .e2-card .jr-goal-hint { display: block; margin-top: 4px; opacity: .75; font-size: .85em; }
+.e2-card .e2-progress { margin: 12px 0 2px; display: block; }
+.e2-card .e2-progress .jr-goal-meta { display: block; margin-bottom: 6px; }

--- a/pipeline/assign-arms-e2.mjs
+++ b/pipeline/assign-arms-e2.mjs
@@ -1,0 +1,82 @@
+// E2 goal-card arm assignment — run ON the prod server at launch, AFTER the code
+// deploy and BEFORE setting E2_START:
+//   cd ~/spurti && set -a && . ./.env && set +a && node pipeline/assign-arms-e2.mjs
+// Snapshots the eligible population (active, internshipStartDate >= 2026-07-16,
+// no journeyplans row), stratifies engagement x level-distance exactly like E1,
+// assigns A/B/C with seeded RNG (deterministic: same snapshot -> same arms),
+// WRITES e2Arm onto each student doc (the /api/me card gate reads it), and saves
+// the full CSV server-side (has emails — never leaves the server).
+// Pre-reg: research/05_experiments/goal_card_e2/preregistration.md
+import mongoose from 'mongoose';
+
+const SEED = 20260907;
+const URI = process.env.MONGO_URI;
+if (!URI) { console.error('no MONGO_URI'); process.exit(1); }
+await mongoose.connect(URI);
+const db = mongoose.connection.db;
+
+// mulberry32 — small deterministic PRNG; Math.random is not reproducible.
+function mulberry32(a) {
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const rand = mulberry32(SEED);
+
+const setters = new Set((await db.collection('journeyplans').find({}, { projection: { email: 1 } }).toArray())
+  .map(p => String(p.email).toLowerCase().trim()));
+
+const studs = await db.collection('students').find(
+  { status: 'active', internshipStartDate: { $gte: new Date('2026-07-16') } },
+  { projection: { email: 1, totalSp: 1, highestSpEver: 1 } }).toArray();
+
+const pop = studs
+  .map(s => ({ email: String(s.email).toLowerCase().trim(), totalSp: s.totalSp || 0, h: Math.max(s.highestSpEver || 0, s.totalSp || 0) }))
+  .filter(s => !setters.has(s.email));
+
+// strata: engagement x distance-to-next-level (identical to E1 for comparability)
+const stratumOf = s => {
+  const eng = s.totalSp <= 100 ? 'floor' : 'earner';
+  const r = s.h % 100;
+  const dist = r >= 70 ? 'near' : r >= 30 ? 'mid' : 'far';
+  return `${eng}|${dist}`;
+};
+const strata = new Map();
+for (const s of pop) {
+  const k = stratumOf(s);
+  if (!strata.has(k)) strata.set(k, []);
+  strata.get(k).push(s);
+}
+
+// within each stratum: deterministic order, seeded Fisher-Yates, then A/B/C in turn
+const rows = [];
+for (const [k, list] of [...strata.entries()].sort()) {
+  list.sort((a, b) => a.email < b.email ? -1 : 1);
+  for (let i = list.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [list[i], list[j]] = [list[j], list[i]];
+  }
+  list.forEach((s, i) => rows.push({ email: s.email, stratum: k, arm: ['A', 'B', 'C'][i % 3] }));
+}
+
+const stamp = new Date().toISOString().slice(0, 10);
+const csv = 'email,stratum,arm\n' + rows.map(r => `${r.email},${r.stratum},${r.arm}`).join('\n');
+const fs = await import('fs');
+const out = `${process.env.HOME}/spurti/e2_assignment_${stamp}.csv`;
+fs.writeFileSync(out, csv);
+
+// Stamp arms onto the student docs — the server's /api/me gate reads e2Arm.
+for (const arm of ['A', 'B', 'C']) {
+  const emails = rows.filter(r => r.arm === arm).map(r => r.email);
+  const res = await db.collection('students').updateMany(
+    { email: { $in: emails } }, { $set: { e2Arm: arm } });
+  console.log(`arm ${arm}: ${emails.length} assigned, ${res.modifiedCount} student docs stamped`);
+}
+
+console.log(`population ${rows.length}`);
+for (const [k, list] of [...strata.entries()].sort()) console.log(`  stratum ${k}: ${list.length}`);
+console.log(`assignment CSV (KEEP SERVER-SIDE, has emails): ${out}`);
+await mongoose.disconnect();

--- a/pipeline/sp-rubric-build-mirror.cjs
+++ b/pipeline/sp-rubric-build-mirror.cjs
@@ -125,6 +125,16 @@ const SPA_GOOD = ['approved', 'audit_passed'];
 // reviewedAt keeps the EARLIER rejection date on resubmitted projects.
 const PROJECT_SP = 500;
 
+// ── E2 goal-card incentive (arm C only; pre-reg 2026-09-07) ──────────────────
+// One-time +10 when an arm-C student of the E2 goal-card experiment sets their
+// first My Journey goal inside the launch window. Arm membership comes from the
+// launch assignment CSV (server-side file, has emails). Missing E2_START or a
+// missing CSV makes the whole category a silent no-op — safe on every host.
+const E2_GOAL_SP = 10;
+const E2_ASSIGN_CSV = process.env.E2_ASSIGN_CSV || `${process.env.HOME}/spurti/e2_assignment_2026-09-07.csv`;
+const E2_START_ENV = process.env.E2_START || '';
+const E2_DAYS_ENV = Number(process.env.E2_DAYS || 7);
+
 // ── Certificate-locked students ──────────────────────────────────────────────
 // Their certificate is fully processed and issued — printed numbers must never
 // move. They keep the exact rule-set in force at print time: no 'project'
@@ -462,6 +472,30 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     if (!prev || date < prev) projectByCanon.set(c, date);
   }
 
+  // 3e2. E2 goal-card: arm-C students who set their first journey goal inside the
+  //      experiment window -> canon -> YYYY-MM-DD of the plan's creation. No-op
+  //      unless E2_START is set and the assignment CSV exists on this host.
+  const e2GoalByCanon = new Map();
+  if (E2_START_ENV && fs.existsSync(E2_ASSIGN_CSV)) {
+    try {
+      const armC = new Set(fs.readFileSync(E2_ASSIGN_CSV, 'utf8').trim().split('\n').slice(1)
+        .map(l => l.split(',')).filter(p => (p[2] || '').trim() === 'C')
+        .map(p => canonOf(p[0].toLowerCase().trim())));
+      const startMs = new Date(E2_START_ENV).getTime();
+      const endMs = startMs + E2_DAYS_ENV * 86400000;
+      for (const jp of await sak.collection('journeyplans').find({},
+            { projection: { email: 1, createdAt: 1, standupBy: 1, vibeBy: 1, spaBy: 1, projectBy: 1 } }).toArray()) {
+        const c = canonOf(String(jp.email || '').toLowerCase().trim());
+        if (!armC.has(c)) continue;
+        if (!(jp.standupBy || jp.vibeBy || jp.spaBy || jp.projectBy)) continue;
+        const t = jp.createdAt ? new Date(jp.createdAt).getTime() : NaN;
+        if (!(t >= startMs && t < endMs)) continue;
+        e2GoalByCanon.set(c, dstr(jp.createdAt) || TODAY);
+      }
+      console.log(`E2 goal-card: ${e2GoalByCanon.size} arm-C setter(s) in window`);
+    } catch (e) { console.error('E2 goal-card scan skipped:', e.message); }
+  }
+
   // 3f. PRESERVED rows (manual/peer_faq) — read BEFORE the wipe and fold into each
   //     student's ledger so commitment/admin SP survives the rebuild. Re-created with
   //     the same delta/date/reason (metadata like original createdAt is not retained).
@@ -560,6 +594,12 @@ const dayLabel = (topic) => { const m = String(topic).match(/Day\s+([IVXLC0-9]+)
     if (projDate && !CERT_LOCKED.has(cand)) {
       rows.push({ date: projDate, order: 7, cat: 'project', delta: PROJECT_SP,
         reason: `Project (${ddmon(projDate)}): mentor review of your project PR completed -> +${PROJECT_SP} SP.` });
+    }
+    // E2 goal-card row: one-time +10, arm C only, first goal set inside the window.
+    const e2Date = e2GoalByCanon.get(cand);
+    if (e2Date && !CERT_LOCKED.has(cand)) {
+      rows.push({ date: e2Date, order: 7, cat: 'goal', delta: E2_GOAL_SP,
+        reason: `Goal set (${ddmon(e2Date)}): first My Journey target date set during the goal-card week -> +${E2_GOAL_SP} SP (one-time).` });
     }
     // Preserved rows (manual commitment/admin SP + peer_faq) — fold in so they survive the wipe.
     for (const p of (preservedByCanon.get(cand) || [])) rows.push(p);

--- a/server/models/E2CardEvent.js
+++ b/server/models/E2CardEvent.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+// E2 goal-card experiment telemetry (pre-reg 2026-09-07): one row per card
+// impression, skip, or set. Append-only; read by the experiment readout scripts,
+// never by the app itself.
+const e2CardEventSchema = new mongoose.Schema({
+  email: { type: String, required: true, lowercase: true, trim: true, index: true },
+  arm: { type: String, enum: ['B', 'C'], required: true },
+  event: { type: String, enum: ['impression', 'skip', 'set'], required: true },
+  phase: { type: String, default: '' },  // standup | vibe | spa | project — what the card asked
+  value: { type: String, default: '' }   // the chosen date, on 'set'
+}, { timestamps: true });
+
+e2CardEventSchema.index({ email: 1, event: 1, createdAt: 1 });
+
+export default mongoose.model('E2CardEvent', e2CardEventSchema);

--- a/server/models/Student.js
+++ b/server/models/Student.js
@@ -31,7 +31,11 @@ const studentSchema = new mongoose.Schema({
   // The last time the student actually OPENED the Achievements tab. Anything
   // earned after this is still new to them, which is what the tab badge counts.
   // Null means never opened, so everything they hold is unseen.
-  achievementsSeenAt: { type: Date, default: null }
+  achievementsSeenAt: { type: Date, default: null },
+  // E2 goal-card experiment (pre-reg 2026-09-07). Assigned once, server-side, by
+  // pipeline/assign-arms-e2.mjs at launch; '' = not in the experiment.
+  // A = control (no card) · B = card · C = card + one-time +10 SP on setting.
+  e2Arm: { type: String, enum: ['', 'A', 'B', 'C'], default: '', index: true }
 }, { timestamps: true });
 
 studentSchema.index({ name: 'text', email: 'text', alternateEmail: 'text' });

--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,8 @@ import AchievementView, { isBot, uaFamilyOf, viewerDayHash } from './models/Achi
 import BoardReign from './models/BoardReign.js';
 import Announcement from './models/Announcement.js';
 import AnnouncementAck from './models/AnnouncementAck.js';
+import JourneyPlan from './models/JourneyPlan.js';
+import E2CardEvent from './models/E2CardEvent.js';
 import { buildAchievementState, verifyAchievement } from './services/achievements.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import Commitment from './models/Commitment.js';
@@ -273,6 +275,14 @@ async function studentPayload(student) {
     level: levelFor(Math.max(Number(row.highestSpEver) || 0, Number(row.totalSp) || 0)),
     isCurrentStudent: row.email === email
   });
+  // E2 goal card: arms B/C, window open, and no goal set yet — the moment a
+  // journey goal exists the card's premise is gone and it stops for good.
+  let e2Card = null;
+  if ((student.e2Arm === 'B' || student.e2Arm === 'C') && e2WindowOpen()) {
+    const plan = await JourneyPlan.findOne({ email: student.email }).lean();
+    const hasGoal = plan && (plan.standupBy || plan.vibeBy || plan.spaBy || plan.projectBy);
+    if (!hasGoal) e2Card = { arm: student.e2Arm, sp: student.e2Arm === 'C' ? 10 : 0 };
+  }
   return {
     student: {
       _id: String(student._id),
@@ -296,7 +306,8 @@ async function studentPayload(student) {
       surveyCompleted: Boolean(student.surveyCompleted),
       poll2Completed: Boolean(student.poll2Completed),
       poll3Completed: Boolean(student.poll3Completed),
-      eligibleForVibeGoals: isVibeEligible(student)
+      eligibleForVibeGoals: isVibeEligible(student),
+      e2Card
     },
     transactions,
     polls,
@@ -311,6 +322,19 @@ async function studentPayload(student) {
     leaderboard: leaderboard.map(mapRow),
     groupLeaderboard: groupStudents.slice(0, 50).map(mapRow)
   };
+}
+
+// ── E2 goal-card experiment window (pre-reg 2026-09-07) ──────────────────────
+// The card renders for arms B/C only between E2_START and E2_START + E2_DAYS.
+// The gate lives server-side so a stale client build can never extend the
+// experiment; arm assignment sits on the student doc (e2Arm), written once by
+// pipeline/assign-arms-e2.mjs. Unset E2_START = experiment off everywhere.
+const E2_START = process.env.E2_START ? new Date(process.env.E2_START) : null;
+const E2_DAYS = Number(process.env.E2_DAYS || 7);
+function e2WindowOpen() {
+  if (!E2_START || Number.isNaN(E2_START.getTime())) return false;
+  const now = Date.now();
+  return now >= E2_START.getTime() && now < E2_START.getTime() + E2_DAYS * 86400000;
 }
 
 function isAdmin(req) {
@@ -715,6 +739,29 @@ api.post('/share/track', async (req, res) => {
     captionEdited: !!captionEdited, captionChars: Number(captionChars) || 0,
     platform
   });
+  res.json({ ok: true });
+});
+
+// E2 goal-card telemetry: one row per impression / skip / set. Cookie-only auth
+// on purpose (unlike vibeStudent): a client-supplied email must never let anyone
+// write experiment rows for someone else. Log failures are swallowed — telemetry
+// must not break the card.
+api.post('/e2/card-event', async (req, res) => {
+  const { event, phase, value } = req.body || {};
+  if (!['impression', 'skip', 'set'].includes(event)) return res.status(400).json({ error: 'bad event' });
+  const email = await studentEmailFromRequest(req);
+  const student = email ? await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean() : null;
+  if (!student || (student.e2Arm !== 'B' && student.e2Arm !== 'C')) {
+    return res.status(403).json({ error: 'not in experiment' });
+  }
+  try {
+    await E2CardEvent.create({
+      email: student.email, arm: student.e2Arm, event,
+      phase: String(phase || ''), value: String(value || '')
+    });
+  } catch (err) {
+    console.error('e2 card-event log failed:', err?.message);
+  }
   res.json({ ok: true });
 });
 


### PR DESCRIPTION
Pre-registered 3-arm experiment (research: 05_experiments/goal_card_e2/preregistration.md, frozen at launch) testing an in-flow goal-setting prompt after E1 null.

**Client** — GoalCardModal: pop-up at login for arms B/C while the window is open and no goal exists (server-gated via student.e2Card). Asks ONE date (first unset phase), one-tap set via existing PUT /journey/plan, one-tap skip. Max once per calendar day (localStorage), never stacks on survey modals, gone forever once any goal is set. Arm C shows a +10 SP badge.

**Server** — e2Arm on Student; e2Card in /api/me payload (window from E2_START/E2_DAYS env + live no-goal check); POST /api/e2/card-event (impression/skip/set; cookie-only auth).

**Pipeline** — one-time +10 goal category for arm-C in-window setters (silent no-op unless E2_START set AND assignment CSV exists); assign-arms-e2.mjs (seed 20260907, E1 strata, stamps e2Arm, writes server-side CSV).

**Launch order (after merge):** server pull + client build + pm2 restart -> run assign-arms-e2.mjs -> set E2_START in .env -> pm2 restart -> verify a B student /api/me shows the flag.

Experiment is OFF by default — without E2_START in the env nothing renders and the rubric line is a no-op.

Generated with Claude Code
https://claude.ai/code/session_011sRFBtASS5eFUjtd4TwnUn