### PR TITLE
Add What-If SP simulator

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -4,7 +4,6 @@ import mongoose from 'mongoose';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-
 import { ALLOW_STUDENT_SEARCH, MONGO_URI, PORT, SAMAGAMA_AUTH_URL } from './config.js';
 import Student from './models/Student.js';
 import Session from './models/Session.js';
@@ -21,6 +20,10 @@ import Announcement from './models/Announcement.js';
 import AnnouncementAck from './models/AnnouncementAck.js';
 import JourneyPlan from './models/JourneyPlan.js';
 import E2CardEvent from './models/E2CardEvent.js';
+import SpaProgress from './models/SpaProgress.js';
+
+import { simulateSp } from './services/simulator.js';
+
 import { buildAchievementState, verifyAchievement } from './services/achievements.js';
 import { leagueBand, levelFor, legendBadge, leaderboardGroup, groupLabel } from './services/levels.js';
 import Commitment from './models/Commitment.js';
@@ -373,7 +376,153 @@ async function vibeStudent(req) {
   if (!email) return null;
   return Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
 }
+// ---- What-If Simulator ----------------------------------------------------
+api.get('/simulator/context', async (req, res) => {
+  const student = await vibeStudent(req);
 
+  if (!student) {
+    return res.status(404).json({ error: 'Student not found' });
+  }
+  const email = normalizeEmail(student.email);
+
+  const [spaProgress, queryTxns] = await Promise.all([
+    SpaProgress.findOne({ email }).lean(),
+    SPTransaction.find({ email, category: 'query' }).lean(),
+  ]);
+
+  // Count only positive query SP earned.
+
+
+  // Count only positive query SP earned.
+  // Query penalties should not reduce the activity-cap progress.
+  const querySp = Math.min(
+    200,
+    queryTxns.reduce(
+      (sum, txn) => sum + Math.max(0, Number(txn.appliedDelta || 0)),
+      0
+    )
+  );
+
+  const studentState = {
+    currentSp: Number(student.totalSp || 0),
+    highestSpEver: Number(
+      student.highestSpEver ?? student.totalSp ?? 0
+    ),
+    spaLearn: Math.max(
+      0,
+      Math.floor(Number(spaProgress?.learnValidated || 0))
+    ),
+    spaTeach: Math.max(
+      0,
+      Math.floor(Number(spaProgress?.teachValidated || 0))
+    ),
+    querySp,
+  };
+
+  const simulation = simulateSp(studentState, {});
+
+  res.json({
+    current: simulation.current,
+    progress: {
+      spaLearn: studentState.spaLearn,
+      spaTeach: studentState.spaTeach,
+      querySp: studentState.querySp,
+    },
+    headroom: simulation.headroom,
+    milestones: simulation.milestones,
+  });
+});
+api.post('/simulator/simulate', async (req, res) => {
+  const student = await vibeStudent(req);
+
+  if (!student) {
+    return res.status(404).json({ error: 'Student not found' });
+  }
+
+  const {
+    sessions = 0,
+    attendancePct = 0,
+    pollPct = 0,
+    additionalSpaLearn = 0,
+    additionalSpaTeach = 0,
+    additionalQueries = 0,
+  } = req.body || {};
+
+  const integerFields = {
+    sessions,
+    additionalSpaLearn,
+    additionalSpaTeach,
+    additionalQueries,
+  };
+
+  for (const [field, value] of Object.entries(integerFields)) {
+    if (!Number.isInteger(value) || value < 0) {
+      return res.status(400).json({
+        error: `${field} must be a non-negative integer`,
+      });
+    }
+  }
+
+  const percentageFields = {
+    attendancePct,
+    pollPct,
+  };
+
+  for (const [field, value] of Object.entries(percentageFields)) {
+    if (
+      typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      value < 0 ||
+      value > 100
+    ) {
+      return res.status(400).json({
+        error: `${field} must be a number between 0 and 100`,
+      });
+    }
+  }
+
+  const email = normalizeEmail(student.email);
+
+  const [spaProgress, queryTxns] = await Promise.all([
+    SpaProgress.findOne({ email }).lean(),
+    SPTransaction.find({ email, category: 'query' }).lean(),
+  ]);
+
+  const querySp = Math.min(
+    200,
+    queryTxns.reduce(
+      (sum, txn) => sum + Math.max(0, Number(txn.appliedDelta || 0)),
+      0
+    )
+  );
+
+  const studentState = {
+    currentSp: Number(student.totalSp || 0),
+    highestSpEver: Number(
+      student.highestSpEver ?? student.totalSp ?? 0
+    ),
+    spaLearn: Math.max(
+      0,
+      Math.floor(Number(spaProgress?.learnValidated || 0))
+    ),
+    spaTeach: Math.max(
+      0,
+      Math.floor(Number(spaProgress?.teachValidated || 0))
+    ),
+    querySp,
+  };
+
+  const result = simulateSp(studentState, {
+    sessions,
+    attendancePct,
+    pollPct,
+    additionalSpaLearn,
+    additionalSpaTeach,
+    additionalQueries,
+  });
+
+  res.json(result);
+});
 api.get('/vibe/state', async (req, res) => {
   const student = await vibeStudent(req);
   if (!student) return res.status(404).json({ error: 'Student not found' });

--- a/server/services/simulator.js
+++ b/server/services/simulator.js
@@ -1,0 +1,233 @@
+import { levelFor, leagueBand, legendBadge } from './levels.js';
+
+const QUERY_UNIT = 5;
+const QUERY_CAP = 200;
+
+const SPA_LEARN_UNIT = 5;
+const SPA_LEARN_CAP = 50;
+
+const SPA_TEACH_UNIT = 10;
+const SPA_TEACH_CAP = 25;
+
+const ATTENDANCE_TIERS = [
+  { min: 90, sp: 10 },
+  { min: 75, sp: 5 },
+  { min: 50, sp: 3 },
+  { min: 0, sp: 0 },
+];
+
+function tierSp(percentage) {
+  const pct = Number(percentage) || 0;
+
+  for (const tier of ATTENDANCE_TIERS) {
+    if (pct >= tier.min) return tier.sp;
+  }
+
+  return 0;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function nextMilestones(currentSp) {
+  const sp = Math.max(0, Number(currentSp) || 0);
+
+  const milestones = [
+    100,
+    200,
+    300,
+    400,
+    500,
+    600,
+    700,
+    800,
+    900,
+    1000,
+    1100,
+    1200,
+    1300,
+    1400,
+    1500,
+  ];
+
+  return milestones
+    .filter((milestone) => milestone > sp)
+    .slice(0, 3)
+    .map((milestone) => ({
+      target: milestone,
+      remaining: milestone - sp,
+    }));
+}
+
+export function simulateSp(studentState = {}, inputs = {}) {
+  const currentSp = Math.max(
+    0,
+    Number(studentState.currentSp) || 0
+  );
+
+  const highestSpEver = Math.max(
+    currentSp,
+    Number(studentState.highestSpEver) || 0
+  );
+
+  const sessions = Math.max(
+    0,
+    Math.floor(Number(inputs.sessions) || 0)
+  );
+
+  const attendancePct = clamp(
+    Number(inputs.attendancePct) || 0,
+    0,
+    100
+  );
+
+  const pollPct = clamp(
+    Number(inputs.pollPct) || 0,
+    0,
+    100
+  );
+
+  const additionalSpaLearn = Math.max(
+    0,
+    Math.floor(Number(inputs.additionalSpaLearn) || 0)
+  );
+
+  const additionalSpaTeach = Math.max(
+    0,
+    Math.floor(Number(inputs.additionalSpaTeach) || 0)
+  );
+
+  const additionalQueries = Math.max(
+    0,
+    Math.floor(Number(inputs.additionalQueries) || 0)
+  );
+
+  const existingSpaLearn = Math.max(
+    0,
+    Math.floor(Number(studentState.spaLearn || 0))
+  );
+
+  const existingSpaTeach = Math.max(
+    0,
+    Math.floor(Number(studentState.spaTeach || 0))
+  );
+
+  const existingQuerySp = Math.max(
+    0,
+    Math.floor(Number(studentState.querySp || 0))
+  );
+
+  // Attendance SP
+  const attendanceSp =
+    sessions * tierSp(attendancePct);
+
+  // Poll SP
+  const pollSp =
+    sessions * tierSp(pollPct);
+
+  // SPA Learning SP
+  const spaLearnHeadroom = Math.max(
+    0,
+    SPA_LEARN_CAP - existingSpaLearn
+  );
+
+  const appliedSpaLearn = Math.min(
+    additionalSpaLearn,
+    spaLearnHeadroom
+  );
+
+  const spaLearnSp =
+    appliedSpaLearn * SPA_LEARN_UNIT;
+
+  // SPA Teaching SP
+  const spaTeachHeadroom = Math.max(
+    0,
+    SPA_TEACH_CAP - existingSpaTeach
+  );
+
+  const appliedSpaTeach = Math.min(
+    additionalSpaTeach,
+    spaTeachHeadroom
+  );
+
+  const spaTeachSp =
+    appliedSpaTeach * SPA_TEACH_UNIT;
+
+  // Query SP
+  const queryHeadroom = Math.max(
+    0,
+    QUERY_CAP - existingQuerySp
+  );
+
+  const appliedQueries = Math.min(
+    additionalQueries,
+    Math.floor(queryHeadroom / QUERY_UNIT)
+  );
+
+  const querySp =
+    appliedQueries * QUERY_UNIT;
+
+  // Total gains
+  const gains = {
+    attendance: attendanceSp,
+    polls: pollSp,
+    spaLearn: spaLearnSp,
+    spaTeach: spaTeachSp,
+    queries: querySp,
+  };
+
+  const totalGain = Object.values(gains).reduce(
+    (sum, value) => sum + value,
+    0
+  );
+
+  // Projected state
+  const projectedSp =
+    currentSp + totalGain;
+
+  const projectedHighestSpEver = Math.max(
+    highestSpEver,
+    projectedSp
+  );
+
+  return {
+    current: {
+      sp: currentSp,
+      highestSpEver,
+      level: levelFor(highestSpEver),
+      league: leagueBand(currentSp),
+      legend: legendBadge(highestSpEver),
+    },
+
+    gains: {
+      ...gains,
+      total: totalGain,
+    },
+
+    projected: {
+      sp: projectedSp,
+      highestSpEver: projectedHighestSpEver,
+      level: levelFor(projectedHighestSpEver),
+      league: leagueBand(projectedSp),
+      legend: legendBadge(projectedHighestSpEver),
+    },
+
+    applied: {
+      sessions,
+      attendancePct,
+      pollPct,
+      spaLearn: appliedSpaLearn,
+      spaTeach: appliedSpaTeach,
+      queries: appliedQueries,
+    },
+
+    headroom: {
+      spaLearn: spaLearnHeadroom,
+      spaTeach: spaTeachHeadroom,
+      queries: queryHeadroom,
+    },
+
+    milestones: nextMilestones(projectedSp),
+  };
+}

--- a/test/simulator.test.js
+++ b/test/simulator.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  simulateSp,
+  nextMilestones,
+} from '../server/services/simulator.js';
+
+test('calculates projected SP correctly', () => {
+  const result = simulateSp(
+    { currentSp: 420, highestSpEver: 420 },
+    {
+      sessions: 5,
+      attendancePct: 90,
+      pollPct: 75,
+      additionalSpaLearn: 2,
+      additionalSpaTeach: 1,
+      additionalQueries: 3,
+    }
+  );
+
+  assert.equal(result.gains.attendance, 50);
+  assert.equal(result.gains.polls, 25);
+  assert.equal(result.gains.spaLearn, 10);
+  assert.equal(result.gains.spaTeach, 10);
+  assert.equal(result.gains.queries, 15);
+  assert.equal(result.gains.total, 110);
+
+  assert.equal(result.projected.sp, 530);
+  assert.equal(result.projected.level, 5);
+  assert.equal(result.projected.league, 'Silver I');
+});
+
+test('applies attendance tier boundaries correctly', () => {
+  assert.equal(
+    simulateSp(
+      { currentSp: 0, highestSpEver: 0 },
+      { sessions: 1, attendancePct: 90 }
+    ).gains.attendance,
+    10
+  );
+
+  assert.equal(
+    simulateSp(
+      { currentSp: 0, highestSpEver: 0 },
+      { sessions: 1, attendancePct: 75 }
+    ).gains.attendance,
+    5
+  );
+
+  assert.equal(
+    simulateSp(
+      { currentSp: 0, highestSpEver: 0 },
+      { sessions: 1, attendancePct: 50 }
+    ).gains.attendance,
+    3
+  );
+
+  assert.equal(
+    simulateSp(
+      { currentSp: 0, highestSpEver: 0 },
+      { sessions: 1, attendancePct: 49 }
+    ).gains.attendance,
+    0
+  );
+});
+
+test('does not exceed SPA caps', () => {
+  const result = simulateSp(
+    {
+      currentSp: 0,
+      highestSpEver: 0,
+      spaLearn: 49,
+      spaTeach: 24,
+    },
+    {
+      additionalSpaLearn: 10,
+      additionalSpaTeach: 10,
+    }
+  );
+
+  assert.equal(result.applied.spaLearn, 1);
+  assert.equal(result.gains.spaLearn, 5);
+
+  assert.equal(result.applied.spaTeach, 1);
+  assert.equal(result.gains.spaTeach, 10);
+});
+
+test('does not exceed query SP cap', () => {
+  const result = simulateSp(
+    {
+      currentSp: 0,
+      highestSpEver: 0,
+      querySp: 195,
+    },
+    {
+      additionalQueries: 10,
+    }
+  );
+
+  assert.equal(result.applied.queries, 1);
+  assert.equal(result.gains.queries, 5);
+});
+
+test('level uses highest SP ever', () => {
+  const result = simulateSp(
+    { currentSp: 420, highestSpEver: 550 },
+    { additionalQueries: 1 }
+  );
+
+  assert.equal(result.current.level, 5);
+  assert.equal(result.projected.level, 5);
+});
+
+test('projected level increases when SP crosses milestone', () => {
+  const result = simulateSp(
+    { currentSp: 490, highestSpEver: 490 },
+    { additionalQueries: 2 }
+  );
+
+  assert.equal(result.projected.sp, 500);
+  assert.equal(result.projected.level, 5);
+});
+
+test('league is based on projected current SP', () => {
+  const result = simulateSp(
+    { currentSp: 490, highestSpEver: 490 },
+    { additionalQueries: 2 }
+  );
+
+  assert.equal(result.projected.league, 'Silver I');
+});
+
+test('next milestones are calculated correctly', () => {
+  assert.deepEqual(nextMilestones(420), [
+    { target: 500, remaining: 80 },
+    { target: 600, remaining: 180 },
+    { target: 700, remaining: 280 },
+  ]);
+});
+
+test('zero inputs produce no SP gain', () => {
+  const result = simulateSp(
+    { currentSp: 420, highestSpEver: 420 },
+    {}
+  );
+
+  assert.equal(result.gains.total, 0);
+  assert.equal(result.projected.sp, 420);
+});
+
+test('does not mutate input objects', () => {
+  const studentState = {
+    currentSp: 420,
+    highestSpEver: 420,
+    spaLearn: 10,
+    spaTeach: 5,
+    querySp: 20,
+  };
+
+  const inputs = {
+    sessions: 2,
+    attendancePct: 90,
+    pollPct: 90,
+    additionalSpaLearn: 2,
+    additionalSpaTeach: 1,
+    additionalQueries: 3,
+  };
+
+  const originalStudentState = structuredClone(studentState);
+  const originalInputs = structuredClone(inputs);
+
+  simulateSp(studentState, inputs);
+
+  assert.deepEqual(studentState, originalStudentState);
+  assert.deepEqual(inputs, originalInputs);
+});


### PR DESCRIPTION
## Overview

This PR adds a new **What-If SP Simulator** feature to Spurti.

The purpose of this feature is to allow a student to check how their SP (Spurti Points) could change if they hypothetically complete different activities.

For example, a student can enter a scenario such as:

- Attend 5 more sessions
- Maintain 90% attendance
- Participate in polls
- Complete additional SPA learning questions
- Complete additional SPA teaching activities
- Answer additional peer queries

The simulator calculates the possible SP gain and shows the projected:

- Current SP
- Projected SP
- Level
- Trophy League
- Legend status
- Upcoming SP milestones

The important part is that this is only a **simulation**. It does not actually add SP to the student's account and does not modify the SP ledger or database.

---

## Why this feature is needed

Students currently have to manually estimate how much SP they may gain from future activities.

This becomes difficult because different activities have different SP rules and caps.

For example:

- Attendance gives different SP depending on the attendance percentage.
- Poll participation also follows percentage-based tiers.
- SPA learning has a maximum credit limit.
- SPA teaching has a maximum credit limit.
- Query SP has a maximum limit.
- Level is based on the student's highest SP ever.
- Trophy league is based on current SP.

The simulator brings these rules together into one place and gives the student a quick way to understand the possible result of future activities.

---

## Main functionality

The simulator accepts hypothetical activities and calculates their effect without applying anything to the student's actual account.

The supported inputs are:

1. Number of sessions
2. Expected attendance percentage
3. Expected poll participation percentage
4. Additional SPA learning questions
5. Additional SPA teaching activities
6. Additional peer queries

The simulator then calculates the SP contribution from each activity separately and combines them into the total projected SP.

---

## Example

Suppose a student currently has:

- Current SP: 420
- Highest SP Ever: 450

The student wants to simulate:

- 5 sessions
- 90% attendance
- 90% poll participation
- 5 SPA learning questions
- 2 SPA teaching activities
- 4 additional queries

The simulator calculates the SP gain from each activity and produces a projected state.

The student can then see whether the projected SP crosses milestones such as:

- 500 SP
- 600 SP
- 700 SP

and whether the projected level or trophy league changes.

---

## SP calculation rules implemented

The simulator follows the existing Spurti SP rules instead of introducing a separate scoring system.

### Attendance

Attendance SP is calculated according to the existing percentage tiers:

- 90% or above → +10 SP per session
- 75%–89% → +5 SP per session
- 50%–74% → +3 SP per session
- Below 50% → +0 SP

The number of sessions is multiplied by the applicable attendance tier.

---

### Poll participation

Poll participation uses the same percentage-based tier structure for the simulator:

- 90% or above → +10 SP per session
- 75%–89% → +5 SP per session
- 50%–74% → +3 SP per session
- Below 50% → +0 SP

This is treated as a hypothetical scored-session calculation in the current V1 simulator.

---

### SPA Learning

SPA learning gives:

- +5 SP per question

There is a maximum of:

- 50 credited questions
- 250 SP maximum

The simulator checks the student's existing validated learning progress before calculating additional SP.

This prevents the simulation from exceeding the existing SPA learning cap.

---

### SPA Teaching

SPA teaching gives:

- +10 SP per peer/activity

There is a maximum of:

- 25 credited activities
- 250 SP maximum

The simulator considers the student's existing validated teaching progress before applying additional hypothetical activities.

---

### Query SP

Query answering gives:

- +5 SP per distinct peer query

The maximum query SP considered by the simulator is:

- 200 SP
- Equivalent to 40 queries

The simulator derives existing query progress from positive query SP transactions.

Query penalties are not counted as progress toward the activity cap because the simulator is measuring how much query activity has already been credited.

---

## Level calculation

The simulator uses the existing Spurti level calculation.

Level is based on:

**Highest SP Ever**

and not simply the current SP.

The simulator therefore maintains both:

- Current SP
- Highest SP Ever

When the projected SP becomes higher than the previous highest SP, the projected highest SP is updated.

This means the projected level can increase when a milestone is crossed.

---

## Trophy League calculation

The simulator uses the existing league calculation from the project.

The league is based on:

**Current / Projected SP**

For example:

- 0–99 → Bronze III
- 100–199 → Bronze II
- 200–299 → Bronze I
- 300–399 → Silver III
- 400–499 → Silver II
- 500–599 → Silver I
- 600–699 → Gold III
- 700–799 → Gold II
- 800–899 → Gold I
- 900–999 → Platinum III
- 1000–1099 → Platinum II
- 1100–1199 → Platinum I
- 1200–1299 → Diamond III
- 1300–1399 → Diamond II
- 1400–1499 → Diamond I
- 1500+ → Legend

The existing `levels.js` service is reused instead of duplicating these rules.

---

## Legend Badge

Legend status is also calculated using the existing project rule.

A student reaches Legend status when:

**Highest SP Ever >= 1500**

The simulator therefore checks projected highest SP rather than only current SP.

---

## Milestone calculation

The simulator also calculates the next upcoming SP milestones.

For example, if projected SP is 420, the response can show:

- 500 → 80 SP remaining
- 600 → 180 SP remaining
- 700 → 280 SP remaining

This helps the student understand how far they are from the next levels/leagues.

---

# Technical implementation

## 1. Simulator service

A new service was added:

`server/services/simulator.js`

This file contains the core simulation logic.

The service is designed as a pure calculation layer.

It receives:

- Current student state
- Hypothetical activity inputs

and returns:

- Current state
- SP gains
- Projected state
- Applied values after caps
- Remaining activity headroom
- Next milestones

No database writes happen inside this service.

---

## 2. Existing level service reused

The simulator reuses the existing:

`server/services/levels.js`

Functions used include:

- `levelFor()`
- `leagueBand()`
- `legendBadge()`

This ensures that the simulator uses the same level and league rules as the rest of the application.

This also avoids having two different definitions of levels or leagues.

---

## 3. Simulator context API

Added:

`GET /api/simulator/context`

This endpoint retrieves the student's current simulator context.

It gets:

- Current SP
- Highest SP Ever
- Existing SPA learning progress
- Existing SPA teaching progress
- Existing query SP
- Remaining activity headroom
- Current level
- Current league
- Legend status
- Upcoming milestones

The current student is obtained through the existing student authentication/request flow.

The client does not provide or control the authoritative current SP.

---

## 4. Simulation API

Added:

`POST /api/simulator/simulate`

This endpoint accepts hypothetical activity values.

Example request structure:

```json
{
  "sessions": 5,
  "attendancePct": 90,
  "pollPct": 90,
  "additionalSpaLearn": 5,
  "additionalSpaTeach": 2,
  "additionalQueries": 4
}