### PR TITLE
feat: add Progress Coach feature with state management and UI updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,15 @@ ALLOW_STUDENT_SEARCH=true
 
 # Students are identified by the `chatengine_token` cookie that SAMAGAMA sets;
 # Spurti validates it against this endpoint (Samagama's own service, same host).
-# With no Samagama running locally there is no student session — use search.
+# With no Samagama running locally there is no student session — use search, or
+# enable the local-only fixture mode below for student-only feature work.
 SAMAGAMA_AUTH_URL=http://127.0.0.1:5001/api/auth/me
+
+# Development-only fixture mode for student-only feature work without Samagama.
+# This is ignored unless NODE_ENV is exactly "development". The fixture command
+# also refuses every database except spurti_dev and every email except @spurti.local.
+NODE_ENV=
+LOCAL_DEV_AUTH_EMAIL=
 
 # Admin dashboard. Sent by the client as `x-admin-email` / `x-admin-token`.
 # Both must be set or the admin routes stay closed.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,50 @@ identified by the `chatengine_token` cookie that **Samagama** sets, which Spurti
 locally you will not have a student session. For local work, keep `ALLOW_STUDENT_SEARCH=true` and
 look students up by email instead — that path is disabled in production on purpose.
 
+### Progress Coach fixture mode (local development only)
+
+The Progress Coach deliberately requires a student identity, so search mode cannot exercise it.
+To develop it locally without Samagama, use a fictional account in the dedicated `spurti_dev`
+database:
+
+```bash
+# .env
+MONGO_URI=mongodb://127.0.0.1:27017/spurti_dev
+NODE_ENV=development
+LOCAL_DEV_AUTH_EMAIL=dev.student@spurti.local
+
+npm run seed-progress-coach-dev
+npm start
+```
+
+Open `http://localhost:5290/spurti/`; the app treats every request as the fictional fixture
+student and the authenticated Progress Coach panel will render. The fixture command refuses to
+run for any database other than `spurti_dev` or any email outside `@spurti.local`, and the auth
+fallback is unavailable unless `NODE_ENV=development`. Do not set these variables in shared or
+production environments.
+
+### Progress Coach
+
+Progress Coach is a read-only action layer above **My Journey**. My Journey remains the source of
+truth for standup attendance, ViBe courses, SPA practice, project PRs, and student-set target
+dates. Progress Coach interprets those existing values and presents one status, a short reason,
+and at most one next action; it never awards SP or changes progress records.
+
+Authenticated students can read their own state at `GET /api/progress-coach/state`. The endpoint
+derives the student from the Samagama session cookie (or the strictly local fixture identity),
+never from a request email or student ID.
+
+- **Action required:** a target is overdue, due today with work remaining, or its required
+  standup pace exceeds the existing 60-minutes-per-working-day capacity.
+- **Needs attention:** progress is behind the linear pace calculated from the existing goal-set
+  snapshot and target date.
+- **On track:** active requirements are on pace; a completed journey shows no invented task.
+
+When several tracks qualify, the single recommendation is selected in this order: overdue,
+critical deadline, behind target pace, weekly pace (only where a real weekly deadline exists),
+almost complete, then a normal active activity. An unmet ViBe weekly floor is not treated as
+"behind" because the existing data does not define a weekly deadline for it.
+
 **Useful scripts:**
 
 ```bash

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1228,6 +1228,74 @@ function Leaderboard({ rows }) {
 const fmtDate = d => d ? new Date(d).toLocaleDateString(undefined, { day: 'numeric', month: 'short' }) : '—';
 const toInput = d => d ? new Date(d).toISOString().slice(0, 10) : '';
 
+const COACH_STATUS_META = {
+  on_track: { label: 'ON TRACK', icon: '🟢', className: 'on-track' },
+  needs_attention: { label: 'NEEDS ATTENTION', icon: '🟡', className: 'needs-attention' },
+  action_required: { label: 'ACTION REQUIRED', icon: '🔴', className: 'action-required' },
+  neutral: { label: 'GETTING STARTED', icon: '🔵', className: 'neutral' },
+  unavailable: { label: 'TEMPORARILY UNAVAILABLE', icon: '⚪', className: 'unavailable' }
+};
+
+const COACH_TRACK_LABELS = {
+  standup: 'standup',
+  vibe: 'ViBe',
+  spa: 'SPA',
+  project: 'project'
+};
+
+function ProgressCoachPanel({ data, onViewTrack }) {
+  const meta = COACH_STATUS_META[data.status] || COACH_STATUS_META.neutral;
+  const action = data.nextAction;
+  const trackLabel = COACH_TRACK_LABELS[action?.trackKey] || 'journey';
+
+  return (
+    <section className={`panel jr-coach jr-coach-${meta.className}`} role="status" aria-live="polite" aria-labelledby="progress-coach-title">
+      <div className="jr-coach-head">
+        <span className="jr-coach-icon" aria-hidden="true">{meta.icon}</span>
+        <div>
+          <p className="eyebrow">Progress Coach</p>
+          <h2 id="progress-coach-title">{meta.label}</h2>
+        </div>
+      </div>
+
+      {data.completion ? (
+        <p className="jr-coach-message">{data.message}</p>
+      ) : (
+        <>
+          {action && (
+            <div className="jr-coach-action">
+              <p className="jr-coach-label">Next best action</p>
+              <h3>{action.title}</h3>
+              {action.catchUpPerDay && (
+                <p className="jr-coach-catchup">About <strong>{action.catchUpPerDay}</strong> to catch up.</p>
+              )}
+              {onViewTrack && action.trackKey && (
+                <button type="button" className="primary jr-coach-cta" onClick={() => onViewTrack(action.trackKey)}>
+                  View {trackLabel} details
+                </button>
+              )}
+            </div>
+          )}
+          <div className="jr-coach-why">
+            <p className="jr-coach-label">Why</p>
+            <p>{data.message}</p>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function ProgressCoachLoading() {
+  return (
+    <section className="panel jr-coach jr-coach-loading" aria-live="polite" aria-busy="true">
+      <p className="eyebrow">Progress Coach</p>
+      <h2>Checking your pace…</h2>
+      <p className="muted">Your next useful action will appear here.</p>
+    </section>
+  );
+}
+
 // The unified phase-by-phase progress + SP tab. Four phases: Standups, ViBe, SPA,
 // Projects. Standups & ViBe show real SP; SPA & Projects are placeholders until the
 // Samagama data (and their SP rule) land. Goal *staking* lives in the Commitments tab.
@@ -1284,6 +1352,7 @@ function PhaseGoal({ phaseKey, field, goal, targetText, form, setForm, onSave })
 function MyJourney({ student, goToCommitment, canCommit = false }) {
   const email = student.email;
   const [data, setData] = useState(null);
+  const [coach, setCoach] = useState(null);
   const [form, setForm] = useState({});
   const [showTraj, setShowTraj] = useState(false);
   const [err, setErr] = useState(null);
@@ -1292,7 +1361,17 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
     const r = await fetch(`${API}/journey/state?email=${encodeURIComponent(email)}`);
     setData(await r.json());
   };
-  useEffect(() => { load(); }, [email]);
+  const loadCoach = async () => {
+    try {
+      const r = await fetch(`${API}/progress-coach/state`);
+      if (r.status === 401) { setCoach({ authRequired: true }); return; }
+      if (!r.ok) { setCoach({ unavailable: true }); return; }
+      setCoach(await r.json());
+    } catch {
+      setCoach({ unavailable: true });
+    }
+  };
+  useEffect(() => { load(); loadCoach(); }, [email]);
 
   if (!data) return <section className="panel">Loading your journey…</section>;
   if (!data.eligible) return <section className="panel empty">My Journey isn’t available for your cohort yet.</section>;
@@ -1306,9 +1385,16 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
     });
     const j = await r.json();
     if (!r.ok) { setErr(j.error); return; }
-    setErr(null); setData(j);
+    setErr(null); setData(j); loadCoach();
   };
   const gp = { form, setForm, onSave: saveTarget };
+
+  const viewTrack = key => {
+    const node = document.getElementById(`journey-phase-${key}`);
+    if (!node) return;
+    node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    node.focus({ preventScroll: true });
+  };
 
   return (
     <div className="jr">
@@ -1318,9 +1404,19 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
         {err && <p className="error">{err}</p>}
       </section>
 
+      {coach === null && <ProgressCoachLoading />}
+      {coach?.status && <ProgressCoachPanel data={coach} onViewTrack={viewTrack} />}
+      {coach?.unavailable && (
+        <section className="panel jr-coach jr-coach-unavailable" role="status">
+          <p className="eyebrow">Progress Coach</p>
+          <h2>Temporarily unavailable</h2>
+          <p className="muted">Some progress information is temporarily unavailable. My Journey is still available below.</p>
+        </section>
+      )}
+
       <div className="jr-grid">
         {/* Standups — continuous, no completion goal; commitment only */}
-        <section className="jr-card phase-standups">
+        <section id="journey-phase-standup" className="jr-card phase-standups" tabIndex="-1">
           <div className="jr-head"><span className="jr-n">1</span><h3>Standups</h3><span className="jr-sp">+{standups.sp} SP</span></div>
           <p className="jr-sub">Zoom attendance + Spandan polls</p>
           <div className="jr-stats">
@@ -1337,7 +1433,7 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
         </section>
 
         {/* ViBe — goal + commitment */}
-        <section className="jr-card phase-vibe">
+        <section id="journey-phase-vibe" className="jr-card phase-vibe" tabIndex="-1">
           <div className="jr-head"><span className="jr-n">2</span><h3>ViBe courses</h3><span className={`jr-sp ${vibe.sp < 0 ? 'neg' : ''}`}>{vibe.sp >= 0 ? '+' : ''}{vibe.sp} SP</span></div>
           <p className="jr-sub">{vibe.clearedCount}/{vibe.totalCourses} courses complete</p>
           <div className="jr-dots">
@@ -1353,7 +1449,7 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
         </section>
 
         {/* SPA — live progress from the rubric summary (same source as the SPA Points tab) */}
-        <section className="jr-card phase-spa">
+        <section id="journey-phase-spa" className="jr-card phase-spa" tabIndex="-1">
           <div className="jr-head"><span className="jr-n">3</span><h3>SPA — Matrix Mystics</h3><span className="jr-sp">+{spa.sp} SP</span></div>
           <p className="jr-sub">{spa.solved}/{spa.total} problems solved · full breakdown in the SPA Points tab</p>
           <div className="jr-stats">
@@ -1364,7 +1460,7 @@ function MyJourney({ student, goToCommitment, canCommit = false }) {
         </section>
 
         {/* Projects — live from the PR submission + review mirrors; SP rule still TBD */}
-        <section className="jr-card phase-project">
+        <section id="journey-phase-project" className="jr-card phase-project" tabIndex="-1">
           <div className="jr-head"><span className="jr-n">4</span><h3>Projects</h3><span className="jr-sp">+{projects.sp} SP</span></div>
           <p className="jr-sub">{projects.submitted ? `${projects.prsRaised} PR${projects.prsRaised === 1 ? '' : 's'} submitted` : 'Pull requests — none submitted yet'}</p>
           {projects.reviewStatus && (

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -656,6 +656,25 @@ input {
 
 /* ---- My Journey (phase-by-phase progress + SP) ---------------------------- */
 .jr { display: grid; gap: 16px; }
+.jr-coach { display: grid; gap: 14px; border-left: 5px solid var(--primary); }
+.jr-coach-on-track { border-left-color: var(--green); }
+.jr-coach-needs-attention { border-left-color: var(--amber); }
+.jr-coach-action-required { border-left-color: var(--red); }
+.jr-coach-neutral { border-left-color: var(--primary); }
+.jr-coach-unavailable, .jr-coach-loading { border-left-color: var(--line); }
+.jr-coach-head { display: flex; align-items: center; gap: 12px; }
+.jr-coach-head .eyebrow { margin-bottom: 4px; }
+.jr-coach-head h2 { margin: 0; font-size: 20px; }
+.jr-coach-icon { width: 32px; height: 32px; display: grid; place-items: center; font-size: 20px; flex: 0 0 auto; }
+.jr-coach-action { padding: 14px; border: 1px solid var(--line); border-radius: 10px; background: #fbfdff; }
+.jr-coach-label { margin: 0 0 5px; color: var(--muted); font-size: 12px; font-weight: 900; letter-spacing: .06em; text-transform: uppercase; }
+.jr-coach-action h3 { margin: 0; font-size: 18px; }
+.jr-coach-message, .jr-coach-why p:last-child { margin: 0; color: var(--muted); line-height: 1.55; }
+.jr-coach-why { display: grid; gap: 2px; }
+.jr-coach-catchup { margin: 8px 0 0; color: var(--muted); font-size: 13px; }
+.jr-coach-cta { min-height: 36px; margin-top: 12px; padding: 0 13px; font-size: 13px; }
+.jr-coach-loading h2 { margin-bottom: 4px; }
+.jr-coach-loading p:last-child { margin-bottom: 0; }
 .jr-plan-row { display: flex; flex-wrap: wrap; gap: 14px; align-items: flex-end; margin-top: 6px; }
 .jr-plan-row label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; font-weight: 700; color: var(--muted); }
 .jr-plan-row input { min-height: 36px; padding: 0 8px; border: 1px solid var(--line); border-radius: 8px; }
@@ -701,6 +720,10 @@ input {
 .jr-pill.amber { background: #fef3e2; color: var(--amber); }
 .jr-pill.muted { background: #f1f5f9; color: var(--muted); font-weight: 600; }
 .jr-link { background: none; border: none; color: var(--primary); font-weight: 800; font-size: 12px; cursor: pointer; padding: 0; margin-left: auto; }
+@media (max-width: 520px) {
+  .jr-coach-action h3 { font-size: 16px; }
+  .jr-coach-cta { width: 100%; }
+}
 
 /* ---- Commitments hub (sub-tabs, one phase at a time) --------------------- */
 .cm { display: grid; gap: 12px; }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "node --test test/*.test.js",
     "seed": "node server/scripts/seed.js",
+    "seed-progress-coach-dev": "node server/scripts/seedProgressCoachDev.js",
     "rebuild": "node server/scripts/rebuild.js",
     "add-students": "node server/scripts/addStudents.js",
     "sync-students": "node server/scripts/syncStudents.js",

--- a/server/scripts/seedProgressCoachDev.js
+++ b/server/scripts/seedProgressCoachDev.js
@@ -1,0 +1,135 @@
+import mongoose from 'mongoose';
+
+import { MONGO_URI } from '../config.js';
+import Student from '../models/Student.js';
+import AttendanceRecord from '../models/AttendanceRecord.js';
+import PollRecord from '../models/PollRecord.js';
+import SPTransaction from '../models/SPTransaction.js';
+import VibeProgress from '../models/VibeProgress.js';
+import SpaProgress from '../models/SpaProgress.js';
+import JourneyPlan from '../models/JourneyPlan.js';
+import { ActPullRequest, ActPrReview } from '../models/ActMirrors.js';
+import { localDevAuthEmail } from '../services/localDevAuth.js';
+
+const email = localDevAuthEmail();
+
+function startOfToday() {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function addDays(date, days) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+async function seed() {
+  if (!email) {
+    throw new Error('Refusing to seed: set NODE_ENV=development and LOCAL_DEV_AUTH_EMAIL first.');
+  }
+  if (!email.endsWith('@spurti.local')) {
+    throw new Error('Refusing to seed: LOCAL_DEV_AUTH_EMAIL must use the fictional @spurti.local domain.');
+  }
+
+  await mongoose.connect(MONGO_URI);
+  try {
+    if (mongoose.connection.name !== 'spurti_dev') {
+      throw new Error('Refusing to seed: MONGO_URI must point to the dedicated spurti_dev database.');
+    }
+
+    // This reset is intentionally limited to the one fictional account, so the
+    // command remains repeatable without touching any other local records.
+    await Promise.all([
+      AttendanceRecord.deleteMany({ email }),
+      PollRecord.deleteMany({ email }),
+      SPTransaction.deleteMany({ email }),
+      VibeProgress.deleteMany({ email }),
+      SpaProgress.deleteMany({ email }),
+      JourneyPlan.deleteMany({ email }),
+      ActPullRequest.deleteMany({ email }),
+      ActPrReview.deleteMany({ email }),
+      Student.deleteMany({ email })
+    ]);
+
+    const today = startOfToday();
+    const student = await Student.create({
+      name: 'Dev Student',
+      email,
+      internshipStartDate: addDays(today, -30),
+      internshipEndDate: addDays(today, 30),
+      status: 'active',
+      totalSp: 420,
+      highestSpEver: 420
+    });
+
+    await AttendanceRecord.create({
+      email,
+      studentId: student._id,
+      sessionLabel: 'Development standup fixture',
+      attendedMinutes: 3000,
+      totalSessionMinutes: 3600,
+      attendancePercentage: 83,
+      qualified: true
+    });
+    await PollRecord.create({
+      email,
+      studentId: student._id,
+      sessionLabel: 'Development standup fixture',
+      totalQuestions: 40,
+      attemptedQuestions: 33,
+      missedQuestions: 7
+    });
+    await SPTransaction.insertMany([
+      {
+        email, studentId: student._id, category: 'initial', sessionLabel: 'Development fixture',
+        deltaValue: 100, appliedDelta: 100, balanceAfter: 100,
+        reason: 'Initial fictional development balance', dateTime: addDays(today, -30)
+      },
+      {
+        email, studentId: student._id, category: 'attendance', sessionLabel: 'Development standup fixture',
+        deltaValue: 250, appliedDelta: 250, balanceAfter: 350,
+        reason: 'Fictional standup attendance', dateTime: addDays(today, -1)
+      },
+      {
+        email, studentId: student._id, category: 'poll', sessionLabel: 'Development standup fixture',
+        deltaValue: 40, appliedDelta: 40, balanceAfter: 390,
+        reason: 'Fictional poll participation', dateTime: addDays(today, -1)
+      },
+      {
+        email, studentId: student._id, category: 'spa', sessionLabel: 'Development SPA fixture',
+        deltaValue: 30, appliedDelta: 30, balanceAfter: 420,
+        reason: 'Fictional SPA progress', dateTime: today
+      }
+    ]);
+    await VibeProgress.insertMany([
+      { email, course: 'onboarding', pct: 100, weekHours: 2, priorCompleted: false },
+      { email, course: 'ai', pct: 35, weekHours: 1, priorCompleted: false },
+      { email, course: 'mern', pct: 0, weekHours: 0, priorCompleted: false }
+    ]);
+    await SpaProgress.create({
+      email,
+      learnValidated: 12,
+      teachValidated: 3,
+      learnCredited: 12,
+      teachCredited: 3
+    });
+    await JourneyPlan.create({
+      email,
+      standupBy: addDays(today, 7),
+      atSet: {
+        standup: { remainingMin: 720, at: addDays(today, -7) }
+      }
+    });
+
+    console.log('Seeded fictional Progress Coach fixture into spurti_dev.');
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+seed().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/server/server.js
+++ b/server/server.js
@@ -29,6 +29,8 @@ import { buildStandupState, placeStandup, settleStandupDemo } from './services/s
 import { buildJourneyState, saveJourneyPlan } from './services/journey.js';
 import { buildSpaState } from './services/spa.js';
 import { buildTrajectoryState } from './services/trajectory.js';
+import { buildProgressCoachState } from './services/progressCoachState.js';
+import { localDevAuthEmail } from './services/localDevAuth.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -171,6 +173,14 @@ function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase();
 }
 
+// Local-only fixture identity for feature development without Samagama. This is
+// unavailable unless NODE_ENV is exactly "development" and an explicit email is
+// configured, so production continues to require the Samagama session cookie.
+const LOCAL_DEV_AUTH_EMAIL = localDevAuthEmail();
+if (LOCAL_DEV_AUTH_EMAIL) {
+  console.warn('[development] local fixture authentication is enabled');
+}
+
 function maskEmail(email) {
   const [name, domain] = String(email || '').split('@');
   if (!name || !domain) return 'hidden email';
@@ -215,6 +225,7 @@ async function getSamagamaUser(chatengineToken) {
 }
 
 async function studentEmailFromRequest(req) {
+  if (LOCAL_DEV_AUTH_EMAIL) return LOCAL_DEV_AUTH_EMAIL;
   const cookies = parseCookies(req.headers.cookie || '');
   const data = await getSamagamaUser(cookies.chatengine_token);
   // Samagama's /api/auth/me nests the user as { user: { email, ... } };
@@ -456,6 +467,31 @@ api.put('/journey/plan', async (req, res) => {
   if (!student) return res.status(404).json({ error: 'Student not found' });   // My Journey goals are universal (Phase 1)
   await saveJourneyPlan(student.email, req.body || {});
   res.json(await buildJourneyState(student));
+});
+
+// ---- Progress Coach (authenticated, read-only interpretation layer) ---------
+// Unlike older student-facing routes, this endpoint never accepts an email or
+// student id from the client. The student is derived from the Samagama session
+// cookie so a caller cannot ask for another student's private progress context.
+api.get('/progress-coach/state', async (req, res) => {
+  const email = await studentEmailFromRequest(req);
+  if (!email) return res.status(401).json({ error: 'Authentication required' });
+
+  const student = await Student.findOne({ $or: [{ email }, { alternateEmail: email }] }).lean();
+  if (!student) return res.status(404).json({ error: 'Student not found' });
+  if (student.status === 'excused') {
+    return res.status(403).json({ error: 'Progress Coach is available for active students only' });
+  }
+
+  res.set('Cache-Control', 'no-store');
+  try {
+    res.json(await buildProgressCoachState(student));
+  } catch (error) {
+    // A failed source must not become a false zero or a false warning. Keep the
+    // failure scoped to this read-only panel so My Journey can still render.
+    console.error('[progress-coach] state unavailable:', error?.message || error);
+    res.status(503).json({ error: 'Progress Coach is temporarily unavailable' });
+  }
 });
 
 api.get('/search', async (req, res) => {
@@ -1318,5 +1354,3 @@ mongoose.connect(MONGO_URI).then(() => {
   console.error(error);
   process.exit(1);
 });
-
-

--- a/server/services/journey.js
+++ b/server/services/journey.js
@@ -61,6 +61,7 @@ export async function buildJourneyState(student) {
   const vibe = {
     ladder,
     current: v.current,
+    weeklyFloor: v.weeklyFloor,
     clearedCount: ladder.filter(l => l.cleared).length,
     totalCourses: ladder.length,
     activeCommitment: v.active
@@ -120,7 +121,11 @@ export async function buildJourneyState(student) {
       standupBy: plan?.standupBy || null,
       vibeBy: plan?.vibeBy || null,
       spaBy: plan?.spaBy || null,
-      projectBy: plan?.projectBy || null
+      projectBy: plan?.projectBy || null,
+      // Read-only context for interpretation layers such as Progress Coach.
+      // These are the existing snapshots captured when a goal was set; they do
+      // not alter My Journey's target or completion semantics.
+      atSet: plan?.atSet || {}
     },
     goals,
     phaseSp: { standups: standups.sp, vibe: vibe.sp, spa: spa.sp, projects: projects.sp },

--- a/server/services/localDevAuth.js
+++ b/server/services/localDevAuth.js
@@ -1,0 +1,9 @@
+// Local fixture authentication is deliberately opt-in and deliberately narrow.
+// It is useful when developing student-only features without a Samagama server,
+// but it must never alter production or shared-environment authentication.
+export function localDevAuthEmail(env = process.env) {
+  if (env.NODE_ENV !== 'development') return null;
+
+  const email = String(env.LOCAL_DEV_AUTH_EMAIL || '').trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : null;
+}

--- a/server/services/progressCoach.js
+++ b/server/services/progressCoach.js
@@ -1,0 +1,314 @@
+// Progress Coach — deterministic interpretation of existing My Journey data.
+//
+// This module deliberately knows nothing about MongoDB, Express, React, or SP.
+// The API layer will adapt buildJourneyState() into the small track shape below,
+// and the client will render the result. Keeping the rules here makes the
+// recommendation predictable and unit-testable.
+
+export const COACH_STATUS = Object.freeze({
+  ON_TRACK: 'on_track',
+  NEEDS_ATTENTION: 'needs_attention',
+  ACTION_REQUIRED: 'action_required',
+  NEUTRAL: 'neutral',
+  UNAVAILABLE: 'unavailable'
+});
+
+export const ACTION_KIND = Object.freeze({
+  OVERDUE: 'overdue',
+  CRITICAL_DEADLINE: 'critical_deadline',
+  BEHIND_PACE: 'behind_pace',
+  WEEKLY_PACE: 'weekly_pace',
+  ALMOST_COMPLETE: 'almost_complete',
+  NORMAL: 'normal'
+});
+
+export const ACTION_PRIORITY = Object.freeze({
+  [ACTION_KIND.OVERDUE]: 500,
+  [ACTION_KIND.CRITICAL_DEADLINE]: 400,
+  [ACTION_KIND.BEHIND_PACE]: 300,
+  [ACTION_KIND.WEEKLY_PACE]: 200,
+  [ACTION_KIND.ALMOST_COMPLETE]: 100,
+  [ACTION_KIND.NORMAL]: 10
+});
+
+const NEEDS_ATTENTION_KINDS = new Set([
+  ACTION_KIND.BEHIND_PACE,
+  ACTION_KIND.WEEKLY_PACE
+]);
+
+const EPSILON = 1e-9;
+
+function numberOrNull(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function dateMs(value) {
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isFinite(ms) ? ms : null;
+  }
+  if (value == null || value === '') return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Calculate the deterministic catch-up amount for a goal.
+ *
+ * A deadline that has arrived has no positive number of days left, so the
+ * caller gets null and can describe the item as overdue instead.
+ */
+export function calculateCatchUp({ remaining, daysLeft, existingPerDay = null }) {
+  const work = numberOrNull(remaining);
+  const days = numberOrNull(daysLeft);
+  if (work == null || work <= 0 || days == null || days <= 0) return null;
+  if (numberOrNull(existingPerDay) != null && existingPerDay > 0) return Math.ceil(existingPerDay);
+  return Math.ceil(work / days);
+}
+
+/**
+ * Estimate how much of the work should remain today if progress follows a
+ * straight line from the moment a target was set to its target date.
+ *
+ * This uses JourneyPlan.atSet, which already snapshots remaining work when a
+ * target is created. If that baseline is absent or malformed, the safe result
+ * is null rather than a guessed pace.
+ */
+export function expectedRemainingAt({ remainingAtSet, startedAt, targetDate, now = new Date() }) {
+  const startRemaining = numberOrNull(remainingAtSet);
+  const startMs = dateMs(startedAt);
+  const targetMs = dateMs(targetDate);
+  const nowMs = dateMs(now);
+  if (startRemaining == null || startRemaining <= 0
+      || startMs == null || targetMs == null || nowMs == null
+      || targetMs <= startMs) return null;
+
+  const elapsed = Math.min(Math.max(nowMs - startMs, 0), targetMs - startMs);
+  const fractionElapsed = elapsed / (targetMs - startMs);
+  return Math.max(0, startRemaining * (1 - fractionElapsed));
+}
+
+/**
+ * Compare actual remaining work with the target's expected remaining work.
+ */
+export function paceSignal({
+  remaining,
+  remainingAtSet,
+  startedAt,
+  targetDate,
+  now = new Date()
+}) {
+  const actual = numberOrNull(remaining);
+  const expected = expectedRemainingAt({ remainingAtSet, startedAt, targetDate, now });
+  if (actual == null || expected == null) {
+    return { available: false, behind: false, actualRemaining: actual, expectedRemaining: null };
+  }
+  return {
+    available: true,
+    behind: actual > expected + EPSILON,
+    actualRemaining: actual,
+    expectedRemaining: expected
+  };
+}
+
+function goalComplete(track, goal) {
+  if (track.complete === true) return true;
+  if (goal.status === 'achieved') return true;
+  return numberOrNull(goal.remaining) === 0 && numberOrNull(goal.target) != null;
+}
+
+function actionOverride(track, kind) {
+  const actions = track.actions || {};
+  if (kind === ACTION_KIND.NORMAL && track.normalAction) return track.normalAction;
+  return actions[kind] || {};
+}
+
+function actionFor(track, kind, { catchUp = null, pace = null } = {}) {
+  const override = actionOverride(track, kind);
+  const goal = track.goal || {};
+  const remaining = numberOrNull(goal.remaining);
+  const unit = track.unitLabel || goal.unit || 'units';
+  const perDay = catchUp == null ? null : `${catchUp} ${unit}/${goal.perDayUnit || 'day'}`;
+
+  return {
+    key: `${track.key}:${kind}`,
+    trackKey: track.key,
+    kind,
+    priority: ACTION_PRIORITY[kind],
+    title: override.title || track.name || track.key,
+    detail: override.detail || null,
+    cta: override.cta || null,
+    remaining,
+    unit,
+    catchUpPerDay: perDay,
+    expectedRemaining: pace?.expectedRemaining ?? null
+  };
+}
+
+function classifyTrack(track, now) {
+  const goal = track.goal || {};
+  const dataState = track.dataState || (track.available === false ? 'unavailable' : 'available');
+  const applicable = track.applicable !== false;
+
+  if (!applicable) return { track, kind: 'inactive', candidate: null, complete: true };
+  if (dataState === 'unavailable') {
+    return { track, kind: 'unavailable', candidate: null, complete: false };
+  }
+
+  const remaining = numberOrNull(goal.remaining);
+  // Unknown remaining work is not evidence of failure. The adapter can still
+  // provide a normal first action, but deadline/pace rules require a known
+  // positive remainder before they are allowed to fire.
+  const hasWork = remaining != null && remaining > 0;
+  const complete = goalComplete(track, goal);
+  const catchUp = calculateCatchUp({
+    remaining,
+    daysLeft: goal.daysLeft,
+    existingPerDay: goal.perDay
+  });
+  const pace = paceSignal({
+    remaining,
+    remainingAtSet: track.remainingAtSet,
+    startedAt: track.targetStartedAt,
+    targetDate: goal.targetDate,
+    now
+  });
+
+  const overdue = hasWork && (goal.status === 'missed' || (numberOrNull(goal.daysLeft) ?? 0) < 0);
+  const deadlineToday = hasWork && goal.status === 'active' && goal.daysLeft === 0;
+  const capacity = track.capacity;
+  const exceedsCapacity = hasWork
+    && capacity
+    && numberOrNull(goal.perDay) != null
+    && goal.perDayUnit === capacity.unit
+    && goal.perDay > capacity.value;
+  const behind = hasWork && (track.behind === true || pace.behind);
+  const weeklyBehind = hasWork && track.weekly?.behind === true;
+  const almostComplete = hasWork && (
+    track.almostComplete === true
+    || (numberOrNull(track.completionUnit) != null
+      && remaining != null
+      && remaining > 0
+      && remaining <= track.completionUnit)
+  );
+
+  let kind = null;
+  if (overdue) kind = ACTION_KIND.OVERDUE;
+  else if (deadlineToday || exceedsCapacity) kind = ACTION_KIND.CRITICAL_DEADLINE;
+  else if (behind) kind = ACTION_KIND.BEHIND_PACE;
+  else if (weeklyBehind) kind = ACTION_KIND.WEEKLY_PACE;
+  else if (almostComplete) kind = ACTION_KIND.ALMOST_COMPLETE;
+  else if (!complete && (track.normalAction || actionOverride(track, ACTION_KIND.NORMAL).title)) {
+    kind = ACTION_KIND.NORMAL;
+  }
+
+  const candidate = kind ? actionFor(track, kind, { catchUp, pace }) : null;
+  return {
+    track,
+    kind: kind || (complete ? 'complete' : 'unactionable'),
+    candidate,
+    complete,
+    pace,
+    catchUp,
+    overdue,
+    deadlineToday,
+    exceedsCapacity,
+    behind,
+    weeklyBehind,
+    almostComplete
+  };
+}
+
+/**
+ * Return the single highest-priority action. Array order is the stable tie
+ * breaker, so equal-priority actions remain predictable.
+ */
+export function getNextBestAction(tracks = [], { now = new Date() } = {}) {
+  const classified = tracks.map((track) => classifyTrack(track, now));
+  const candidates = classified
+    .map((item, index) => item.candidate ? { ...item.candidate, _index: index } : null)
+    .filter(Boolean)
+    .sort((a, b) => b.priority - a.priority || a._index - b._index);
+  if (!candidates.length) return null;
+  const { _index, ...action } = candidates[0];
+  return action;
+}
+
+function defaultExplanation(action, classified) {
+  if (!action) return null;
+  const item = classified.find((entry) => entry.candidate?.key === action.key);
+  if (!item) return null;
+  const track = item.track;
+  if (action.detail) return action.detail;
+  if (item.overdue) return `${track.name || track.key} is past its target date.`;
+  if (item.deadlineToday) return `${track.name || track.key} is due today and still has work remaining.`;
+  if (item.exceedsCapacity) return `${track.name || track.key} needs more than the available pace to finish on time.`;
+  if (item.behind) return `${track.name || track.key} is behind its expected pace.`;
+  if (item.weeklyBehind) return `${track.name || track.key} is behind this week's target.`;
+  if (item.almostComplete) return `${track.name || track.key} is close to completion.`;
+  return `Continue with ${track.name || track.key}.`;
+}
+
+/**
+ * Build the complete student-facing interpretation from normalized track data.
+ * This function never writes data and never invents a failure when a source is
+ * unavailable.
+ */
+export function buildProgressCoach(context = {}, { now = new Date() } = {}) {
+  const tracks = Array.isArray(context.tracks)
+    ? context.tracks
+    : Object.values(context.tracks || {});
+  const classified = tracks.map((track) => classifyTrack(track, now));
+  const applicable = classified.filter((item) => item.kind !== 'inactive');
+  const unavailable = applicable.filter((item) => item.kind === 'unavailable');
+  const available = applicable.filter((item) => item.kind !== 'unavailable');
+  const action = getNextBestAction(tracks, { now });
+  const explanation = defaultExplanation(action, classified);
+  const hasNormalOrMeaningfulAction = available.some((item) => item.candidate);
+  const allComplete = available.length > 0 && available.every((item) => item.complete);
+  const hasActivity = context.hasActivity ?? available.some((item) => item.track.hasActivity !== false);
+
+  let status;
+  let completion = false;
+  if (unavailable.length) {
+    status = COACH_STATUS.UNAVAILABLE;
+  } else if (action?.kind === ACTION_KIND.OVERDUE || action?.kind === ACTION_KIND.CRITICAL_DEADLINE) {
+    status = COACH_STATUS.ACTION_REQUIRED;
+  } else if (action && NEEDS_ATTENTION_KINDS.has(action.kind)) {
+    status = COACH_STATUS.NEEDS_ATTENTION;
+  } else if (allComplete) {
+    status = COACH_STATUS.ON_TRACK;
+    completion = true;
+  } else if (hasNormalOrMeaningfulAction) {
+    status = COACH_STATUS.ON_TRACK;
+  } else if (!hasActivity) {
+    status = COACH_STATUS.NEUTRAL;
+  } else {
+    status = COACH_STATUS.ON_TRACK;
+  }
+
+  const messages = {
+    [COACH_STATUS.ON_TRACK]: completion
+      ? "You're on track — you've completed this week's active milestones."
+      : (explanation || 'Your active journey requirements are on track.'),
+    [COACH_STATUS.NEEDS_ATTENTION]: explanation || 'One active journey requirement needs attention.',
+    [COACH_STATUS.ACTION_REQUIRED]: explanation || 'One active journey requirement needs action.',
+    [COACH_STATUS.NEUTRAL]: 'Your progress will appear here as you participate in your journey.',
+    [COACH_STATUS.UNAVAILABLE]: 'Some progress information is temporarily unavailable.'
+  };
+
+  return {
+    status,
+    message: messages[status],
+    completion,
+    nextAction: action,
+    unavailableTracks: unavailable.map((item) => item.track.key),
+    evaluatedTracks: available.map((item) => item.track.key)
+  };
+}
+
+// Kept exported for focused unit tests and for the future API adapter. It is
+// intentionally not part of the public HTTP response shape.
+export function classifyProgressTrack(track, { now = new Date() } = {}) {
+  return classifyTrack(track, now);
+}

--- a/server/services/progressCoachState.js
+++ b/server/services/progressCoachState.js
@@ -1,0 +1,107 @@
+// Adapter from the existing My Journey state to the pure Progress Coach rules.
+// This module owns data-shape translation only; status and recommendation rules
+// stay in progressCoach.js so they can be tested without MongoDB.
+
+import { buildJourneyState, STANDUP_MIN_PER_DAY } from './journey.js';
+import { buildProgressCoach } from './progressCoach.js';
+
+function hasGoal(goal) {
+  return Boolean(goal?.hasTarget || goal?.status === 'active' || goal?.status === 'missed');
+}
+
+function snapshot(plan, key, remainingField) {
+  const row = plan?.atSet?.[key];
+  if (!row) return {};
+  return {
+    remainingAtSet: typeof row[remainingField] === 'number' ? row[remainingField] : null,
+    targetStartedAt: row.at || null
+  };
+}
+
+function buildTracks(journey) {
+  const { goals, plan, standups, vibe, spa, projects } = journey;
+
+  const standupHasActivity = standups.sessionsAttended > 0 || standups.pollsTotal > 0;
+  const vibeHasActivity = vibe.ladder.some((course) => course.pct > 0 || course.prior);
+  const spaHasActivity = spa.solved > 0 || spa.taught > 0;
+  const projectHasActivity = projects.submitted || Boolean(projects.reviewStatus);
+
+  return [
+    {
+      key: 'standup',
+      name: 'Standup attendance',
+      goal: goals.standup,
+      unitLabel: 'minutes',
+      completionUnit: STANDUP_MIN_PER_DAY,
+      capacity: { value: STANDUP_MIN_PER_DAY, unit: 'working day' },
+      hasActivity: standupHasActivity,
+      ...snapshot(plan, 'standup', 'remainingMin'),
+      // No upcoming-session service is available in My Journey yet, so an
+      // entirely new student gets a neutral state instead of a made-up CTA.
+      normalAction: standupHasActivity || hasGoal(goals.standup)
+        ? { title: 'Keep attending standups' }
+        : null
+    },
+    {
+      key: 'vibe',
+      name: vibe.current?.name || 'ViBe courses',
+      goal: goals.vibe,
+      unitLabel: '%',
+      hasActivity: vibeHasActivity,
+      weekly: vibe.weeklyFloor ? {
+        met: vibe.weeklyFloor.met,
+        // The current ViBe state exposes whether the floor is met, but not a
+        // week-progress deadline. Do not call an unmet floor "behind" before
+        // an existing weekly semantic says that it is behind.
+        behind: false
+      } : null,
+      ...snapshot(plan, 'vibe', 'remainingPct'),
+      normalAction: vibeHasActivity || hasGoal(goals.vibe)
+        ? { title: vibe.current ? `Continue ${vibe.current.name}` : 'Continue ViBe courses' }
+        : null
+    },
+    {
+      key: 'spa',
+      name: 'SPA practice',
+      goal: goals.spa,
+      unitLabel: 'problems',
+      completionUnit: 1,
+      hasActivity: spaHasActivity,
+      ...snapshot(plan, 'spa', 'remainingCount'),
+      normalAction: spaHasActivity || hasGoal(goals.spa)
+        ? { title: 'Solve the next SPA problem' }
+        : null
+    },
+    {
+      key: 'project',
+      name: 'Project work',
+      goal: goals.project,
+      unitLabel: 'PR',
+      completionUnit: 1,
+      hasActivity: projectHasActivity,
+      ...snapshot(plan, 'project', 'prsRaised'),
+      // JourneyPlan stores the number of PRs at goal creation, whereas the
+      // coach compares remaining work. Convert the existing snapshot here.
+      remainingAtSet: typeof plan?.atSet?.project?.prsRaised === 'number'
+        ? Math.max(0, 1 - plan.atSet.project.prsRaised)
+        : null,
+      normalAction: projectHasActivity || hasGoal(goals.project)
+        ? { title: 'Continue your project work' }
+        : null
+    }
+  ];
+}
+
+export async function buildProgressCoachState(student, options = {}) {
+  const journey = await buildJourneyState(student);
+  if (!journey.eligible) return { eligible: false };
+
+  const tracks = buildTracks(journey);
+  const hasActivity = tracks.some((track) => track.hasActivity);
+  return {
+    eligible: true,
+    ...buildProgressCoach({ tracks, hasActivity }, options)
+  };
+}
+
+export { buildTracks };

--- a/test/local-dev-auth.test.js
+++ b/test/local-dev-auth.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { localDevAuthEmail } from '../server/services/localDevAuth.js';
+
+test('enables the local fixture identity only in development', () => {
+  assert.equal(localDevAuthEmail({
+    NODE_ENV: 'development',
+    LOCAL_DEV_AUTH_EMAIL: ' Dev.Student@Spurti.Local '
+  }), 'dev.student@spurti.local');
+});
+
+test('does not enable local fixture authentication without a valid email', () => {
+  assert.equal(localDevAuthEmail({ NODE_ENV: 'development' }), null);
+  assert.equal(localDevAuthEmail({ NODE_ENV: 'development', LOCAL_DEV_AUTH_EMAIL: 'not-an-email' }), null);
+});
+
+test('never enables local fixture authentication outside development', () => {
+  assert.equal(localDevAuthEmail({
+    NODE_ENV: 'production', LOCAL_DEV_AUTH_EMAIL: 'dev.student@spurti.local'
+  }), null);
+  assert.equal(localDevAuthEmail({
+    NODE_ENV: 'staging', LOCAL_DEV_AUTH_EMAIL: 'dev.student@spurti.local'
+  }), null);
+});

--- a/test/progress-coach-state.test.js
+++ b/test/progress-coach-state.test.js
@@ -1,0 +1,92 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTracks } from '../server/services/progressCoachState.js';
+
+const goal = (extra = {}) => ({
+  status: 'none',
+  hasTarget: false,
+  remaining: null,
+  ...extra
+});
+
+function journey(extra = {}) {
+  return {
+    goals: {
+      standup: goal(),
+      vibe: goal(),
+      spa: goal(),
+      project: goal()
+    },
+    plan: { atSet: {} },
+    standups: { sessionsAttended: 0, pollsTotal: 0 },
+    vibe: {
+      ladder: [
+        { key: 'ai', name: 'Fundamentals of AI', pct: 0, prior: false },
+        { key: 'mern', name: 'MERN Stack', pct: 0, prior: false }
+      ],
+      current: { name: 'Fundamentals of AI' },
+      weeklyFloor: { met: false }
+    },
+    spa: { solved: 0, taught: 0 },
+    projects: { submitted: false, reviewStatus: null },
+    ...extra
+  };
+}
+
+describe('Progress Coach My Journey adapter', () => {
+  test('maps existing goal snapshots into pace inputs', () => {
+    const tracks = buildTracks(journey({
+      plan: {
+        atSet: {
+          standup: { remainingMin: 1800, at: '2026-09-01T00:00:00Z' },
+          vibe: { remainingPct: 80, at: '2026-09-01T00:00:00Z' },
+          spa: { remainingCount: 20, at: '2026-09-01T00:00:00Z' },
+          project: { prsRaised: 0, at: '2026-09-01T00:00:00Z' }
+        }
+      },
+      goals: {
+        standup: goal({ status: 'active', hasTarget: true, remaining: 1800, targetDate: '2026-09-30T00:00:00Z' }),
+        vibe: goal({ status: 'active', hasTarget: true, remaining: 80, targetDate: '2026-09-30T00:00:00Z' }),
+        spa: goal({ status: 'active', hasTarget: true, remaining: 20, targetDate: '2026-09-30T00:00:00Z' }),
+        project: goal({ status: 'active', hasTarget: true, remaining: 1, targetDate: '2026-09-30T00:00:00Z' })
+      }
+    }));
+
+    assert.deepEqual(tracks.map(t => t.key), ['standup', 'vibe', 'spa', 'project']);
+    assert.equal(tracks[0].remainingAtSet, 1800);
+    assert.equal(tracks[0].targetStartedAt, '2026-09-01T00:00:00Z');
+    assert.equal(tracks[3].remainingAtSet, 1);
+  });
+
+  test('does not create normal actions for a student with no activity or goal', () => {
+    const tracks = buildTracks(journey());
+
+    assert.equal(tracks.every(t => t.normalAction === null), true);
+  });
+
+  test('creates a normal action when an existing journey goal is active', () => {
+    const tracks = buildTracks(journey({
+      goals: {
+        standup: goal({ status: 'active', hasTarget: true, remaining: 900, targetDate: '2026-09-30T00:00:00Z' }),
+        vibe: goal(),
+        spa: goal(),
+        project: goal()
+      }
+    }));
+
+    assert.deepEqual(tracks[0].normalAction, { title: 'Keep attending standups' });
+  });
+
+  test('does not call an unmet ViBe floor behind without weekly timing semantics', () => {
+    const tracks = buildTracks(journey({
+      vibe: {
+        ladder: [{ key: 'ai', name: 'Fundamentals of AI', pct: 20, prior: false }],
+        current: { name: 'Fundamentals of AI' },
+        weeklyFloor: { met: false }
+      }
+    }));
+
+    assert.equal(tracks[1].weekly.behind, false);
+    assert.equal(tracks[1].hasActivity, true);
+  });
+});

--- a/test/progress-coach.test.js
+++ b/test/progress-coach.test.js
@@ -1,0 +1,239 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ACTION_KIND,
+  COACH_STATUS,
+  buildProgressCoach,
+  calculateCatchUp,
+  expectedRemainingAt,
+  getNextBestAction,
+  paceSignal
+} from '../server/services/progressCoach.js';
+
+const NOW = new Date('2026-09-08T00:00:00Z');
+
+function goal(extra = {}) {
+  return {
+    status: 'active',
+    remaining: 10,
+    daysLeft: 5,
+    targetDate: '2026-09-13T00:00:00Z',
+    perDayUnit: 'day',
+    ...extra
+  };
+}
+
+function track(key, extra = {}) {
+  return {
+    key,
+    name: key,
+    dataState: 'available',
+    goal: goal(),
+    actions: {
+      normal: { title: `Continue ${key}` }
+    },
+    ...extra
+  };
+}
+
+describe('catch-up calculations', () => {
+  test('rounds remaining work up to a whole unit per day', () => {
+    assert.equal(calculateCatchUp({ remaining: 26, daysLeft: 2 }), 13);
+    assert.equal(calculateCatchUp({ remaining: 5, daysLeft: 2 }), 3);
+    assert.equal(calculateCatchUp({ remaining: 120, daysLeft: 2, existingPerDay: 60 }), 60);
+  });
+
+  test('does not invent a catch-up rate with no time left or no remaining work', () => {
+    assert.equal(calculateCatchUp({ remaining: 5, daysLeft: 0 }), null);
+    assert.equal(calculateCatchUp({ remaining: 0, daysLeft: 2 }), null);
+    assert.equal(calculateCatchUp({ remaining: 5, daysLeft: null }), null);
+  });
+});
+
+describe('expected pace', () => {
+  test('uses the existing target snapshot as a linear expected pace', () => {
+    assert.equal(expectedRemainingAt({
+      remainingAtSet: 100,
+      startedAt: '2026-09-01T00:00:00Z',
+      targetDate: '2026-09-11T00:00:00Z',
+      now: '2026-09-06T00:00:00Z'
+    }), 50);
+  });
+
+  test('clamps expected remaining work at zero after the deadline', () => {
+    assert.equal(expectedRemainingAt({
+      remainingAtSet: 10,
+      startedAt: '2026-09-01T00:00:00Z',
+      targetDate: '2026-09-11T00:00:00Z',
+      now: '2026-09-20T00:00:00Z'
+    }), 0);
+  });
+
+  test('reports behind only when a valid baseline exists', () => {
+    assert.deepEqual(paceSignal({
+      remaining: 60,
+      remainingAtSet: 100,
+      startedAt: '2026-09-01T00:00:00Z',
+      targetDate: '2026-09-11T00:00:00Z',
+      now: '2026-09-06T00:00:00Z'
+    }), {
+      available: true,
+      behind: true,
+      actualRemaining: 60,
+      expectedRemaining: 50
+    });
+
+    assert.equal(paceSignal({ remaining: 60 }).available, false);
+  });
+});
+
+describe('Progress Coach status', () => {
+  test('returns ON TRACK when active requirements are on expected pace', () => {
+    const result = buildProgressCoach({
+      tracks: [track('standup', {
+        remainingAtSet: 100,
+        targetStartedAt: '2026-09-01T00:00:00Z',
+        goal: goal({ remaining: 50 })
+      })]
+    }, { now: new Date('2026-09-06T00:00:00Z') });
+
+    assert.equal(result.status, COACH_STATUS.ON_TRACK);
+    assert.equal(result.nextAction.kind, ACTION_KIND.NORMAL);
+  });
+
+  test('returns NEEDS ATTENTION when work is behind but catchable', () => {
+    const result = buildProgressCoach({
+      tracks: [track('vibe', {
+        remainingAtSet: 100,
+        targetStartedAt: '2026-09-01T00:00:00Z',
+        goal: goal({ remaining: 80 }),
+        actions: {
+          behind_pace: { title: 'Continue ViBe', detail: 'ViBe is behind this week.' }
+        }
+      })]
+    }, { now: new Date('2026-09-06T00:00:00Z') });
+
+    assert.equal(result.status, COACH_STATUS.NEEDS_ATTENTION);
+    assert.equal(result.nextAction.kind, ACTION_KIND.BEHIND_PACE);
+    assert.equal(result.message, 'ViBe is behind this week.');
+  });
+
+  test('returns ACTION REQUIRED for an overdue goal', () => {
+    const result = buildProgressCoach({
+      tracks: [track('spa', {
+        goal: goal({ status: 'missed', daysLeft: 0, remaining: 3 }),
+        actions: { overdue: { title: 'Finish SPA work' } }
+      })]
+    }, { now: NOW });
+
+    assert.equal(result.status, COACH_STATUS.ACTION_REQUIRED);
+    assert.equal(result.nextAction.kind, ACTION_KIND.OVERDUE);
+  });
+
+  test('deadline-day action outranks an almost-complete activity', () => {
+    const result = buildProgressCoach({
+      tracks: [
+        track('standup', {
+          goal: goal({ daysLeft: 0, remaining: 4 }),
+          actions: { critical_deadline: { title: 'Catch up on standups' } }
+        }),
+        track('project', {
+          goal: goal({ remaining: 1 }),
+          completionUnit: 1,
+          actions: { almost_complete: { title: 'Submit the final PR' } }
+        })
+      ]
+    }, { now: NOW });
+
+    assert.equal(result.nextAction.trackKey, 'standup');
+    assert.equal(result.nextAction.kind, ACTION_KIND.CRITICAL_DEADLINE);
+    assert.equal(result.status, COACH_STATUS.ACTION_REQUIRED);
+    assert.equal(result.message, 'standup is due today and still has work remaining.');
+  });
+
+  test('an overdue activity outranks a normal next activity', () => {
+    const action = getNextBestAction([
+      track('standup', { goal: goal({ status: 'missed', remaining: 40 }), actions: { overdue: { title: 'Attend standups' } } }),
+      track('project', { actions: { normal: { title: 'Start project' } } })
+    ], { now: NOW });
+
+    assert.equal(action.trackKey, 'standup');
+    assert.equal(action.kind, ACTION_KIND.OVERDUE);
+  });
+
+  test('selects only one action when multiple requirements need attention', () => {
+    const result = buildProgressCoach({
+      tracks: [
+        track('standup', { goal: goal({ status: 'missed', remaining: 10 }) }),
+        track('vibe', { behind: true }),
+        track('spa', { weekly: { behind: true } })
+      ]
+    }, { now: NOW });
+
+    assert.equal(result.status, COACH_STATUS.ACTION_REQUIRED);
+    assert.equal(result.nextAction.trackKey, 'standup');
+    assert.ok(result.nextAction);
+  });
+
+  test('returns a neutral onboarding state when there is no meaningful activity', () => {
+    const result = buildProgressCoach({
+      hasActivity: false,
+      tracks: [track('standup', { goal: {}, actions: {} })]
+    }, { now: NOW });
+
+    assert.equal(result.status, COACH_STATUS.NEUTRAL);
+    assert.equal(result.nextAction, null);
+  });
+
+  test('excludes inactive future tracks from recommendations', () => {
+    const result = buildProgressCoach({
+      tracks: [
+        track('future-project', {
+          applicable: false,
+          goal: goal({ status: 'missed', remaining: 1 }),
+          actions: { overdue: { title: 'This must not be recommended' } }
+        }),
+        track('spa', { behind: true })
+      ]
+    }, { now: NOW });
+
+    assert.equal(result.status, COACH_STATUS.NEEDS_ATTENTION);
+    assert.equal(result.nextAction.trackKey, 'spa');
+    assert.deepEqual(result.evaluatedTracks, ['spa']);
+  });
+
+  test('does not convert unavailable data into a failure', () => {
+    const result = buildProgressCoach({
+      tracks: [track('vibe', { dataState: 'unavailable', actions: {} })]
+    }, { now: NOW });
+
+    assert.equal(result.status, COACH_STATUS.UNAVAILABLE);
+    assert.deepEqual(result.unavailableTracks, ['vibe']);
+    assert.equal(result.nextAction, null);
+  });
+
+  test('does not call an unknown remainder overdue', () => {
+    const result = buildProgressCoach({
+      tracks: [track('vibe', {
+        goal: goal({ status: 'missed', remaining: null }),
+        actions: {}
+      })]
+    }, { now: NOW });
+
+    assert.equal(result.status, COACH_STATUS.ON_TRACK);
+    assert.equal(result.nextAction, null);
+  });
+
+  test('returns completion state without manufacturing another action', () => {
+    const result = buildProgressCoach({
+      tracks: [
+        track('standup', { complete: true, goal: { status: 'achieved', remaining: 0 }, actions: {} }),
+        track('spa', { complete: true, goal: { status: 'achieved', remaining: 0 }, actions: {} })
+      ]
+    }, { now: NOW });
+
+    assert.equal(result.status, COACH_STATUS.ON_TRACK);
+    assert.equal(result.completion, true);
+    assert.equal(result.nextAction, null);
+  });
+});


### PR DESCRIPTION
- Implemented Progress Coach state management in the server, allowing for a read-only interpretation of student progress.
- Added new API endpoint `/progress-coach/state` to retrieve Progress Coach data based on student session.
- Developed CSS styles for the Progress Coach UI, including various states (on track, needs attention, action required).
- Created a seeding script `seedProgressCoachDev.js` for local development, populating the database with test data for Progress Coach.
- Introduced local development authentication to facilitate testing without a live server.
- Added unit tests for local development authentication and Progress Coach functionality, ensuring reliability and correctness.
- Updated existing journey state management to include snapshots for Progress Coach.